### PR TITLE
feat(wado-from-idl): generate web:dom from a WebIDL snapshot (Tide M5)

### DIFF
--- a/.claude/hooks/incremental-gc.sh
+++ b/.claude/hooks/incremental-gc.sh
@@ -61,11 +61,11 @@ fi
 # to a relink. The fingerprint goes with the binary -- cargo reads freshness
 # there -- paired by the trailing hash, the crate name being spelled differently.
 #
-# The build lock does not reach this: cargo drops it once everything is
+# The build lock does not reach this. Cargo drops it once everything is
 # compiled, and `cargo test` then spawns the binaries one at a time. Evicting
 # one it has already judged fresh makes that spawn fail outright rather than
-# rebuild, so a live cargo -- of any kind, since none of them announce which
-# phase they are in -- holds these back.
+# rebuild. So any live cargo holds these back: none of them says which phase
+# it is in.
 evicted_bins=0
 if [ "$(avail)" -lt "$goal" ] && [ -d "$DEPS" ] && ! pgrep -x cargo >/dev/null; then
     while IFS=$'\t' read -r _ bin; do

--- a/.claude/hooks/incremental-gc.sh
+++ b/.claude/hooks/incremental-gc.sh
@@ -60,8 +60,14 @@ fi
 # Extensionless executables only: leaving the .rlib / .rmeta keeps the eviction
 # to a relink. The fingerprint goes with the binary -- cargo reads freshness
 # there -- paired by the trailing hash, the crate name being spelled differently.
+#
+# The build lock does not reach this: cargo drops it once everything is
+# compiled, and `cargo test` then spawns the binaries one at a time. Evicting
+# one it has already judged fresh makes that spawn fail outright rather than
+# rebuild, so a live cargo -- of any kind, since none of them announce which
+# phase they are in -- holds these back.
 evicted_bins=0
-if [ "$(avail)" -lt "$goal" ] && [ -d "$DEPS" ]; then
+if [ "$(avail)" -lt "$goal" ] && [ -d "$DEPS" ] && ! pgrep -x cargo >/dev/null; then
     while IFS=$'\t' read -r _ bin; do
         [ "$(avail)" -lt "$goal" ] || break
         hash=${bin##*-}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3457,6 +3457,8 @@ dependencies = [
  "heck",
  "indexmap",
  "lexopt",
+ "serde",
+ "serde_json",
  "wit-parser",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3459,6 +3459,7 @@ dependencies = [
  "lexopt",
  "serde",
  "serde_json",
+ "wado-compiler",
  "wit-parser",
 ]
 

--- a/docs/wep-2026-04-01-tide.md
+++ b/docs/wep-2026-04-01-tide.md
@@ -63,7 +63,7 @@ Wado eliminates several root causes of these pain points:
 
 `wado-from-idl` uses the [`@webref/idl`](https://www.npmjs.com/package/@webref/idl) npm package as its source of truth. This package provides curated, validated WebIDL definitions scraped from W3C and WHATWG specifications, updated weekly. All definitions are guaranteed to parse and be internally consistent.
 
-The package's `parseAll()` API (powered by `webidl2`) produces parsed AST nodes. `scripts/webidl/snapshot.mjs` runs it and writes the AST of one slice to `wado-compiler/lib/web/dom.webidl.json`, next to the module generated from it. The slice is the interfaces the script lists, their partials and included mixins from every spec, and the typedefs their members name. The snapshot is vendored, so generation is deterministic and needs no network. `mise run update-webidl-snapshot` retakes it, and the slice is widened by editing the script's list.
+`parseAll()` (powered by `webidl2`) returns parsed AST nodes. `scripts/webidl/snapshot.mjs` writes one slice of that AST to `wado-compiler/lib/web/dom.webidl.json`, beside the module built from it: the interfaces the script lists, their partials, their included mixins, and the typedefs their members name. The file is vendored, so generation needs no network. To widen the slice, edit the list and run `mise run update-webidl-snapshot`.
 
 ### Tool Implementation
 
@@ -77,13 +77,13 @@ wado-from-idl --webidl wado-compiler/lib/web/dom.webidl.json --output-dir wado-c
 
 Pipeline:
 
-```
+```text
 @webref/idl → snapshot.mjs (webidl2 AST, JSON) → webidl.rs → IR (WadoModule: resources, effects) → WadoCodeGenerator → web/dom.wado
 ```
 
 The WIT path remains unchanged (`--wit-dir`). Both frontends produce the same IR, so codegen improvements benefit both WASI and Web API bindings.
 
-The frontend emits every member whose types the slice can express. It never approximates one it cannot; that member is reported on stderr instead, as `Element.attributes: NamedNodeMap is outside the slice`. A slice has to be closed, so a parent outside it is an error and widening the slice means adding the whole chain. A test regenerates the module from the snapshot and fails when the bundled file is stale.
+The frontend emits every member whose types the slice has. One it cannot type is skipped and named on stderr, as `Element.attributes: NamedNodeMap is outside the slice`. Nothing is approximated. A slice must be closed: a parent outside it is an error, so widening the slice means adding the whole chain. A test regenerates the module and fails when the bundled file is stale.
 
 ### Unified Attribute: `#[cm("...")]`
 
@@ -269,11 +269,11 @@ variant CanvasImageSourceOrPath {
 }
 ```
 
-What the frontend emits today falls short of that shape in three places, each a known gap:
+The frontend falls short of that shape in three ways, each a known gap:
 
-- An `optional` parameter is an `Option<T>` with no default: `clone_node(null)`. `None` is the argument left out, so the WebIDL default applies in the browser. `= null` waits on the compiler, which rejects a default on a `#[cm]` operation: its call site is a dispatch wrapper that takes the arguments as declared. A trailing optional whose type the slice cannot express (a dictionary, a callback) is dropped, and so is everything after it. A variadic has no default to fall back on, so its member is skipped.
-- A union lowers to the one constituent the slice can express: `(TrustedHTML or DOMString)` to `String`, `(ScrollIntoViewOptions or boolean)` to `bool`. An `undefined` constituent makes it nullable. Two expressible constituents want the variant above, which is not built, so the member is skipped.
-- Overloads are not merged: a name is emitted only when exactly one of its overloads lowers, so `Window.alert()` / `alert(message)` is skipped.
+- An `optional` parameter is an `Option<T>`, with no default: `clone_node(null)`. Leaving it `None` is leaving the argument out, so the browser applies the WebIDL default. A default value waits on the compiler, which rejects one on a `#[cm]` operation. An optional the slice cannot type is dropped, along with every argument after it, and a variadic takes its member with it.
+- A union becomes the one constituent the slice can type: `(TrustedHTML or DOMString)` is `String`. An `undefined` constituent makes it nullable. Two typable constituents want the variant above, which is not built, so the member is skipped.
+- Overloads are not merged. A name is emitted only when exactly one of its overloads lowers, so `Window.alert()` / `alert(message)` is skipped.
 
 ### Concrete Examples
 
@@ -885,7 +885,7 @@ impl ParentNode for DocumentFragment { /* generated delegation to host */ }
 
 Mixins are the one place where Wado traits shine over `resource extends`: a mixin can be applied to unrelated types that don't share an inheritance chain.
 
-Known gap: the frontend folds a mixin's members into each interface that includes it, so `Document` and `Element` each declare their own `query_selector`, imported from their own CM interface. The CM surface is the same either way, because the trait form changes only the Wado declaration. It waits on a consumer that needs to name the mixin as a bound.
+Known gap: a mixin's members are folded into each interface that includes it, so `Document` and `Element` each declare their own `query_selector`. The trait form changes only the Wado declaration, not the CM surface. It waits on a consumer that needs the mixin as a bound.
 
 #### Union Types (Variant Generation)
 
@@ -917,7 +917,7 @@ web/
 └── ...
 ```
 
-One module per package. The WASI layout, one file per WIT interface under a package directory plus a flat re-export, does not carry over: WebIDL specs reference each other in both directions (`HTMLElement` extends the DOM's `Element`, whose `Document` returns an `HTMLElement` as its `body`), so a per-spec split would import in a cycle. A package is instead the unit a slice is cut at. Its `[Global]` interface yields the effect that hands out the first handle: `Dom::window()`, plus an accessor for each read-only attribute of the global typed as another slice resource, `Dom::document()`.
+One module per package. The WASI layout, a file per WIT interface, does not carry over: WebIDL specs reference each other both ways, so a per-spec split would import in a cycle. `HTMLElement` extends the DOM's `Element`, and that spec's `Document` returns an `HTMLElement`. The package is therefore the unit a slice is cut at. Its `[Global]` interface yields the effect that hands out the first handle: `Dom::window()`, and an accessor for each read-only attribute of the global typed as another slice resource, such as `Dom::document()`.
 
 ### Comparison Summary
 

--- a/docs/wep-2026-04-01-tide.md
+++ b/docs/wep-2026-04-01-tide.md
@@ -83,7 +83,7 @@ Pipeline:
 
 The WIT path remains unchanged (`--wit-dir`). Both frontends produce the same IR, so codegen improvements benefit both WASI and Web API bindings.
 
-The frontend emits every member whose types the slice can express. A member it cannot express is reported on stderr, as `Element.attributes: NamedNodeMap is outside the slice`, never approximated. A slice has to be closed: a parent outside it is an error, so widening the slice means adding the chain. A test regenerates the module from the snapshot and fails when the bundled file is stale.
+The frontend emits every member whose types the slice can express. It never approximates one it cannot; that member is reported on stderr instead, as `Element.attributes: NamedNodeMap is outside the slice`. A slice has to be closed, so a parent outside it is an error and widening the slice means adding the whole chain. A test regenerates the module from the snapshot and fails when the bundled file is stale.
 
 ### Unified Attribute: `#[cm("...")]`
 
@@ -271,7 +271,7 @@ variant CanvasImageSourceOrPath {
 
 What the frontend emits today falls short of that shape in three places, each a known gap:
 
-- An `optional` parameter is an `Option<T>` with no default: `clone_node(null)`. `None` is the argument left out, so the WebIDL default applies in the browser. The compiler rejects a default on a `#[cm]` operation, whose call site is a dispatch wrapper that takes the arguments as declared, so `= null` waits on that. A trailing optional whose type the slice cannot express (a dictionary, a callback) is dropped, with everything after it. A variadic has no default to fall back on, so its member is skipped.
+- An `optional` parameter is an `Option<T>` with no default: `clone_node(null)`. `None` is the argument left out, so the WebIDL default applies in the browser. `= null` waits on the compiler, which rejects a default on a `#[cm]` operation: its call site is a dispatch wrapper that takes the arguments as declared. A trailing optional whose type the slice cannot express (a dictionary, a callback) is dropped, and so is everything after it. A variadic has no default to fall back on, so its member is skipped.
 - A union lowers to the one constituent the slice can express: `(TrustedHTML or DOMString)` to `String`, `(ScrollIntoViewOptions or boolean)` to `bool`. An `undefined` constituent makes it nullable. Two expressible constituents want the variant above, which is not built, so the member is skipped.
 - Overloads are not merged: a name is emitted only when exactly one of its overloads lowers, so `Window.alert()` / `alert(message)` is skipped.
 
@@ -885,7 +885,7 @@ impl ParentNode for DocumentFragment { /* generated delegation to host */ }
 
 Mixins are the one place where Wado traits shine over `resource extends`: a mixin can be applied to unrelated types that don't share an inheritance chain.
 
-Known gap: the frontend folds a mixin's members into each interface that includes it, so `Document` and `Element` each declare their own `query_selector`, imported from their own CM interface. The CM surface is the same either way. The trait form changes only the Wado declaration, and waits on a consumer that needs to name the mixin as a bound.
+Known gap: the frontend folds a mixin's members into each interface that includes it, so `Document` and `Element` each declare their own `query_selector`, imported from their own CM interface. The CM surface is the same either way, because the trait form changes only the Wado declaration. It waits on a consumer that needs to name the mixin as a bound.
 
 #### Union Types (Variant Generation)
 

--- a/docs/wep-2026-04-01-tide.md
+++ b/docs/wep-2026-04-01-tide.md
@@ -63,7 +63,7 @@ Wado eliminates several root causes of these pain points:
 
 `wado-from-idl` uses the [`@webref/idl`](https://www.npmjs.com/package/@webref/idl) npm package as its source of truth. This package provides curated, validated WebIDL definitions scraped from W3C and WHATWG specifications, updated weekly. All definitions are guaranteed to parse and be internally consistent.
 
-The package's `parseAll()` API (powered by `webidl2`) produces parsed AST nodes. `scripts/webidl/snapshot.mjs` runs it and writes the AST of one slice — the interfaces it lists, their `partial interface`s and the mixins they include as written by the specs that define one of them, and the typedefs their members name — to `wado-compiler/lib/web/dom.webidl.json`, next to the module generated from it. The snapshot is vendored, so generation is deterministic and needs no network; `mise run update-webidl-snapshot` retakes it, and the slice is widened by editing the script's list.
+The package's `parseAll()` API (powered by `webidl2`) produces parsed AST nodes. `scripts/webidl/snapshot.mjs` runs it and writes the AST of one slice to `wado-compiler/lib/web/dom.webidl.json`, next to the module generated from it. The slice is the interfaces the script lists, their partials and included mixins from the specs that define one of them, and the typedefs their members name. The snapshot is vendored, so generation is deterministic and needs no network. `mise run update-webidl-snapshot` retakes it, and the slice is widened by editing the script's list.
 
 ### Tool Implementation
 
@@ -83,7 +83,7 @@ Pipeline:
 
 The WIT path remains unchanged (`--wit-dir`). Both frontends produce the same IR, so codegen improvements benefit both WASI and Web API bindings.
 
-The frontend emits every member whose types the slice can express, and reports each one it cannot on stderr — `Element.attributes: NamedNodeMap is outside the slice` — rather than approximating it. A slice has to be closed: a parent outside it is an error, so widening the slice means adding the chain. A test regenerates the module from the snapshot and fails when the bundled file is stale.
+The frontend emits every member whose types the slice can express. A member it cannot express is reported on stderr, as `Element.attributes: NamedNodeMap is outside the slice`, never approximated. A slice has to be closed: a parent outside it is an error, so widening the slice means adding the chain. A test regenerates the module from the snapshot and fails when the bundled file is stale.
 
 ### Unified Attribute: `#[cm("...")]`
 
@@ -271,8 +271,8 @@ variant CanvasImageSourceOrPath {
 
 What the frontend emits today falls short of that shape in three places, each a known gap:
 
-- An `optional` parameter is an `Option<T>` with no default: `clone_node(null)`. `None` is the argument left out, so the WebIDL default applies in the browser. The compiler rejects a default on a `#[cm]` operation — its call site is a dispatch wrapper that takes the arguments as declared — so `= null` waits on that. A trailing optional whose type the slice cannot express (a dictionary, a callback) is dropped, with everything after it.
-- A union lowers to the one constituent the slice can express — `(TrustedHTML or DOMString)` to `String`, `(ScrollIntoViewOptions or boolean)` to `bool` — and an `undefined` constituent makes it nullable. Two expressible constituents want the variant above, which is not built, so the member is skipped.
+- An `optional` parameter is an `Option<T>` with no default: `clone_node(null)`. `None` is the argument left out, so the WebIDL default applies in the browser. The compiler rejects a default on a `#[cm]` operation, whose call site is a dispatch wrapper that takes the arguments as declared, so `= null` waits on that. A trailing optional whose type the slice cannot express (a dictionary, a callback) is dropped, with everything after it.
+- A union lowers to the one constituent the slice can express: `(TrustedHTML or DOMString)` to `String`, `(ScrollIntoViewOptions or boolean)` to `bool`. An `undefined` constituent makes it nullable. Two expressible constituents want the variant above, which is not built, so the member is skipped.
 - Overloads are not merged: a name is emitted only when exactly one of its overloads lowers, so `Window.alert()` / `alert(message)` is skipped.
 
 ### Concrete Examples
@@ -885,7 +885,7 @@ impl ParentNode for DocumentFragment { /* generated delegation to host */ }
 
 Mixins are the one place where Wado traits shine over `resource extends`: a mixin can be applied to unrelated types that don't share an inheritance chain.
 
-Known gap: the frontend folds a mixin's members into each interface that includes it, so `Document` and `Element` each declare their own `query_selector`, imported from their own CM interface. The CM surface is the same either way — the trait form changes only the Wado declaration, and it waits on a consumer that needs to name the mixin as a bound.
+Known gap: the frontend folds a mixin's members into each interface that includes it, so `Document` and `Element` each declare their own `query_selector`, imported from their own CM interface. The CM surface is the same either way. The trait form changes only the Wado declaration, and waits on a consumer that needs to name the mixin as a bound.
 
 #### Union Types (Variant Generation)
 
@@ -917,7 +917,7 @@ web/
 └── ...
 ```
 
-One module per package. The WASI layout — one file per WIT interface under a package directory, plus a flat re-export — does not carry over: WebIDL specs reference each other in both directions (`HTMLElement` extends the DOM's `Element`, whose `Document` returns an `HTMLElement` as its `body`), so a per-spec split would import in a cycle. A package is instead the unit a slice is cut at, and its `[Global]` interface yields the effect that hands out the first handle: `Dom::window()`, plus an accessor for each read-only attribute of the global typed as another slice resource — `Dom::document()`.
+One module per package. The WASI layout, one file per WIT interface under a package directory plus a flat re-export, does not carry over: WebIDL specs reference each other in both directions (`HTMLElement` extends the DOM's `Element`, whose `Document` returns an `HTMLElement` as its `body`), so a per-spec split would import in a cycle. A package is instead the unit a slice is cut at. Its `[Global]` interface yields the effect that hands out the first handle: `Dom::window()`, plus an accessor for each read-only attribute of the global typed as another slice resource, `Dom::document()`.
 
 ### Comparison Summary
 
@@ -1006,7 +1006,7 @@ Out of MVP: `Inspect` / `Display` host imports; the `serde`-is-an-error rule.
 - [x] Vendor a pinned JSON snapshot of the slice so generation is deterministic in tests
 - [x] Slice only: `EventTarget`, `Event`, `Node`, `Element`, `HTMLElement`, `HTMLInputElement`, `Document`, `Window`, with every member whose types the slice expresses
 
-Out of MVP: mixins as traits, union-to-variant, dictionaries, overload merging, enums, full spec coverage — see Method Overload Strategy and Mixins for what stands in for each.
+Out of MVP: mixins as traits, union-to-variant, dictionaries, overload merging, enums, full spec coverage. Method Overload Strategy and Mixins say what stands in for each.
 
 ### M6 — Host glue and browser E2E
 

--- a/docs/wep-2026-04-01-tide.md
+++ b/docs/wep-2026-04-01-tide.md
@@ -63,7 +63,7 @@ Wado eliminates several root causes of these pain points:
 
 `wado-from-idl` uses the [`@webref/idl`](https://www.npmjs.com/package/@webref/idl) npm package as its source of truth. This package provides curated, validated WebIDL definitions scraped from W3C and WHATWG specifications, updated weekly. All definitions are guaranteed to parse and be internally consistent.
 
-The package's `parseAll()` API (powered by `webidl2`) produces parsed AST nodes. `scripts/webidl/snapshot.mjs` runs it and writes the AST of one slice to `wado-compiler/lib/web/dom.webidl.json`, next to the module generated from it. The slice is the interfaces the script lists, their partials and included mixins from the specs that define one of them, and the typedefs their members name. The snapshot is vendored, so generation is deterministic and needs no network. `mise run update-webidl-snapshot` retakes it, and the slice is widened by editing the script's list.
+The package's `parseAll()` API (powered by `webidl2`) produces parsed AST nodes. `scripts/webidl/snapshot.mjs` runs it and writes the AST of one slice to `wado-compiler/lib/web/dom.webidl.json`, next to the module generated from it. The slice is the interfaces the script lists, their partials and included mixins from every spec, and the typedefs their members name. The snapshot is vendored, so generation is deterministic and needs no network. `mise run update-webidl-snapshot` retakes it, and the slice is widened by editing the script's list.
 
 ### Tool Implementation
 
@@ -271,7 +271,7 @@ variant CanvasImageSourceOrPath {
 
 What the frontend emits today falls short of that shape in three places, each a known gap:
 
-- An `optional` parameter is an `Option<T>` with no default: `clone_node(null)`. `None` is the argument left out, so the WebIDL default applies in the browser. The compiler rejects a default on a `#[cm]` operation, whose call site is a dispatch wrapper that takes the arguments as declared, so `= null` waits on that. A trailing optional whose type the slice cannot express (a dictionary, a callback) is dropped, with everything after it.
+- An `optional` parameter is an `Option<T>` with no default: `clone_node(null)`. `None` is the argument left out, so the WebIDL default applies in the browser. The compiler rejects a default on a `#[cm]` operation, whose call site is a dispatch wrapper that takes the arguments as declared, so `= null` waits on that. A trailing optional whose type the slice cannot express (a dictionary, a callback) is dropped, with everything after it. A variadic has no default to fall back on, so its member is skipped.
 - A union lowers to the one constituent the slice can express: `(TrustedHTML or DOMString)` to `String`, `(ScrollIntoViewOptions or boolean)` to `bool`. An `undefined` constituent makes it nullable. Two expressible constituents want the variant above, which is not built, so the member is skipped.
 - Overloads are not merged: a name is emitted only when exactly one of its overloads lowers, so `Window.alert()` / `alert(message)` is skipped.
 
@@ -367,10 +367,10 @@ pub resource Node extends EventTarget {
     fn set_text_content(&self, value: Option<String>);
 
     #[cm("web:dom#Node.appendChild")]
-    fn append_child(&self, node: &Node) -> Node;
+    fn append_child(&self, node: Node) -> Node;
 
     #[cm("web:dom#Node.removeChild")]
-    fn remove_child(&self, child: &Node) -> Node;
+    fn remove_child(&self, child: Node) -> Node;
 
     #[cm("web:dom#Node.cloneNode")]
     fn clone_node(&self, deep: bool = false) -> Node;
@@ -432,7 +432,7 @@ pub resource Document extends Node {
     fn get_element_by_id(&self, element_id: String) -> Option<Element>;
 
     #[cm("web:dom#Document.createElement")]
-    fn create_element(&self, local_name: String) -> Element;
+    fn create_element(&self, local_name: String, options: Option<String>) -> Element;
 
     #[cm("web:dom#Document.createTextNode")]
     fn create_text_node(&self, data: String) -> Text;
@@ -458,11 +458,11 @@ use { Dom, Document, Element } from "web:dom";
 
 fn setup_page() with Dom {
     let doc = Dom::document();
-    let el = doc.create_element("div");
+    let el = doc.create_element("div", null);
     el.set_id("app");
     el.set_text_content(Option::Some("Hello, Wado!"));
     if let Some(body) = doc.body() {
-        body.append_child(&el);  // append_child from Node, available via extends
+        body.append_child(el);  // append_child from Node, available via extends
     }
 }
 ```

--- a/docs/wep-2026-04-01-tide.md
+++ b/docs/wep-2026-04-01-tide.md
@@ -63,29 +63,27 @@ Wado eliminates several root causes of these pain points:
 
 `wado-from-idl` uses the [`@webref/idl`](https://www.npmjs.com/package/@webref/idl) npm package as its source of truth. This package provides curated, validated WebIDL definitions scraped from W3C and WHATWG specifications, updated weekly. All definitions are guaranteed to parse and be internally consistent.
 
-```sh
-npm install @webref/idl
-```
-
-The package's `parseAll()` API (powered by `webidl2`) produces parsed AST nodes with structured `default` fields for optional parameters and dictionary members. Default value types: `boolean`, `number`, `string`, `null`, `dictionary` (`= {}`), `sequence` (`= []`). When no default is specified, the `default` field is `null`.
+The package's `parseAll()` API (powered by `webidl2`) produces parsed AST nodes. `scripts/webidl/snapshot.mjs` runs it and writes the AST of one slice — the interfaces it lists, their `partial interface`s and the mixins they include as written by the specs that define one of them, and the typedefs their members name — to `wado-compiler/lib/web/dom.webidl.json`, next to the module generated from it. The snapshot is vendored, so generation is deterministic and needs no network; `mise run update-webidl-snapshot` retakes it, and the slice is widened by editing the script's list.
 
 ### Tool Implementation
 
 `wado-from-idl` (renamed from `wado-from-wit`) already provides a type-safe IR (`WadoModule`, `WadoResource`, `WadoStruct`, `WadoEffect`, etc.) and a `WadoCodeGenerator` that emits clean Wado source. The concepts map directly: WIT interfaces and WebIDL interfaces both produce resources, structs, enums, and effects.
 
-The crate gains a WebIDL parser alongside the WIT parser, sharing the IR and codegen layers:
+The crate reads the snapshot alongside the WIT parser, sharing the IR and codegen layers (`wado-from-idl/src/webidl.rs`; `mise run update-stdlib-web`):
 
 ```sh
-wado-from-idl --webidl-dir ./webidl-json/ --output-dir ./web/
+wado-from-idl --webidl wado-compiler/lib/web/dom.webidl.json --output-dir wado-compiler/lib/web
 ```
 
 Pipeline:
 
 ```
-@webref/idl (JSON) → Parse → IR (WadoModule: resources, types, effects) → WadoCodeGenerator → web/*.wado
+@webref/idl → snapshot.mjs (webidl2 AST, JSON) → webidl.rs → IR (WadoModule: resources, effects) → WadoCodeGenerator → web/dom.wado
 ```
 
 The WIT path remains unchanged (`--wit-dir`). Both frontends produce the same IR, so codegen improvements benefit both WASI and Web API bindings.
+
+The frontend emits every member whose types the slice can express, and reports each one it cannot on stderr — `Element.attributes: NamedNodeMap is outside the slice` — rather than approximating it. A slice has to be closed: a parent outside it is an error, so widening the slice means adding the chain. A test regenerates the module from the snapshot and fails when the bundled file is stale.
 
 ### Unified Attribute: `#[cm("...")]`
 
@@ -238,7 +236,7 @@ fn app() with (Dom, Fetch) {
 
 ### Method Overload Strategy
 
-WebIDL allows method overloading (same name, different signatures) and optional parameters with default values. `wado-from-idl` resolves these using [default arguments](./wep-2026-04-11-default-arguments.md):
+WebIDL allows method overloading (same name, different signatures) and optional parameters with default values. The intended shape resolves these using [default arguments](./wep-2026-04-11-default-arguments.md):
 
 ```webidl
 // WebIDL: optional parameter with default
@@ -270,6 +268,12 @@ variant CanvasImageSourceOrPath {
     Path(Path2d),
 }
 ```
+
+What the frontend emits today falls short of that shape in three places, each a known gap:
+
+- An `optional` parameter is an `Option<T>` with no default: `clone_node(null)`. `None` is the argument left out, so the WebIDL default applies in the browser. The compiler rejects a default on a `#[cm]` operation — its call site is a dispatch wrapper that takes the arguments as declared — so `= null` waits on that. A trailing optional whose type the slice cannot express (a dictionary, a callback) is dropped, with everything after it.
+- A union lowers to the one constituent the slice can express — `(TrustedHTML or DOMString)` to `String`, `(ScrollIntoViewOptions or boolean)` to `bool` — and an `undefined` constituent makes it nullable. Two expressible constituents want the variant above, which is not built, so the member is skipped.
+- Overloads are not merged: a name is emitted only when exactly one of its overloads lowers, so `Window.alert()` / `alert(message)` is skipped.
 
 ### Concrete Examples
 
@@ -881,6 +885,8 @@ impl ParentNode for DocumentFragment { /* generated delegation to host */ }
 
 Mixins are the one place where Wado traits shine over `resource extends`: a mixin can be applied to unrelated types that don't share an inheritance chain.
 
+Known gap: the frontend folds a mixin's members into each interface that includes it, so `Document` and `Element` each declare their own `query_selector`, imported from their own CM interface. The CM surface is the same either way — the trait form changes only the Wado declaration, and it waits on a consumer that needs to name the mixin as a bound.
+
 #### Union Types (Variant Generation)
 
 WebIDL unions become Wado variants:
@@ -904,31 +910,14 @@ Common unions get readable names from their WebIDL typedef. Unnamed unions get a
 
 ```
 web/
-├── dom/
-│   ├── types.wado          # EventTarget, Node, Element, Document, Window
-│   ├── events.wado         # Event, MouseEvent, KeyboardEvent, UIEvent
-│   ├── html_elements.wado  # HTMLElement, HTMLInputElement, HTMLDivElement, ...
-│   └── effect.wado         # pub effect Dom { ... }
-├── dom.wado                # flat re-export: pub use { ... } from "web:dom/types.wado";
-├── fetch/
-│   ├── types.wado          # Request, Response, Headers, RequestInit
-│   └── effect.wado         # pub effect Fetch { ... }
-├── fetch.wado
-├── canvas/
-│   ├── types.wado          # CanvasRenderingContext2D, Path2D, ImageData
-│   └── effect.wado
-├── canvas.wado
-├── websocket/
-│   ├── types.wado          # WebSocket, CloseEvent, MessageEvent
-│   └── effect.wado
-├── websocket.wado
-├── url/
-│   └── types.wado          # URL, URLSearchParams
-├── url.wado
+├── dom.wado         # web:dom — every resource of the slice, and the Dom effect
+├── dom.webidl.json  # the snapshot dom.wado is generated from
+├── fetch.wado       # web:fetch — Request, Response, Headers, and the Fetch effect
+├── fetch.webidl.json
 └── ...
 ```
 
-Organized by W3C/WHATWG specification, mirroring how `wasi/` is organized by WASI interface.
+One module per package. The WASI layout — one file per WIT interface under a package directory, plus a flat re-export — does not carry over: WebIDL specs reference each other in both directions (`HTMLElement` extends the DOM's `Element`, whose `Document` returns an `HTMLElement` as its `body`), so a per-spec split would import in a cycle. A package is instead the unit a slice is cut at, and its `[Global]` interface yields the effect that hands out the first handle: `Dom::window()`, plus an accessor for each read-only attribute of the global typed as another slice resource — `Dom::document()`.
 
 ### Comparison Summary
 
@@ -1012,12 +1001,12 @@ Out of MVP: `Inspect` / `Display` host imports; the `serde`-is-an-error rule.
 
 ### M5 — WebIDL frontend, minimum slice
 
-- [ ] `@webref/idl` JSON ingestion alongside the WIT frontend, sharing the IR (`wado-from-idl`)
-- [ ] IR and codegen: `extends`, `#[cm(..., type = "extern-handle")]`, `#[cm_params]`
-- [ ] Vendor a pinned JSON snapshot of the slice so generation is deterministic in tests
-- [ ] Slice only: `EventTarget`, `Node`, `Element`, `HTMLElement`, `HTMLInputElement`, `Document`, `Window`, and the members the demo calls
+- [x] `@webref/idl` JSON ingestion alongside the WIT frontend, sharing the IR (`wado-from-idl`)
+- [x] IR and codegen: `extends`, `#[cm(..., type = "extern-handle")]`, `#[cm_params]`
+- [x] Vendor a pinned JSON snapshot of the slice so generation is deterministic in tests
+- [x] Slice only: `EventTarget`, `Event`, `Node`, `Element`, `HTMLElement`, `HTMLInputElement`, `Document`, `Window`, with every member whose types the slice expresses
 
-Out of MVP: mixins, union types, dictionaries, overload-to-variant, enums, full spec coverage.
+Out of MVP: mixins as traits, union-to-variant, dictionaries, overload merging, enums, full spec coverage — see Method Overload Strategy and Mixins for what stands in for each.
 
 ### M6 — Host glue and browser E2E
 
@@ -1028,12 +1017,13 @@ Out of MVP: mixins, union types, dictionaries, overload-to-variant, enums, full 
 
 ### Deferred, and what each blocks
 
-| Deferred                               | Blocks                           | Note                                                                          |
-| -------------------------------------- | -------------------------------- | ----------------------------------------------------------------------------- |
-| Passing a Wado closure to the host     | `add_event_listener`, all events | Shape settled (see Callbacks); own WEP when built — first thing after the MVP |
-| `Promise` → `Future<T>`                | `fetch`, every async browser API |                                                                               |
-| Handle release                         | long-lived pages                 | v1 leaks one table slot per handle                                            |
-| `Inspect` / `Display` / `serde` rules  | debug printing a handle          |                                                                               |
-| Mixins, unions, dictionaries, full IDL | breadth                          | Slice first, breadth after the pipeline is proven end to end                  |
-| `extends` on `i32`-backed resources    | WIT-side hierarchies             | Deliberately out of scope in v1                                               |
-| A real `externref` handle              | performance, release             | Needs a non-component target — Resource Inheritance, "Known gap"              |
+| Deferred                               | Blocks                                 | Note                                                                                         |
+| -------------------------------------- | -------------------------------------- | -------------------------------------------------------------------------------------------- |
+| Passing a Wado closure to the host     | `add_event_listener`, all events       | Shape settled (see Callbacks); own WEP when built — first thing after the MVP                |
+| `Promise` → `Future<T>`                | `fetch`, every async browser API       |                                                                                              |
+| Default arguments on a CM operation    | `clone_node()` over `clone_node(null)` | The compiler rejects them on a `#[cm]` operation; an `optional` is an `Option<T>` until then |
+| Handle release                         | long-lived pages                       | v1 leaks one table slot per handle                                                           |
+| `Inspect` / `Display` / `serde` rules  | debug printing a handle                |                                                                                              |
+| Mixins, unions, dictionaries, full IDL | breadth                                | Slice first, breadth after the pipeline is proven end to end                                 |
+| `extends` on `i32`-backed resources    | WIT-side hierarchies                   | Deliberately out of scope in v1                                                              |
+| A real `externref` handle              | performance, release                   | Needs a non-component target — Resource Inheritance, "Known gap"                             |

--- a/docs/wep-2026-04-01-tide.md
+++ b/docs/wep-2026-04-01-tide.md
@@ -272,7 +272,7 @@ variant CanvasImageSourceOrPath {
 The frontend falls short of that shape in three ways, each a known gap:
 
 - An `optional` parameter is an `Option<T>`, with no default: `clone_node(null)`. Leaving it `None` is leaving the argument out, so the browser applies the WebIDL default. A default value waits on the compiler, which rejects one on a `#[cm]` operation. An optional the slice cannot type is dropped, along with every argument after it, and a variadic takes its member with it.
-- A union becomes the one constituent the slice can type: `(TrustedHTML or DOMString)` is `String`. An `undefined` constituent makes it nullable. Two typable constituents want the variant above, which is not built, so the member is skipped.
+- A union collapses to its one typable constituent only where the guest supplies the value. `set_inner_html` takes `(TrustedHTML or DOMString)` as `String`: the slice cannot build a `TrustedHTML`, so nothing is lost on the way in. On the way out the host could return the dropped constituent, so the member is skipped — there is no `inner_html` getter, only `get_html`. An `undefined` constituent is the nullability marker, not a dropped one. Two typable constituents want the variant above, which is not built, so the member is skipped.
 - Overloads are not merged. A name is emitted only when exactly one of its overloads lowers, so `Window.alert()` / `alert(message)` is skipped.
 
 ### Concrete Examples

--- a/docs/wep-2026-04-28-resource-inheritance.md
+++ b/docs/wep-2026-04-28-resource-inheritance.md
@@ -592,7 +592,7 @@ Implemented, with tests in `wado-compiler/tests/integration/extern_handle_resour
 
 - Lowering. An extern-handle resource is not a CM `resource`: it registers as a `u32` newtype (`component_model.rs`), so every `own` / `borrow` path passes it by, a `&self` receiver loses its reference, and the WIT renders the same opaque `u32` in every position (`wit_emit.rs::extern_handle`). Upcast and an inherited method's receiver are wasm-level no-ops — the call resolves to the declaring resource through `MethodOwner::Ancestor`.
 
-- That newtype has two readings, and a synthesized binding needs both. `CmInterfaceRegistry::resolve_type` peels the handle to its `u32`, which is what the boundary decides with: the flat ABI, the canonical options, the emitted WIT. `value_type` keeps the resource's own type, which is what the guest holds. A binding's own signature takes the second, because `Option<Element>` and `Option<u32>` are distinct GC types: a call site building one while the binding declares the other emits invalid Wasm (`tests/integration/web_dom.rs`). Reaching the resource's `TypeId` from a CM type is `cm_type_to_type_id`, which looks it up under the package rather than a per-interface module, a `web:` package being one flat file.
+- The registry reads that newtype two ways. `resolve_type` peels the handle to its `u32`, the view the boundary decides with: the flat ABI, the canonical options, the emitted WIT. `value_type` keeps the resource's own type, the view the guest holds. A binding's signature takes the second, because `Option<Element>` and `Option<u32>` are distinct GC types (`tests/integration/web_dom.rs`). `cm_type_to_type_id` finds the resource's `TypeId` under its package, a `web:` package being one flat file.
 
 Not built:
 

--- a/docs/wep-2026-04-28-resource-inheritance.md
+++ b/docs/wep-2026-04-28-resource-inheritance.md
@@ -592,6 +592,8 @@ Implemented, with tests in `wado-compiler/tests/integration/extern_handle_resour
 
 - Lowering. An extern-handle resource is not a CM `resource`: it registers as a `u32` newtype (`component_model.rs`), so every `own` / `borrow` path passes it by, a `&self` receiver loses its reference, and the WIT renders the same opaque `u32` in every position (`wit_emit.rs::extern_handle`). Upcast and an inherited method's receiver are wasm-level no-ops — the call resolves to the declaring resource through `MethodOwner::Ancestor`.
 
+- That newtype has two readings, and a synthesized binding needs both. `CmInterfaceRegistry::resolve_type` peels the handle to its `u32`, which is what the boundary decides with: the flat ABI, the canonical options, the emitted WIT. `value_type` keeps the resource's own type, which is what the guest holds. A binding's own signature takes the second, because `Option<Element>` and `Option<u32>` are distinct GC types: a call site building one while the binding declares the other emits invalid Wasm (`tests/integration/web_dom.rs`). Reaching the resource's `TypeId` from a CM type is `cm_type_to_type_id`, which looks it up under the package rather than a per-interface module, a `web:` package being one flat file.
+
 Not built:
 
 - `downcast`, and the `Eq` / `Inspect` / `Display` host imports.

--- a/docs/wep-2026-08-29-markup-dialect.md
+++ b/docs/wep-2026-08-29-markup-dialect.md
@@ -9,8 +9,8 @@ Wado has to emit HTML on two fronts and has a surface for neither.
   by [`core:router`](./wep-2026-05-06-core-router.md) returns HTML. Marl already
   exports `escape_text` / `escape_attr` for HTML-templating consumers; the
   consumer does not exist.
-- Client-side. [`web:dom`](./wep-2026-04-01-tide.md) is a 55-line seed — one
-  interface and five resources — and
+- Client-side. [`web:dom`](./wep-2026-04-01-tide.md) is eight resources
+  generated from a WebIDL slice, with no host to run against, and
   [Reactive Signals](./wep-2026-04-04-reactive-signals.md) is designed around a
   UI surface it does not have.
 

--- a/mise.toml
+++ b/mise.toml
@@ -457,6 +457,25 @@ cargo run -p wado-from-idl -- \
 find wado-compiler/lib/wasi -type f -name '*.wado' -exec cargo run -p wado-cli -- format -w {} +
 """
 
+[tasks.update-webidl-snapshot]
+description = "Re-snapshot the WebIDL slice from @webref/idl (network) into lib/web/dom.webidl.json"
+run = """
+#!/usr/bin/env bash
+set -xe -o pipefail
+cd scripts/webidl && npm install && cd ../..
+node scripts/webidl/snapshot.mjs wado-compiler/lib/web/dom.webidl.json
+"""
+
+[tasks.update-stdlib-web]
+description = "Regenerate the web:dom stdlib from the vendored WebIDL snapshot"
+run = """
+#!/usr/bin/env bash
+set -xe -o pipefail
+cargo run -p wado-from-idl -- \
+    --webidl wado-compiler/lib/web/dom.webidl.json \
+    --output-dir wado-compiler/lib/web
+"""
+
 [tasks.update-stdlib-kiln]
 description = "Regenerate core:kiln stdlib submodules from WIT file (facade is hand-written)"
 run = """

--- a/mise.toml
+++ b/mise.toml
@@ -457,14 +457,14 @@ cargo run -p wado-from-idl -- \
 find wado-compiler/lib/wasi -type f -name '*.wado' -exec cargo run -p wado-cli -- format -w {} +
 """
 
+[tasks.webidl-deps]
+description = "Install @webref/idl for the WebIDL snapshot (scripts/webidl)"
+run = "cd scripts/webidl && npm install"
+
 [tasks.update-webidl-snapshot]
-description = "Re-snapshot the WebIDL slice from @webref/idl (network) into lib/web/dom.webidl.json"
-run = """
-#!/usr/bin/env bash
-set -xe -o pipefail
-cd scripts/webidl && npm install && cd ../..
-node scripts/webidl/snapshot.mjs wado-compiler/lib/web/dom.webidl.json
-"""
+description = "Re-snapshot the WebIDL slice from @webref/idl into lib/web/dom.webidl.json"
+depends = ["webidl-deps"]
+run = "node scripts/webidl/snapshot.mjs wado-compiler/lib/web/dom.webidl.json"
 
 [tasks.update-stdlib-web]
 description = "Regenerate the web:dom stdlib from the vendored WebIDL snapshot"

--- a/scripts/webidl/package-lock.json
+++ b/scripts/webidl/package-lock.json
@@ -1,0 +1,32 @@
+{
+  "name": "wado-webidl-snapshot",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "wado-webidl-snapshot",
+      "dependencies": {
+        "@webref/idl": "^3.83.1",
+        "webidl2": "^24.5.0"
+      }
+    },
+    "node_modules/@webref/idl": {
+      "version": "3.83.1",
+      "resolved": "https://registry.npmjs.org/@webref/idl/-/idl-3.83.1.tgz",
+      "integrity": "sha512-Z3b6MzknPTYKhW3cEFQYEJ1UJfIfeZaP5NqHivfeJ1OD/NqQO9nb+OdSo7J/hiTPMfySJVu6OQvLDbFwHzFhaA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "webidl2": "^24.5.0"
+      }
+    },
+    "node_modules/webidl2": {
+      "version": "24.5.0",
+      "resolved": "https://registry.npmjs.org/webidl2/-/webidl2-24.5.0.tgz",
+      "integrity": "sha512-fxOigKkIem1iAgQ9t4cFOP+kWEA8y6Be/uh50FpJh0FijoeeT/VMrOyJzNLUgjy0rGMEcHeReKDCqj0g9dIe9A==",
+      "license": "W3C",
+      "engines": {
+        "node": ">= 18"
+      }
+    }
+  }
+}

--- a/scripts/webidl/package.json
+++ b/scripts/webidl/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "wado-webidl-snapshot",
+  "private": true,
+  "type": "module",
+  "description": "Snapshot the WebIDL slice Tide generates web:* from, out of @webref/idl.",
+  "dependencies": {
+    "@webref/idl": "^3.83.1",
+    "webidl2": "^24.5.0"
+  }
+}

--- a/scripts/webidl/snapshot.mjs
+++ b/scripts/webidl/snapshot.mjs
@@ -2,10 +2,9 @@
 //
 // Usage: node snapshot.mjs <output.json>
 //
-// The slice is the interfaces listed below, with their partials and included
-// mixins from the specs that define one of them, and the typedefs their
-// members name. `wado-from-idl --webidl` reads the output, so generation
-// never needs the network.
+// The slice is the interfaces listed below, their partials and included mixins
+// from every spec, and the typedefs their members name. `wado-from-idl --webidl`
+// reads the output, so generation never needs the network.
 
 import { parseAll } from "@webref/idl";
 import { readFile, writeFile } from "node:fs/promises";
@@ -29,44 +28,27 @@ if (!out) {
   process.exit(1);
 }
 
-// webidl2 nodes expose their fields through getters, so a spread would drop
-// them; `toJSON` is the plain shape.
-const plain = (spec, def) => ({ spec, ...JSON.parse(JSON.stringify(def)) });
-
 const all = await parseAll();
-const specs = Object.keys(all).sort();
+// Spec order is the output order, so the snapshot is deterministic.
+const defs = Object.keys(all)
+  .sort()
+  .flatMap((spec) => all[spec]);
 
-const inSlice = (def) => def.type === "interface" && SLICE.includes(def.name);
-const defining = specs.filter((spec) =>
-  all[spec].some((def) => inSlice(def) && !def.partial),
+const interfaces = defs.filter(
+  (def) => def.type === "interface" && SLICE.includes(def.name),
 );
-const interfaces = [];
-const includes = [];
-for (const spec of defining) {
-  for (const def of all[spec]) {
-    if (inSlice(def)) interfaces.push(plain(spec, def));
-    if (def.type === "includes" && SLICE.includes(def.target)) {
-      includes.push(plain(spec, def));
-    }
-  }
-}
+const includes = defs.filter(
+  (def) => def.type === "includes" && SLICE.includes(def.target),
+);
 const mixinNames = new Set(includes.map((i) => i.includes));
-const mixins = [];
-for (const spec of defining) {
-  for (const def of all[spec]) {
-    if (def.type === "interface mixin" && mixinNames.has(def.name)) {
-      mixins.push(plain(spec, def));
-    }
-  }
-}
+const mixins = defs.filter(
+  (def) => def.type === "interface mixin" && mixinNames.has(def.name),
+);
 
 // A typedef is kept when a member of the slice names it, transitively.
-const typedefs = new Map();
-for (const spec of specs) {
-  for (const def of all[spec]) {
-    if (def.type === "typedef") typedefs.set(def.name, plain(spec, def));
-  }
-}
+const typedefs = new Map(
+  defs.filter((def) => def.type === "typedef").map((def) => [def.name, def]),
+);
 const kept = new Map();
 const visit = (t) => {
   if (Array.isArray(t.idlType)) {
@@ -102,5 +84,5 @@ const snapshot = {
 };
 await writeFile(out, JSON.stringify(snapshot, null, 2) + "\n");
 console.error(
-  `snapshot: ${interfaces.length} interface and ${mixins.length} mixin definitions from ${defining.join(", ")}, ${kept.size} typedefs (@webref/idl ${webref.version}) → ${out}`,
+  `snapshot: ${interfaces.length} interface and ${mixins.length} mixin definitions, ${kept.size} typedefs (@webref/idl ${webref.version}) → ${out}`,
 );

--- a/scripts/webidl/snapshot.mjs
+++ b/scripts/webidl/snapshot.mjs
@@ -2,10 +2,10 @@
 //
 // Usage: node snapshot.mjs <output.json>
 //
-// The slice is the interfaces listed below, their `partial interface`s and
-// the mixins they include — as written by the specs that define one of them —
-// and the typedefs their members name. The output is what
-// `wado-from-idl --webidl` reads, so generation never needs the network.
+// The slice is the interfaces listed below, with their partials and included
+// mixins from the specs that define one of them, and the typedefs their
+// members name. `wado-from-idl --webidl` reads the output, so generation
+// never needs the network.
 
 import { parseAll } from "@webref/idl";
 import { readFile, writeFile } from "node:fs/promises";
@@ -67,10 +67,17 @@ for (const spec of specs) {
     if (def.type === "typedef") typedefs.set(def.name, plain(spec, def));
   }
 }
-const named = new Set();
+const kept = new Map();
 const visit = (t) => {
-  if (Array.isArray(t.idlType)) t.idlType.forEach(visit);
-  else named.add(t.idlType);
+  if (Array.isArray(t.idlType)) {
+    t.idlType.forEach(visit);
+    return;
+  }
+  const td = typedefs.get(t.idlType);
+  if (td && !kept.has(td.name)) {
+    kept.set(td.name, td);
+    visit(td.idlType);
+  }
 };
 for (const iface of [...interfaces, ...mixins]) {
   for (const m of iface.members) {
@@ -78,18 +85,6 @@ for (const iface of [...interfaces, ...mixins]) {
     for (const a of m.arguments ?? []) visit(a.idlType);
   }
 }
-const kept = [];
-const queue = [...named];
-while (queue.length) {
-  const name = queue.shift();
-  const td = typedefs.get(name);
-  if (!td || kept.includes(td)) continue;
-  kept.push(td);
-  const before = named.size;
-  visit(td.idlType);
-  queue.push(...[...named].slice(before));
-}
-kept.sort((a, b) => a.name.localeCompare(b.name));
 
 const require = createRequire(import.meta.url);
 const webref = JSON.parse(
@@ -103,9 +98,9 @@ const snapshot = {
   interfaces,
   mixins,
   includes,
-  typedefs: kept,
+  typedefs: [...kept.values()].sort((a, b) => a.name.localeCompare(b.name)),
 };
 await writeFile(out, JSON.stringify(snapshot, null, 2) + "\n");
 console.error(
-  `snapshot: ${interfaces.length} interface and ${mixins.length} mixin definitions from ${defining.join(", ")}, ${kept.length} typedefs (@webref/idl ${webref.version}) → ${out}`,
+  `snapshot: ${interfaces.length} interface and ${mixins.length} mixin definitions from ${defining.join(", ")}, ${kept.size} typedefs (@webref/idl ${webref.version}) → ${out}`,
 );

--- a/scripts/webidl/snapshot.mjs
+++ b/scripts/webidl/snapshot.mjs
@@ -1,0 +1,111 @@
+// Write the webidl2 AST of the `web:dom` slice as JSON.
+//
+// Usage: node snapshot.mjs <output.json>
+//
+// The slice is the interfaces listed below, their `partial interface`s and
+// the mixins they include — as written by the specs that define one of them —
+// and the typedefs their members name. The output is what
+// `wado-from-idl --webidl` reads, so generation never needs the network.
+
+import { parseAll } from "@webref/idl";
+import { readFile, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+
+const PACKAGE = "dom";
+const SLICE = [
+  "EventTarget",
+  "Event",
+  "Node",
+  "Element",
+  "HTMLElement",
+  "HTMLInputElement",
+  "Document",
+  "Window",
+];
+
+const out = process.argv[2];
+if (!out) {
+  console.error("Usage: node snapshot.mjs <output.json>");
+  process.exit(1);
+}
+
+// webidl2 nodes expose their fields through getters, so a spread would drop
+// them; `toJSON` is the plain shape.
+const plain = (spec, def) => ({ spec, ...JSON.parse(JSON.stringify(def)) });
+
+const all = await parseAll();
+const specs = Object.keys(all).sort();
+
+const inSlice = (def) => def.type === "interface" && SLICE.includes(def.name);
+const defining = specs.filter((spec) =>
+  all[spec].some((def) => inSlice(def) && !def.partial),
+);
+const interfaces = [];
+const includes = [];
+for (const spec of defining) {
+  for (const def of all[spec]) {
+    if (inSlice(def)) interfaces.push(plain(spec, def));
+    if (def.type === "includes" && SLICE.includes(def.target)) {
+      includes.push(plain(spec, def));
+    }
+  }
+}
+const mixinNames = new Set(includes.map((i) => i.includes));
+const mixins = [];
+for (const spec of defining) {
+  for (const def of all[spec]) {
+    if (def.type === "interface mixin" && mixinNames.has(def.name)) {
+      mixins.push(plain(spec, def));
+    }
+  }
+}
+
+// A typedef is kept when a member of the slice names it, transitively.
+const typedefs = new Map();
+for (const spec of specs) {
+  for (const def of all[spec]) {
+    if (def.type === "typedef") typedefs.set(def.name, plain(spec, def));
+  }
+}
+const named = new Set();
+const visit = (t) => {
+  if (Array.isArray(t.idlType)) t.idlType.forEach(visit);
+  else named.add(t.idlType);
+};
+for (const iface of [...interfaces, ...mixins]) {
+  for (const m of iface.members) {
+    if (m.idlType) visit(m.idlType);
+    for (const a of m.arguments ?? []) visit(a.idlType);
+  }
+}
+const kept = [];
+const queue = [...named];
+while (queue.length) {
+  const name = queue.shift();
+  const td = typedefs.get(name);
+  if (!td || kept.includes(td)) continue;
+  kept.push(td);
+  const before = named.size;
+  visit(td.idlType);
+  queue.push(...[...named].slice(before));
+}
+kept.sort((a, b) => a.name.localeCompare(b.name));
+
+const require = createRequire(import.meta.url);
+const webref = JSON.parse(
+  await readFile(require.resolve("@webref/idl/package.json"), "utf8"),
+);
+
+const snapshot = {
+  webref: webref.version,
+  package: PACKAGE,
+  slice: SLICE,
+  interfaces,
+  mixins,
+  includes,
+  typedefs: kept,
+};
+await writeFile(out, JSON.stringify(snapshot, null, 2) + "\n");
+console.error(
+  `snapshot: ${interfaces.length} interface and ${mixins.length} mixin definitions from ${defining.join(", ")}, ${kept.length} typedefs (@webref/idl ${webref.version}) → ${out}`,
+);

--- a/wado-compiler/AGENTS.md
+++ b/wado-compiler/AGENTS.md
@@ -25,8 +25,8 @@ The Wado compiler crate. The NIR optimizer has its own guide:
 `src/stdlib.rs` lists `lib/core/` and `lib/wasi/`. A dev build reads them from
 disk, so editing one takes effect on the next `wado` run with no rebuild. A
 release build embeds them, as does any `wasm32` build, which has no filesystem.
-`lib/wasi/` and `lib/core/kiln/` are generated from WIT: read
-`wado-from-idl/AGENTS.md` first.
+`lib/wasi/` and `lib/core/kiln/` are generated from WIT, `lib/web/` from a
+WebIDL snapshot: read `wado-from-idl/AGENTS.md` first.
 
 `builtin::select` returns one of its operands rather than a copy, so write the
 `if` for `i128`, `u128` and any composite: `src/optimize/select_lowering.rs`

--- a/wado-compiler/lib/web/dom.wado
+++ b/wado-compiler/lib/web/dom.wado
@@ -1,55 +1,1055 @@
+#![generated(by = "wado-from-idl", sources = ["wado-compiler/lib/web/dom.webidl.json"])]
 #![stdlib("web:dom")]
 
-/// The DOM entry points, which hand out the first handle.
-#[cm("web:dom/global")]
-pub interface Dom {
-    #[cm("web:dom/global#document")]
-    fn document() -> Document;
+#[cm("web:dom/event-target", type = "extern-handle")]
+pub resource EventTarget {
+    #[cm("web:dom/event-target#new")]
+    fn new() -> EventTarget;
+    #[cm("web:dom/event-target#dispatch-event")]
+    #[cm_params("self", "event")]
+    fn dispatch_event(&self, event: Event) -> bool;
 }
 
 #[cm("web:dom/event", type = "extern-handle")]
 pub resource Event {
     #[cm("web:dom/event#new")]
-    #[cm_params("event-type")]
-    fn new(event_type: String) -> Event;
-}
-
-#[cm("web:dom/event-target", type = "extern-handle")]
-pub resource EventTarget {
-    #[cm("web:dom/event-target#dispatch-event")]
-    #[cm_params("self", "event")]
-    fn dispatch_event(&self, event: &Event) -> bool;
+    #[cm_params("type")]
+    fn new(type_: String) -> Event;
+    #[cm("web:dom/event#type")]
+    #[cm_params("self")]
+    fn type_(&self) -> String;
+    #[cm("web:dom/event#target")]
+    #[cm_params("self")]
+    fn target(&self) -> Option<EventTarget>;
+    #[cm("web:dom/event#src-element")]
+    #[cm_params("self")]
+    fn src_element(&self) -> Option<EventTarget>;
+    #[cm("web:dom/event#current-target")]
+    #[cm_params("self")]
+    fn current_target(&self) -> Option<EventTarget>;
+    #[cm("web:dom/event#event-phase")]
+    #[cm_params("self")]
+    fn event_phase(&self) -> u16;
+    #[cm("web:dom/event#stop-propagation")]
+    #[cm_params("self")]
+    fn stop_propagation(&self);
+    #[cm("web:dom/event#cancel-bubble")]
+    #[cm_params("self")]
+    fn cancel_bubble(&self) -> bool;
+    #[cm("web:dom/event#set-cancel-bubble")]
+    #[cm_params("self", "value")]
+    fn set_cancel_bubble(&self, value: bool);
+    #[cm("web:dom/event#stop-immediate-propagation")]
+    #[cm_params("self")]
+    fn stop_immediate_propagation(&self);
+    #[cm("web:dom/event#bubbles")]
+    #[cm_params("self")]
+    fn bubbles(&self) -> bool;
+    #[cm("web:dom/event#cancelable")]
+    #[cm_params("self")]
+    fn cancelable(&self) -> bool;
+    #[cm("web:dom/event#return-value")]
+    #[cm_params("self")]
+    fn return_value(&self) -> bool;
+    #[cm("web:dom/event#set-return-value")]
+    #[cm_params("self", "value")]
+    fn set_return_value(&self, value: bool);
+    #[cm("web:dom/event#prevent-default")]
+    #[cm_params("self")]
+    fn prevent_default(&self);
+    #[cm("web:dom/event#default-prevented")]
+    #[cm_params("self")]
+    fn default_prevented(&self) -> bool;
+    #[cm("web:dom/event#composed")]
+    #[cm_params("self")]
+    fn composed(&self) -> bool;
+    #[cm("web:dom/event#is-trusted")]
+    #[cm_params("self")]
+    fn is_trusted(&self) -> bool;
+    #[cm("web:dom/event#time-stamp")]
+    #[cm_params("self")]
+    fn time_stamp(&self) -> f64;
+    #[cm("web:dom/event#init-event")]
+    #[cm_params("self", "type", "bubbles", "cancelable")]
+    fn init_event(&self, type_: String, bubbles: Option<bool>, cancelable: Option<bool>);
 }
 
 #[cm("web:dom/node", type = "extern-handle")]
 pub resource Node extends EventTarget {
+    #[cm("web:dom/node#node-type")]
+    #[cm_params("self")]
+    fn node_type(&self) -> u16;
+    #[cm("web:dom/node#node-name")]
+    #[cm_params("self")]
+    fn node_name(&self) -> String;
+    #[cm("web:dom/node#base-uri")]
+    #[cm_params("self")]
+    fn base_uri(&self) -> String;
+    #[cm("web:dom/node#is-connected")]
+    #[cm_params("self")]
+    fn is_connected(&self) -> bool;
+    #[cm("web:dom/node#owner-document")]
+    #[cm_params("self")]
+    fn owner_document(&self) -> Option<Document>;
+    #[cm("web:dom/node#get-root-node")]
+    #[cm_params("self")]
+    fn get_root_node(&self) -> Node;
+    #[cm("web:dom/node#parent-node")]
+    #[cm_params("self")]
+    fn parent_node(&self) -> Option<Node>;
+    #[cm("web:dom/node#parent-element")]
+    #[cm_params("self")]
+    fn parent_element(&self) -> Option<Element>;
+    #[cm("web:dom/node#has-child-nodes")]
+    #[cm_params("self")]
+    fn has_child_nodes(&self) -> bool;
+    #[cm("web:dom/node#first-child")]
+    #[cm_params("self")]
+    fn first_child(&self) -> Option<Node>;
+    #[cm("web:dom/node#last-child")]
+    #[cm_params("self")]
+    fn last_child(&self) -> Option<Node>;
+    #[cm("web:dom/node#previous-sibling")]
+    #[cm_params("self")]
+    fn previous_sibling(&self) -> Option<Node>;
+    #[cm("web:dom/node#next-sibling")]
+    #[cm_params("self")]
+    fn next_sibling(&self) -> Option<Node>;
+    #[cm("web:dom/node#node-value")]
+    #[cm_params("self")]
+    fn node_value(&self) -> Option<String>;
+    #[cm("web:dom/node#set-node-value")]
+    #[cm_params("self", "value")]
+    fn set_node_value(&self, value: Option<String>);
     #[cm("web:dom/node#text-content")]
     #[cm_params("self")]
-    fn text_content(&self) -> String;
+    fn text_content(&self) -> Option<String>;
     #[cm("web:dom/node#set-text-content")]
     #[cm_params("self", "value")]
-    fn set_text_content(&self, value: String);
+    fn set_text_content(&self, value: Option<String>);
+    #[cm("web:dom/node#normalize")]
+    #[cm_params("self")]
+    fn normalize(&self);
+    #[cm("web:dom/node#clone-node")]
+    #[cm_params("self", "subtree")]
+    fn clone_node(&self, subtree: Option<bool>) -> Node;
+    #[cm("web:dom/node#is-equal-node")]
+    #[cm_params("self", "other-node")]
+    fn is_equal_node(&self, other_node: Option<Node>) -> bool;
+    #[cm("web:dom/node#is-same-node")]
+    #[cm_params("self", "other-node")]
+    fn is_same_node(&self, other_node: Option<Node>) -> bool;
+    #[cm("web:dom/node#compare-document-position")]
+    #[cm_params("self", "other")]
+    fn compare_document_position(&self, other: Node) -> u16;
+    #[cm("web:dom/node#contains")]
+    #[cm_params("self", "other")]
+    fn contains(&self, other: Option<Node>) -> bool;
+    #[cm("web:dom/node#lookup-prefix")]
+    #[cm_params("self", "namespace")]
+    fn lookup_prefix(&self, namespace: Option<String>) -> Option<String>;
+    #[cm("web:dom/node#lookup-namespace-uri")]
+    #[cm_params("self", "prefix")]
+    fn lookup_namespace_uri(&self, prefix: Option<String>) -> Option<String>;
+    #[cm("web:dom/node#is-default-namespace")]
+    #[cm_params("self", "namespace")]
+    fn is_default_namespace(&self, namespace: Option<String>) -> bool;
+    #[cm("web:dom/node#insert-before")]
+    #[cm_params("self", "node", "child")]
+    fn insert_before(&self, node: Node, child: Option<Node>) -> Node;
     #[cm("web:dom/node#append-child")]
+    #[cm_params("self", "node")]
+    fn append_child(&self, node: Node) -> Node;
+    #[cm("web:dom/node#replace-child")]
+    #[cm_params("self", "node", "child")]
+    fn replace_child(&self, node: Node, child: Node) -> Node;
+    #[cm("web:dom/node#remove-child")]
     #[cm_params("self", "child")]
-    fn append_child(&self, child: &Node) -> Node;
+    fn remove_child(&self, child: Node) -> Node;
 }
 
 #[cm("web:dom/element", type = "extern-handle")]
 pub resource Element extends Node {
+    #[cm("web:dom/element#namespace-uri")]
+    #[cm_params("self")]
+    fn namespace_uri(&self) -> Option<String>;
+    #[cm("web:dom/element#prefix")]
+    #[cm_params("self")]
+    fn prefix(&self) -> Option<String>;
+    #[cm("web:dom/element#local-name")]
+    #[cm_params("self")]
+    fn local_name(&self) -> String;
+    #[cm("web:dom/element#tag-name")]
+    #[cm_params("self")]
+    fn tag_name(&self) -> String;
     #[cm("web:dom/element#id")]
     #[cm_params("self")]
     fn id(&self) -> String;
     #[cm("web:dom/element#set-id")]
     #[cm_params("self", "value")]
     fn set_id(&self, value: String);
-    #[cm("web:dom/element#tag-name")]
+    #[cm("web:dom/element#class-name")]
     #[cm_params("self")]
-    fn tag_name(&self) -> String;
+    fn class_name(&self) -> String;
+    #[cm("web:dom/element#set-class-name")]
+    #[cm_params("self", "value")]
+    fn set_class_name(&self, value: String);
+    #[cm("web:dom/element#slot")]
+    #[cm_params("self")]
+    fn slot(&self) -> String;
+    #[cm("web:dom/element#set-slot")]
+    #[cm_params("self", "value")]
+    fn set_slot(&self, value: String);
+    #[cm("web:dom/element#has-attributes")]
+    #[cm_params("self")]
+    fn has_attributes(&self) -> bool;
+    #[cm("web:dom/element#get-attribute")]
+    #[cm_params("self", "qualified-name")]
+    fn get_attribute(&self, qualified_name: String) -> Option<String>;
+    #[cm("web:dom/element#get-attribute-ns")]
+    #[cm_params("self", "namespace", "local-name")]
+    fn get_attribute_ns(&self, namespace: Option<String>, local_name: String) -> Option<String>;
+    #[cm("web:dom/element#set-attribute")]
+    #[cm_params("self", "qualified-name", "value")]
+    fn set_attribute(&self, qualified_name: String, value: String);
+    #[cm("web:dom/element#set-attribute-ns")]
+    #[cm_params("self", "namespace", "qualified-name", "value")]
+    fn set_attribute_ns(&self, namespace: Option<String>, qualified_name: String, value: String);
+    #[cm("web:dom/element#remove-attribute")]
+    #[cm_params("self", "qualified-name")]
+    fn remove_attribute(&self, qualified_name: String);
+    #[cm("web:dom/element#remove-attribute-ns")]
+    #[cm_params("self", "namespace", "local-name")]
+    fn remove_attribute_ns(&self, namespace: Option<String>, local_name: String);
+    #[cm("web:dom/element#toggle-attribute")]
+    #[cm_params("self", "qualified-name", "force")]
+    fn toggle_attribute(&self, qualified_name: String, force: Option<bool>) -> bool;
+    #[cm("web:dom/element#has-attribute")]
+    #[cm_params("self", "qualified-name")]
+    fn has_attribute(&self, qualified_name: String) -> bool;
+    #[cm("web:dom/element#has-attribute-ns")]
+    #[cm_params("self", "namespace", "local-name")]
+    fn has_attribute_ns(&self, namespace: Option<String>, local_name: String) -> bool;
+    #[cm("web:dom/element#closest")]
+    #[cm_params("self", "selectors")]
+    fn closest(&self, selectors: String) -> Option<Element>;
+    #[cm("web:dom/element#matches")]
+    #[cm_params("self", "selectors")]
+    fn matches_(&self, selectors: String) -> bool;
+    #[cm("web:dom/element#webkit-matches-selector")]
+    #[cm_params("self", "selectors")]
+    fn webkit_matches_selector(&self, selectors: String) -> bool;
+    #[cm("web:dom/element#insert-adjacent-element")]
+    #[cm_params("self", "where", "element")]
+    fn insert_adjacent_element(&self, where: String, element: Element) -> Option<Element>;
+    #[cm("web:dom/element#insert-adjacent-text")]
+    #[cm_params("self", "where", "data")]
+    fn insert_adjacent_text(&self, where: String, data: String);
+    #[cm("web:dom/element#set-html")]
+    #[cm_params("self", "html")]
+    fn set_html(&self, html: String);
+    #[cm("web:dom/element#set-html-unsafe")]
+    #[cm_params("self", "html")]
+    fn set_html_unsafe(&self, html: String);
+    #[cm("web:dom/element#get-html")]
+    #[cm_params("self")]
+    fn get_html(&self) -> String;
+    #[cm("web:dom/element#inner-html")]
+    #[cm_params("self")]
+    fn inner_html(&self) -> String;
+    #[cm("web:dom/element#set-inner-html")]
+    #[cm_params("self", "value")]
+    fn set_inner_html(&self, value: String);
+    #[cm("web:dom/element#outer-html")]
+    #[cm_params("self")]
+    fn outer_html(&self) -> String;
+    #[cm("web:dom/element#set-outer-html")]
+    #[cm_params("self", "value")]
+    fn set_outer_html(&self, value: String);
+    #[cm("web:dom/element#insert-adjacent-html")]
+    #[cm_params("self", "position", "string")]
+    fn insert_adjacent_html(&self, position: String, string: String);
+    #[cm("web:dom/element#first-element-child")]
+    #[cm_params("self")]
+    fn first_element_child(&self) -> Option<Element>;
+    #[cm("web:dom/element#last-element-child")]
+    #[cm_params("self")]
+    fn last_element_child(&self) -> Option<Element>;
+    #[cm("web:dom/element#child-element-count")]
+    #[cm_params("self")]
+    fn child_element_count(&self) -> u32;
+    #[cm("web:dom/element#prepend")]
+    #[cm_params("self")]
+    fn prepend(&self);
+    #[cm("web:dom/element#append")]
+    #[cm_params("self")]
+    fn append(&self);
+    #[cm("web:dom/element#replace-children")]
+    #[cm_params("self")]
+    fn replace_children(&self);
+    #[cm("web:dom/element#move-before")]
+    #[cm_params("self", "node", "child")]
+    fn move_before(&self, node: Node, child: Option<Node>);
+    #[cm("web:dom/element#query-selector")]
+    #[cm_params("self", "selectors")]
+    fn query_selector(&self, selectors: String) -> Option<Element>;
+    #[cm("web:dom/element#previous-element-sibling")]
+    #[cm_params("self")]
+    fn previous_element_sibling(&self) -> Option<Element>;
+    #[cm("web:dom/element#next-element-sibling")]
+    #[cm_params("self")]
+    fn next_element_sibling(&self) -> Option<Element>;
+    #[cm("web:dom/element#before")]
+    #[cm_params("self")]
+    fn before(&self);
+    #[cm("web:dom/element#after")]
+    #[cm_params("self")]
+    fn after(&self);
+    #[cm("web:dom/element#replace-with")]
+    #[cm_params("self")]
+    fn replace_with(&self);
+    #[cm("web:dom/element#remove")]
+    #[cm_params("self")]
+    fn remove(&self);
+}
+
+#[cm("web:dom/html-element", type = "extern-handle")]
+pub resource HtmlElement extends Element {
+    #[cm("web:dom/html-element#title")]
+    #[cm_params("self")]
+    fn title(&self) -> String;
+    #[cm("web:dom/html-element#set-title")]
+    #[cm_params("self", "value")]
+    fn set_title(&self, value: String);
+    #[cm("web:dom/html-element#lang")]
+    #[cm_params("self")]
+    fn lang(&self) -> String;
+    #[cm("web:dom/html-element#set-lang")]
+    #[cm_params("self", "value")]
+    fn set_lang(&self, value: String);
+    #[cm("web:dom/html-element#translate")]
+    #[cm_params("self")]
+    fn translate(&self) -> bool;
+    #[cm("web:dom/html-element#set-translate")]
+    #[cm_params("self", "value")]
+    fn set_translate(&self, value: bool);
+    #[cm("web:dom/html-element#dir")]
+    #[cm_params("self")]
+    fn dir(&self) -> String;
+    #[cm("web:dom/html-element#set-dir")]
+    #[cm_params("self", "value")]
+    fn set_dir(&self, value: String);
+    #[cm("web:dom/html-element#inert")]
+    #[cm_params("self")]
+    fn inert(&self) -> bool;
+    #[cm("web:dom/html-element#set-inert")]
+    #[cm_params("self", "value")]
+    fn set_inert(&self, value: bool);
+    #[cm("web:dom/html-element#click")]
+    #[cm_params("self")]
+    fn click(&self);
+    #[cm("web:dom/html-element#access-key")]
+    #[cm_params("self")]
+    fn access_key(&self) -> String;
+    #[cm("web:dom/html-element#set-access-key")]
+    #[cm_params("self", "value")]
+    fn set_access_key(&self, value: String);
+    #[cm("web:dom/html-element#access-key-label")]
+    #[cm_params("self")]
+    fn access_key_label(&self) -> String;
+    #[cm("web:dom/html-element#draggable")]
+    #[cm_params("self")]
+    fn draggable(&self) -> bool;
+    #[cm("web:dom/html-element#set-draggable")]
+    #[cm_params("self", "value")]
+    fn set_draggable(&self, value: bool);
+    #[cm("web:dom/html-element#spellcheck")]
+    #[cm_params("self")]
+    fn spellcheck(&self) -> bool;
+    #[cm("web:dom/html-element#set-spellcheck")]
+    #[cm_params("self", "value")]
+    fn set_spellcheck(&self, value: bool);
+    #[cm("web:dom/html-element#writing-suggestions")]
+    #[cm_params("self")]
+    fn writing_suggestions(&self) -> String;
+    #[cm("web:dom/html-element#set-writing-suggestions")]
+    #[cm_params("self", "value")]
+    fn set_writing_suggestions(&self, value: String);
+    #[cm("web:dom/html-element#autocapitalize")]
+    #[cm_params("self")]
+    fn autocapitalize(&self) -> String;
+    #[cm("web:dom/html-element#set-autocapitalize")]
+    #[cm_params("self", "value")]
+    fn set_autocapitalize(&self, value: String);
+    #[cm("web:dom/html-element#autocorrect")]
+    #[cm_params("self")]
+    fn autocorrect(&self) -> bool;
+    #[cm("web:dom/html-element#set-autocorrect")]
+    #[cm_params("self", "value")]
+    fn set_autocorrect(&self, value: bool);
+    #[cm("web:dom/html-element#inner-text")]
+    #[cm_params("self")]
+    fn inner_text(&self) -> String;
+    #[cm("web:dom/html-element#set-inner-text")]
+    #[cm_params("self", "value")]
+    fn set_inner_text(&self, value: String);
+    #[cm("web:dom/html-element#outer-text")]
+    #[cm_params("self")]
+    fn outer_text(&self) -> String;
+    #[cm("web:dom/html-element#set-outer-text")]
+    #[cm_params("self", "value")]
+    fn set_outer_text(&self, value: String);
+    #[cm("web:dom/html-element#show-popover")]
+    #[cm_params("self")]
+    fn show_popover(&self);
+    #[cm("web:dom/html-element#hide-popover")]
+    #[cm_params("self")]
+    fn hide_popover(&self);
+    #[cm("web:dom/html-element#toggle-popover")]
+    #[cm_params("self", "options")]
+    fn toggle_popover(&self, options: Option<bool>) -> bool;
+    #[cm("web:dom/html-element#popover")]
+    #[cm_params("self")]
+    fn popover(&self) -> Option<String>;
+    #[cm("web:dom/html-element#set-popover")]
+    #[cm_params("self", "value")]
+    fn set_popover(&self, value: Option<String>);
+    #[cm("web:dom/html-element#heading-offset")]
+    #[cm_params("self")]
+    fn heading_offset(&self) -> u32;
+    #[cm("web:dom/html-element#set-heading-offset")]
+    #[cm_params("self", "value")]
+    fn set_heading_offset(&self, value: u32);
+    #[cm("web:dom/html-element#heading-reset")]
+    #[cm_params("self")]
+    fn heading_reset(&self) -> bool;
+    #[cm("web:dom/html-element#set-heading-reset")]
+    #[cm_params("self", "value")]
+    fn set_heading_reset(&self, value: bool);
+    #[cm("web:dom/html-element#content-editable")]
+    #[cm_params("self")]
+    fn content_editable(&self) -> String;
+    #[cm("web:dom/html-element#set-content-editable")]
+    #[cm_params("self", "value")]
+    fn set_content_editable(&self, value: String);
+    #[cm("web:dom/html-element#enter-key-hint")]
+    #[cm_params("self")]
+    fn enter_key_hint(&self) -> String;
+    #[cm("web:dom/html-element#set-enter-key-hint")]
+    #[cm_params("self", "value")]
+    fn set_enter_key_hint(&self, value: String);
+    #[cm("web:dom/html-element#is-content-editable")]
+    #[cm_params("self")]
+    fn is_content_editable(&self) -> bool;
+    #[cm("web:dom/html-element#input-mode")]
+    #[cm_params("self")]
+    fn input_mode(&self) -> String;
+    #[cm("web:dom/html-element#set-input-mode")]
+    #[cm_params("self", "value")]
+    fn set_input_mode(&self, value: String);
+    #[cm("web:dom/html-element#nonce")]
+    #[cm_params("self")]
+    fn nonce(&self) -> String;
+    #[cm("web:dom/html-element#set-nonce")]
+    #[cm_params("self", "value")]
+    fn set_nonce(&self, value: String);
+    #[cm("web:dom/html-element#autofocus")]
+    #[cm_params("self")]
+    fn autofocus(&self) -> bool;
+    #[cm("web:dom/html-element#set-autofocus")]
+    #[cm_params("self", "value")]
+    fn set_autofocus(&self, value: bool);
+    #[cm("web:dom/html-element#tab-index")]
+    #[cm_params("self")]
+    fn tab_index(&self) -> i32;
+    #[cm("web:dom/html-element#set-tab-index")]
+    #[cm_params("self", "value")]
+    fn set_tab_index(&self, value: i32);
+    #[cm("web:dom/html-element#focus")]
+    #[cm_params("self")]
+    fn focus(&self);
+    #[cm("web:dom/html-element#blur")]
+    #[cm_params("self")]
+    fn blur(&self);
+}
+
+#[cm("web:dom/html-input-element", type = "extern-handle")]
+pub resource HtmlInputElement extends HtmlElement {
+    #[cm("web:dom/html-input-element#accept")]
+    #[cm_params("self")]
+    fn accept(&self) -> String;
+    #[cm("web:dom/html-input-element#set-accept")]
+    #[cm_params("self", "value")]
+    fn set_accept(&self, value: String);
+    #[cm("web:dom/html-input-element#alpha")]
+    #[cm_params("self")]
+    fn alpha(&self) -> bool;
+    #[cm("web:dom/html-input-element#set-alpha")]
+    #[cm_params("self", "value")]
+    fn set_alpha(&self, value: bool);
+    #[cm("web:dom/html-input-element#alt")]
+    #[cm_params("self")]
+    fn alt(&self) -> String;
+    #[cm("web:dom/html-input-element#set-alt")]
+    #[cm_params("self", "value")]
+    fn set_alt(&self, value: String);
+    #[cm("web:dom/html-input-element#autocomplete")]
+    #[cm_params("self")]
+    fn autocomplete(&self) -> String;
+    #[cm("web:dom/html-input-element#set-autocomplete")]
+    #[cm_params("self", "value")]
+    fn set_autocomplete(&self, value: String);
+    #[cm("web:dom/html-input-element#default-checked")]
+    #[cm_params("self")]
+    fn default_checked(&self) -> bool;
+    #[cm("web:dom/html-input-element#set-default-checked")]
+    #[cm_params("self", "value")]
+    fn set_default_checked(&self, value: bool);
+    #[cm("web:dom/html-input-element#checked")]
+    #[cm_params("self")]
+    fn checked(&self) -> bool;
+    #[cm("web:dom/html-input-element#set-checked")]
+    #[cm_params("self", "value")]
+    fn set_checked(&self, value: bool);
+    #[cm("web:dom/html-input-element#color-space")]
+    #[cm_params("self")]
+    fn color_space(&self) -> String;
+    #[cm("web:dom/html-input-element#set-color-space")]
+    #[cm_params("self", "value")]
+    fn set_color_space(&self, value: String);
+    #[cm("web:dom/html-input-element#dir-name")]
+    #[cm_params("self")]
+    fn dir_name(&self) -> String;
+    #[cm("web:dom/html-input-element#set-dir-name")]
+    #[cm_params("self", "value")]
+    fn set_dir_name(&self, value: String);
+    #[cm("web:dom/html-input-element#disabled")]
+    #[cm_params("self")]
+    fn disabled(&self) -> bool;
+    #[cm("web:dom/html-input-element#set-disabled")]
+    #[cm_params("self", "value")]
+    fn set_disabled(&self, value: bool);
+    #[cm("web:dom/html-input-element#form-action")]
+    #[cm_params("self")]
+    fn form_action(&self) -> String;
+    #[cm("web:dom/html-input-element#set-form-action")]
+    #[cm_params("self", "value")]
+    fn set_form_action(&self, value: String);
+    #[cm("web:dom/html-input-element#form-enctype")]
+    #[cm_params("self")]
+    fn form_enctype(&self) -> String;
+    #[cm("web:dom/html-input-element#set-form-enctype")]
+    #[cm_params("self", "value")]
+    fn set_form_enctype(&self, value: String);
+    #[cm("web:dom/html-input-element#form-method")]
+    #[cm_params("self")]
+    fn form_method(&self) -> String;
+    #[cm("web:dom/html-input-element#set-form-method")]
+    #[cm_params("self", "value")]
+    fn set_form_method(&self, value: String);
+    #[cm("web:dom/html-input-element#form-no-validate")]
+    #[cm_params("self")]
+    fn form_no_validate(&self) -> bool;
+    #[cm("web:dom/html-input-element#set-form-no-validate")]
+    #[cm_params("self", "value")]
+    fn set_form_no_validate(&self, value: bool);
+    #[cm("web:dom/html-input-element#form-target")]
+    #[cm_params("self")]
+    fn form_target(&self) -> String;
+    #[cm("web:dom/html-input-element#set-form-target")]
+    #[cm_params("self", "value")]
+    fn set_form_target(&self, value: String);
+    #[cm("web:dom/html-input-element#height")]
+    #[cm_params("self")]
+    fn height(&self) -> u32;
+    #[cm("web:dom/html-input-element#set-height")]
+    #[cm_params("self", "value")]
+    fn set_height(&self, value: u32);
+    #[cm("web:dom/html-input-element#indeterminate")]
+    #[cm_params("self")]
+    fn indeterminate(&self) -> bool;
+    #[cm("web:dom/html-input-element#set-indeterminate")]
+    #[cm_params("self", "value")]
+    fn set_indeterminate(&self, value: bool);
+    #[cm("web:dom/html-input-element#max")]
+    #[cm_params("self")]
+    fn max(&self) -> String;
+    #[cm("web:dom/html-input-element#set-max")]
+    #[cm_params("self", "value")]
+    fn set_max(&self, value: String);
+    #[cm("web:dom/html-input-element#max-length")]
+    #[cm_params("self")]
+    fn max_length(&self) -> i32;
+    #[cm("web:dom/html-input-element#set-max-length")]
+    #[cm_params("self", "value")]
+    fn set_max_length(&self, value: i32);
+    #[cm("web:dom/html-input-element#min")]
+    #[cm_params("self")]
+    fn min(&self) -> String;
+    #[cm("web:dom/html-input-element#set-min")]
+    #[cm_params("self", "value")]
+    fn set_min(&self, value: String);
+    #[cm("web:dom/html-input-element#min-length")]
+    #[cm_params("self")]
+    fn min_length(&self) -> i32;
+    #[cm("web:dom/html-input-element#set-min-length")]
+    #[cm_params("self", "value")]
+    fn set_min_length(&self, value: i32);
+    #[cm("web:dom/html-input-element#multiple")]
+    #[cm_params("self")]
+    fn multiple(&self) -> bool;
+    #[cm("web:dom/html-input-element#set-multiple")]
+    #[cm_params("self", "value")]
+    fn set_multiple(&self, value: bool);
+    #[cm("web:dom/html-input-element#name")]
+    #[cm_params("self")]
+    fn name(&self) -> String;
+    #[cm("web:dom/html-input-element#set-name")]
+    #[cm_params("self", "value")]
+    fn set_name(&self, value: String);
+    #[cm("web:dom/html-input-element#pattern")]
+    #[cm_params("self")]
+    fn pattern(&self) -> String;
+    #[cm("web:dom/html-input-element#set-pattern")]
+    #[cm_params("self", "value")]
+    fn set_pattern(&self, value: String);
+    #[cm("web:dom/html-input-element#placeholder")]
+    #[cm_params("self")]
+    fn placeholder(&self) -> String;
+    #[cm("web:dom/html-input-element#set-placeholder")]
+    #[cm_params("self", "value")]
+    fn set_placeholder(&self, value: String);
+    #[cm("web:dom/html-input-element#read-only")]
+    #[cm_params("self")]
+    fn read_only(&self) -> bool;
+    #[cm("web:dom/html-input-element#set-read-only")]
+    #[cm_params("self", "value")]
+    fn set_read_only(&self, value: bool);
+    #[cm("web:dom/html-input-element#required")]
+    #[cm_params("self")]
+    fn required(&self) -> bool;
+    #[cm("web:dom/html-input-element#set-required")]
+    #[cm_params("self", "value")]
+    fn set_required(&self, value: bool);
+    #[cm("web:dom/html-input-element#size")]
+    #[cm_params("self")]
+    fn size(&self) -> u32;
+    #[cm("web:dom/html-input-element#set-size")]
+    #[cm_params("self", "value")]
+    fn set_size(&self, value: u32);
+    #[cm("web:dom/html-input-element#src")]
+    #[cm_params("self")]
+    fn src(&self) -> String;
+    #[cm("web:dom/html-input-element#set-src")]
+    #[cm_params("self", "value")]
+    fn set_src(&self, value: String);
+    #[cm("web:dom/html-input-element#step")]
+    #[cm_params("self")]
+    fn step(&self) -> String;
+    #[cm("web:dom/html-input-element#set-step")]
+    #[cm_params("self", "value")]
+    fn set_step(&self, value: String);
+    #[cm("web:dom/html-input-element#type")]
+    #[cm_params("self")]
+    fn type_(&self) -> String;
+    #[cm("web:dom/html-input-element#set-type")]
+    #[cm_params("self", "value")]
+    fn set_type_(&self, value: String);
+    #[cm("web:dom/html-input-element#default-value")]
+    #[cm_params("self")]
+    fn default_value(&self) -> String;
+    #[cm("web:dom/html-input-element#set-default-value")]
+    #[cm_params("self", "value")]
+    fn set_default_value(&self, value: String);
+    #[cm("web:dom/html-input-element#value")]
+    #[cm_params("self")]
+    fn value(&self) -> String;
+    #[cm("web:dom/html-input-element#set-value")]
+    #[cm_params("self", "value")]
+    fn set_value(&self, value: String);
+    #[cm("web:dom/html-input-element#value-as-number")]
+    #[cm_params("self")]
+    fn value_as_number(&self) -> f64;
+    #[cm("web:dom/html-input-element#set-value-as-number")]
+    #[cm_params("self", "value")]
+    fn set_value_as_number(&self, value: f64);
+    #[cm("web:dom/html-input-element#width")]
+    #[cm_params("self")]
+    fn width(&self) -> u32;
+    #[cm("web:dom/html-input-element#set-width")]
+    #[cm_params("self", "value")]
+    fn set_width(&self, value: u32);
+    #[cm("web:dom/html-input-element#step-up")]
+    #[cm_params("self", "n")]
+    fn step_up(&self, n: Option<i32>);
+    #[cm("web:dom/html-input-element#step-down")]
+    #[cm_params("self", "n")]
+    fn step_down(&self, n: Option<i32>);
+    #[cm("web:dom/html-input-element#will-validate")]
+    #[cm_params("self")]
+    fn will_validate(&self) -> bool;
+    #[cm("web:dom/html-input-element#validation-message")]
+    #[cm_params("self")]
+    fn validation_message(&self) -> String;
+    #[cm("web:dom/html-input-element#check-validity")]
+    #[cm_params("self")]
+    fn check_validity(&self) -> bool;
+    #[cm("web:dom/html-input-element#report-validity")]
+    #[cm_params("self")]
+    fn report_validity(&self) -> bool;
+    #[cm("web:dom/html-input-element#set-custom-validity")]
+    #[cm_params("self", "error")]
+    fn set_custom_validity(&self, error: String);
+    #[cm("web:dom/html-input-element#select")]
+    #[cm_params("self")]
+    fn select(&self);
+    #[cm("web:dom/html-input-element#selection-start")]
+    #[cm_params("self")]
+    fn selection_start(&self) -> Option<u32>;
+    #[cm("web:dom/html-input-element#set-selection-start")]
+    #[cm_params("self", "value")]
+    fn set_selection_start(&self, value: Option<u32>);
+    #[cm("web:dom/html-input-element#selection-end")]
+    #[cm_params("self")]
+    fn selection_end(&self) -> Option<u32>;
+    #[cm("web:dom/html-input-element#set-selection-end")]
+    #[cm_params("self", "value")]
+    fn set_selection_end(&self, value: Option<u32>);
+    #[cm("web:dom/html-input-element#selection-direction")]
+    #[cm_params("self")]
+    fn selection_direction(&self) -> Option<String>;
+    #[cm("web:dom/html-input-element#set-selection-direction")]
+    #[cm_params("self", "value")]
+    fn set_selection_direction(&self, value: Option<String>);
+    #[cm("web:dom/html-input-element#set-selection-range")]
+    #[cm_params("self", "start", "end", "direction")]
+    fn set_selection_range(&self, start: u32, end: u32, direction: Option<String>);
+    #[cm("web:dom/html-input-element#show-picker")]
+    #[cm_params("self")]
+    fn show_picker(&self);
+    #[cm("web:dom/html-input-element#align")]
+    #[cm_params("self")]
+    fn align(&self) -> String;
+    #[cm("web:dom/html-input-element#set-align")]
+    #[cm_params("self", "value")]
+    fn set_align(&self, value: String);
+    #[cm("web:dom/html-input-element#use-map")]
+    #[cm_params("self")]
+    fn use_map(&self) -> String;
+    #[cm("web:dom/html-input-element#set-use-map")]
+    #[cm_params("self", "value")]
+    fn set_use_map(&self, value: String);
+    #[cm("web:dom/html-input-element#popover-target-element")]
+    #[cm_params("self")]
+    fn popover_target_element(&self) -> Option<Element>;
+    #[cm("web:dom/html-input-element#set-popover-target-element")]
+    #[cm_params("self", "value")]
+    fn set_popover_target_element(&self, value: Option<Element>);
+    #[cm("web:dom/html-input-element#popover-target-action")]
+    #[cm_params("self")]
+    fn popover_target_action(&self) -> String;
+    #[cm("web:dom/html-input-element#set-popover-target-action")]
+    #[cm_params("self", "value")]
+    fn set_popover_target_action(&self, value: String);
 }
 
 #[cm("web:dom/document", type = "extern-handle")]
 pub resource Document extends Node {
+    #[cm("web:dom/document#new")]
+    fn new() -> Document;
+    #[cm("web:dom/document#url")]
+    #[cm_params("self")]
+    fn url(&self) -> String;
+    #[cm("web:dom/document#document-uri")]
+    #[cm_params("self")]
+    fn document_uri(&self) -> String;
+    #[cm("web:dom/document#compat-mode")]
+    #[cm_params("self")]
+    fn compat_mode(&self) -> String;
+    #[cm("web:dom/document#character-set")]
+    #[cm_params("self")]
+    fn character_set(&self) -> String;
+    #[cm("web:dom/document#charset")]
+    #[cm_params("self")]
+    fn charset(&self) -> String;
+    #[cm("web:dom/document#input-encoding")]
+    #[cm_params("self")]
+    fn input_encoding(&self) -> String;
+    #[cm("web:dom/document#content-type")]
+    #[cm_params("self")]
+    fn content_type(&self) -> String;
+    #[cm("web:dom/document#document-element")]
+    #[cm_params("self")]
+    fn document_element(&self) -> Option<Element>;
     #[cm("web:dom/document#create-element")]
-    #[cm_params("self", "local-name")]
-    fn create_element(&self, local_name: String) -> Element;
+    #[cm_params("self", "local-name", "options")]
+    fn create_element(&self, local_name: String, options: Option<String>) -> Element;
+    #[cm("web:dom/document#create-element-ns")]
+    #[cm_params("self", "namespace", "qualified-name", "options")]
+    fn create_element_ns(&self, namespace: Option<String>, qualified_name: String, options: Option<String>) -> Element;
+    #[cm("web:dom/document#import-node")]
+    #[cm_params("self", "node", "options")]
+    fn import_node(&self, node: Node, options: Option<bool>) -> Node;
+    #[cm("web:dom/document#adopt-node")]
+    #[cm_params("self", "node")]
+    fn adopt_node(&self, node: Node) -> Node;
+    #[cm("web:dom/document#create-event")]
+    #[cm_params("self", "interface")]
+    fn create_event(&self, interface_: String) -> Event;
+    #[cm("web:dom/document#parse-html-unsafe")]
+    #[cm_params("html")]
+    fn parse_html_unsafe(html: String) -> Document;
+    #[cm("web:dom/document#parse-html")]
+    #[cm_params("html")]
+    fn parse_html(html: String) -> Document;
+    #[cm("web:dom/document#domain")]
+    #[cm_params("self")]
+    fn domain(&self) -> String;
+    #[cm("web:dom/document#set-domain")]
+    #[cm_params("self", "value")]
+    fn set_domain(&self, value: String);
+    #[cm("web:dom/document#referrer")]
+    #[cm_params("self")]
+    fn referrer(&self) -> String;
+    #[cm("web:dom/document#cookie")]
+    #[cm_params("self")]
+    fn cookie(&self) -> String;
+    #[cm("web:dom/document#set-cookie")]
+    #[cm_params("self", "value")]
+    fn set_cookie(&self, value: String);
+    #[cm("web:dom/document#last-modified")]
+    #[cm_params("self")]
+    fn last_modified(&self) -> String;
+    #[cm("web:dom/document#title")]
+    #[cm_params("self")]
+    fn title(&self) -> String;
+    #[cm("web:dom/document#set-title")]
+    #[cm_params("self", "value")]
+    fn set_title(&self, value: String);
+    #[cm("web:dom/document#dir")]
+    #[cm_params("self")]
+    fn dir(&self) -> String;
+    #[cm("web:dom/document#set-dir")]
+    #[cm_params("self", "value")]
+    fn set_dir(&self, value: String);
+    #[cm("web:dom/document#body")]
+    #[cm_params("self")]
+    fn body(&self) -> Option<HtmlElement>;
+    #[cm("web:dom/document#set-body")]
+    #[cm_params("self", "value")]
+    fn set_body(&self, value: Option<HtmlElement>);
+    #[cm("web:dom/document#open")]
+    #[cm_params("self", "unused1", "unused2")]
+    fn open(&self, unused1: Option<String>, unused2: Option<String>) -> Document;
+    #[cm("web:dom/document#close")]
+    #[cm_params("self")]
+    fn close(&self);
+    #[cm("web:dom/document#write")]
+    #[cm_params("self")]
+    fn write(&self);
+    #[cm("web:dom/document#writeln")]
+    #[cm_params("self")]
+    fn writeln(&self);
+    #[cm("web:dom/document#has-focus")]
+    #[cm_params("self")]
+    fn has_focus(&self) -> bool;
+    #[cm("web:dom/document#design-mode")]
+    #[cm_params("self")]
+    fn design_mode(&self) -> String;
+    #[cm("web:dom/document#set-design-mode")]
+    #[cm_params("self", "value")]
+    fn set_design_mode(&self, value: String);
+    #[cm("web:dom/document#exec-command")]
+    #[cm_params("self", "command-id", "show-ui", "value")]
+    fn exec_command(&self, command_id: String, show_ui: Option<bool>, value: Option<String>) -> bool;
+    #[cm("web:dom/document#query-command-enabled")]
+    #[cm_params("self", "command-id")]
+    fn query_command_enabled(&self, command_id: String) -> bool;
+    #[cm("web:dom/document#query-command-indeterm")]
+    #[cm_params("self", "command-id")]
+    fn query_command_indeterm(&self, command_id: String) -> bool;
+    #[cm("web:dom/document#query-command-state")]
+    #[cm_params("self", "command-id")]
+    fn query_command_state(&self, command_id: String) -> bool;
+    #[cm("web:dom/document#query-command-supported")]
+    #[cm_params("self", "command-id")]
+    fn query_command_supported(&self, command_id: String) -> bool;
+    #[cm("web:dom/document#query-command-value")]
+    #[cm_params("self", "command-id")]
+    fn query_command_value(&self, command_id: String) -> String;
+    #[cm("web:dom/document#hidden")]
+    #[cm_params("self")]
+    fn hidden(&self) -> bool;
+    #[cm("web:dom/document#fg-color")]
+    #[cm_params("self")]
+    fn fg_color(&self) -> String;
+    #[cm("web:dom/document#set-fg-color")]
+    #[cm_params("self", "value")]
+    fn set_fg_color(&self, value: String);
+    #[cm("web:dom/document#link-color")]
+    #[cm_params("self")]
+    fn link_color(&self) -> String;
+    #[cm("web:dom/document#set-link-color")]
+    #[cm_params("self", "value")]
+    fn set_link_color(&self, value: String);
+    #[cm("web:dom/document#vlink-color")]
+    #[cm_params("self")]
+    fn vlink_color(&self) -> String;
+    #[cm("web:dom/document#set-vlink-color")]
+    #[cm_params("self", "value")]
+    fn set_vlink_color(&self, value: String);
+    #[cm("web:dom/document#alink-color")]
+    #[cm_params("self")]
+    fn alink_color(&self) -> String;
+    #[cm("web:dom/document#set-alink-color")]
+    #[cm_params("self", "value")]
+    fn set_alink_color(&self, value: String);
+    #[cm("web:dom/document#bg-color")]
+    #[cm_params("self")]
+    fn bg_color(&self) -> String;
+    #[cm("web:dom/document#set-bg-color")]
+    #[cm_params("self", "value")]
+    fn set_bg_color(&self, value: String);
+    #[cm("web:dom/document#clear")]
+    #[cm_params("self")]
+    fn clear(&self);
+    #[cm("web:dom/document#capture-events")]
+    #[cm_params("self")]
+    fn capture_events(&self);
+    #[cm("web:dom/document#release-events")]
+    #[cm_params("self")]
+    fn release_events(&self);
+    #[cm("web:dom/document#get-element-by-id")]
+    #[cm_params("self", "element-id")]
+    fn get_element_by_id(&self, element_id: String) -> Option<Element>;
+    #[cm("web:dom/document#active-element")]
+    #[cm_params("self")]
+    fn active_element(&self) -> Option<Element>;
+    #[cm("web:dom/document#first-element-child")]
+    #[cm_params("self")]
+    fn first_element_child(&self) -> Option<Element>;
+    #[cm("web:dom/document#last-element-child")]
+    #[cm_params("self")]
+    fn last_element_child(&self) -> Option<Element>;
+    #[cm("web:dom/document#child-element-count")]
+    #[cm_params("self")]
+    fn child_element_count(&self) -> u32;
+    #[cm("web:dom/document#prepend")]
+    #[cm_params("self")]
+    fn prepend(&self);
+    #[cm("web:dom/document#append")]
+    #[cm_params("self")]
+    fn append(&self);
+    #[cm("web:dom/document#replace-children")]
+    #[cm_params("self")]
+    fn replace_children(&self);
+    #[cm("web:dom/document#move-before")]
+    #[cm_params("self", "node", "child")]
+    fn move_before(&self, node: Node, child: Option<Node>);
+    #[cm("web:dom/document#query-selector")]
+    #[cm_params("self", "selectors")]
+    fn query_selector(&self, selectors: String) -> Option<Element>;
+    #[cm("web:dom/document#create-ns-resolver")]
+    #[cm_params("self", "node-resolver")]
+    fn create_ns_resolver(&self, node_resolver: Node) -> Node;
+}
+
+#[cm("web:dom/window", type = "extern-handle")]
+pub resource Window extends EventTarget {
+    #[cm("web:dom/window#event")]
+    #[cm_params("self")]
+    fn event(&self) -> Option<Event>;
+    #[cm("web:dom/window#document")]
+    #[cm_params("self")]
+    fn document(&self) -> Document;
+    #[cm("web:dom/window#name")]
+    #[cm_params("self")]
+    fn name(&self) -> String;
+    #[cm("web:dom/window#set-name")]
+    #[cm_params("self", "value")]
+    fn set_name(&self, value: String);
+    #[cm("web:dom/window#status")]
+    #[cm_params("self")]
+    fn status(&self) -> String;
+    #[cm("web:dom/window#set-status")]
+    #[cm_params("self", "value")]
+    fn set_status(&self, value: String);
+    #[cm("web:dom/window#close")]
+    #[cm_params("self")]
+    fn close(&self);
+    #[cm("web:dom/window#closed")]
+    #[cm_params("self")]
+    fn closed(&self) -> bool;
+    #[cm("web:dom/window#stop")]
+    #[cm_params("self")]
+    fn stop(&self);
+    #[cm("web:dom/window#focus")]
+    #[cm_params("self")]
+    fn focus(&self);
+    #[cm("web:dom/window#blur")]
+    #[cm_params("self")]
+    fn blur(&self);
+    #[cm("web:dom/window#length")]
+    #[cm_params("self")]
+    fn length(&self) -> u32;
+    #[cm("web:dom/window#frame-element")]
+    #[cm_params("self")]
+    fn frame_element(&self) -> Option<Element>;
+    #[cm("web:dom/window#origin-agent-cluster")]
+    #[cm_params("self")]
+    fn origin_agent_cluster(&self) -> bool;
+    #[cm("web:dom/window#confirm")]
+    #[cm_params("self", "message")]
+    fn confirm(&self, message: Option<String>) -> bool;
+    #[cm("web:dom/window#prompt")]
+    #[cm_params("self", "message", "default")]
+    fn prompt(&self, message: Option<String>, default: Option<String>) -> Option<String>;
+    #[cm("web:dom/window#print")]
+    #[cm_params("self")]
+    fn print(&self);
+    #[cm("web:dom/window#capture-events")]
+    #[cm_params("self")]
+    fn capture_events(&self);
+    #[cm("web:dom/window#release-events")]
+    #[cm_params("self")]
+    fn release_events(&self);
+    #[cm("web:dom/window#origin")]
+    #[cm_params("self")]
+    fn origin(&self) -> String;
+    #[cm("web:dom/window#is-secure-context")]
+    #[cm_params("self")]
+    fn is_secure_context(&self) -> bool;
+    #[cm("web:dom/window#cross-origin-isolated")]
+    #[cm_params("self")]
+    fn cross_origin_isolated(&self) -> bool;
+    #[cm("web:dom/window#btoa")]
+    #[cm_params("self", "data")]
+    fn btoa(&self, data: String) -> String;
+    #[cm("web:dom/window#atob")]
+    #[cm_params("self", "data")]
+    fn atob(&self, data: String) -> String;
+    #[cm("web:dom/window#set-timeout")]
+    #[cm_params("self", "handler", "timeout")]
+    fn set_timeout(&self, handler: String, timeout: Option<i32>) -> i32;
+    #[cm("web:dom/window#clear-timeout")]
+    #[cm_params("self", "id")]
+    fn clear_timeout(&self, id: Option<i32>);
+    #[cm("web:dom/window#set-interval")]
+    #[cm_params("self", "handler", "timeout")]
+    fn set_interval(&self, handler: String, timeout: Option<i32>) -> i32;
+    #[cm("web:dom/window#clear-interval")]
+    #[cm_params("self", "id")]
+    fn clear_interval(&self, id: Option<i32>);
+    #[cm("web:dom/window#cancel-animation-frame")]
+    #[cm_params("self", "handle")]
+    fn cancel_animation_frame(&self, handle: u32);
+}
+
+/// The DOM entry points, which hand out the first handle.
+#[cm("web:dom/global")]
+pub interface Dom {
+    #[cm("web:dom/global#window")]
+    fn window() -> Window;
+    #[cm("web:dom/global#document")]
+    fn document() -> Document;
 }

--- a/wado-compiler/lib/web/dom.wado
+++ b/wado-compiler/lib/web/dom.wado
@@ -299,15 +299,9 @@ pub resource Element extends Node {
     #[cm("web:dom/element#get-html")]
     #[cm_params("self")]
     fn get_html(&self) -> String;
-    #[cm("web:dom/element#inner-html")]
-    #[cm_params("self")]
-    fn inner_html(&self) -> String;
     #[cm("web:dom/element#set-inner-html")]
     #[cm_params("self", "value")]
     fn set_inner_html(&self, value: String);
-    #[cm("web:dom/element#outer-html")]
-    #[cm_params("self")]
-    fn outer_html(&self) -> String;
     #[cm("web:dom/element#set-outer-html")]
     #[cm_params("self", "value")]
     fn set_outer_html(&self, value: String);

--- a/wado-compiler/lib/web/dom.wado
+++ b/wado-compiler/lib/web/dom.wado
@@ -654,7 +654,7 @@ pub resource HtmlInputElement extends HtmlElement {
     fn type_(&self) -> String;
     #[cm("web:dom/html-input-element#set-type")]
     #[cm_params("self", "value")]
-    fn set_type_(&self, value: String);
+    fn set_type(&self, value: String);
     #[cm("web:dom/html-input-element#default-value")]
     #[cm_params("self")]
     fn default_value(&self) -> String;

--- a/wado-compiler/lib/web/dom.wado
+++ b/wado-compiler/lib/web/dom.wado
@@ -14,10 +14,10 @@ pub resource EventTarget {
 pub resource Event {
     #[cm("web:dom/event#new")]
     #[cm_params("type")]
-    fn new(type_: String) -> Event;
+    fn new(type: String) -> Event;
     #[cm("web:dom/event#type")]
     #[cm_params("self")]
-    fn type_(&self) -> String;
+    fn type(&self) -> String;
     #[cm("web:dom/event#target")]
     #[cm_params("self")]
     fn target(&self) -> Option<EventTarget>;
@@ -71,7 +71,7 @@ pub resource Event {
     fn time_stamp(&self) -> f64;
     #[cm("web:dom/event#init-event")]
     #[cm_params("self", "type", "bubbles", "cancelable")]
-    fn init_event(&self, type_: String, bubbles: Option<bool>, cancelable: Option<bool>);
+    fn init_event(&self, type: String, bubbles: Option<bool>, cancelable: Option<bool>);
 }
 
 #[cm("web:dom/node", type = "extern-handle")]
@@ -170,6 +170,45 @@ pub resource Node extends EventTarget {
 
 #[cm("web:dom/element", type = "extern-handle")]
 pub resource Element extends Node {
+    #[cm("web:dom/element#get-spatial-navigation-container")]
+    #[cm_params("self")]
+    fn get_spatial_navigation_container(&self) -> Node;
+    #[cm("web:dom/element#check-visibility")]
+    #[cm_params("self")]
+    fn check_visibility(&self) -> bool;
+    #[cm("web:dom/element#scroll-top")]
+    #[cm_params("self")]
+    fn scroll_top(&self) -> f64;
+    #[cm("web:dom/element#set-scroll-top")]
+    #[cm_params("self", "value")]
+    fn set_scroll_top(&self, value: f64);
+    #[cm("web:dom/element#scroll-left")]
+    #[cm_params("self")]
+    fn scroll_left(&self) -> f64;
+    #[cm("web:dom/element#set-scroll-left")]
+    #[cm_params("self", "value")]
+    fn set_scroll_left(&self, value: f64);
+    #[cm("web:dom/element#scroll-width")]
+    #[cm_params("self")]
+    fn scroll_width(&self) -> i32;
+    #[cm("web:dom/element#scroll-height")]
+    #[cm_params("self")]
+    fn scroll_height(&self) -> i32;
+    #[cm("web:dom/element#client-top")]
+    #[cm_params("self")]
+    fn client_top(&self) -> i32;
+    #[cm("web:dom/element#client-left")]
+    #[cm_params("self")]
+    fn client_left(&self) -> i32;
+    #[cm("web:dom/element#client-width")]
+    #[cm_params("self")]
+    fn client_width(&self) -> i32;
+    #[cm("web:dom/element#client-height")]
+    #[cm_params("self")]
+    fn client_height(&self) -> i32;
+    #[cm("web:dom/element#current-css-zoom")]
+    #[cm_params("self")]
+    fn current_css_zoom(&self) -> f64;
     #[cm("web:dom/element#namespace-uri")]
     #[cm_params("self")]
     fn namespace_uri(&self) -> Option<String>;
@@ -245,6 +284,12 @@ pub resource Element extends Node {
     #[cm("web:dom/element#insert-adjacent-text")]
     #[cm_params("self", "where", "data")]
     fn insert_adjacent_text(&self, where: String, data: String);
+    #[cm("web:dom/element#element-timing")]
+    #[cm_params("self")]
+    fn element_timing(&self) -> String;
+    #[cm("web:dom/element#set-element-timing")]
+    #[cm_params("self", "value")]
+    fn set_element_timing(&self, value: String);
     #[cm("web:dom/element#set-html")]
     #[cm_params("self", "html")]
     fn set_html(&self, html: String);
@@ -269,6 +314,15 @@ pub resource Element extends Node {
     #[cm("web:dom/element#insert-adjacent-html")]
     #[cm_params("self", "position", "string")]
     fn insert_adjacent_html(&self, position: String, string: String);
+    #[cm("web:dom/element#set-pointer-capture")]
+    #[cm_params("self", "pointer-id")]
+    fn set_pointer_capture(&self, pointer_id: i32);
+    #[cm("web:dom/element#release-pointer-capture")]
+    #[cm_params("self", "pointer-id")]
+    fn release_pointer_capture(&self, pointer_id: i32);
+    #[cm("web:dom/element#has-pointer-capture")]
+    #[cm_params("self", "pointer-id")]
+    fn has_pointer_capture(&self, pointer_id: i32) -> bool;
     #[cm("web:dom/element#first-element-child")]
     #[cm_params("self")]
     fn first_element_child(&self) -> Option<Element>;
@@ -278,15 +332,6 @@ pub resource Element extends Node {
     #[cm("web:dom/element#child-element-count")]
     #[cm_params("self")]
     fn child_element_count(&self) -> u32;
-    #[cm("web:dom/element#prepend")]
-    #[cm_params("self")]
-    fn prepend(&self);
-    #[cm("web:dom/element#append")]
-    #[cm_params("self")]
-    fn append(&self);
-    #[cm("web:dom/element#replace-children")]
-    #[cm_params("self")]
-    fn replace_children(&self);
     #[cm("web:dom/element#move-before")]
     #[cm_params("self", "node", "child")]
     fn move_before(&self, node: Node, child: Option<Node>);
@@ -299,22 +344,316 @@ pub resource Element extends Node {
     #[cm("web:dom/element#next-element-sibling")]
     #[cm_params("self")]
     fn next_element_sibling(&self) -> Option<Element>;
-    #[cm("web:dom/element#before")]
-    #[cm_params("self")]
-    fn before(&self);
-    #[cm("web:dom/element#after")]
-    #[cm_params("self")]
-    fn after(&self);
-    #[cm("web:dom/element#replace-with")]
-    #[cm_params("self")]
-    fn replace_with(&self);
     #[cm("web:dom/element#remove")]
     #[cm_params("self")]
     fn remove(&self);
+    #[cm("web:dom/element#role")]
+    #[cm_params("self")]
+    fn role(&self) -> Option<String>;
+    #[cm("web:dom/element#set-role")]
+    #[cm_params("self", "value")]
+    fn set_role(&self, value: Option<String>);
+    #[cm("web:dom/element#aria-active-descendant-element")]
+    #[cm_params("self")]
+    fn aria_active_descendant_element(&self) -> Option<Element>;
+    #[cm("web:dom/element#set-aria-active-descendant-element")]
+    #[cm_params("self", "value")]
+    fn set_aria_active_descendant_element(&self, value: Option<Element>);
+    #[cm("web:dom/element#aria-atomic")]
+    #[cm_params("self")]
+    fn aria_atomic(&self) -> Option<String>;
+    #[cm("web:dom/element#set-aria-atomic")]
+    #[cm_params("self", "value")]
+    fn set_aria_atomic(&self, value: Option<String>);
+    #[cm("web:dom/element#aria-auto-complete")]
+    #[cm_params("self")]
+    fn aria_auto_complete(&self) -> Option<String>;
+    #[cm("web:dom/element#set-aria-auto-complete")]
+    #[cm_params("self", "value")]
+    fn set_aria_auto_complete(&self, value: Option<String>);
+    #[cm("web:dom/element#aria-braille-label")]
+    #[cm_params("self")]
+    fn aria_braille_label(&self) -> Option<String>;
+    #[cm("web:dom/element#set-aria-braille-label")]
+    #[cm_params("self", "value")]
+    fn set_aria_braille_label(&self, value: Option<String>);
+    #[cm("web:dom/element#aria-braille-role-description")]
+    #[cm_params("self")]
+    fn aria_braille_role_description(&self) -> Option<String>;
+    #[cm("web:dom/element#set-aria-braille-role-description")]
+    #[cm_params("self", "value")]
+    fn set_aria_braille_role_description(&self, value: Option<String>);
+    #[cm("web:dom/element#aria-busy")]
+    #[cm_params("self")]
+    fn aria_busy(&self) -> Option<String>;
+    #[cm("web:dom/element#set-aria-busy")]
+    #[cm_params("self", "value")]
+    fn set_aria_busy(&self, value: Option<String>);
+    #[cm("web:dom/element#aria-checked")]
+    #[cm_params("self")]
+    fn aria_checked(&self) -> Option<String>;
+    #[cm("web:dom/element#set-aria-checked")]
+    #[cm_params("self", "value")]
+    fn set_aria_checked(&self, value: Option<String>);
+    #[cm("web:dom/element#aria-col-count")]
+    #[cm_params("self")]
+    fn aria_col_count(&self) -> Option<String>;
+    #[cm("web:dom/element#set-aria-col-count")]
+    #[cm_params("self", "value")]
+    fn set_aria_col_count(&self, value: Option<String>);
+    #[cm("web:dom/element#aria-col-index")]
+    #[cm_params("self")]
+    fn aria_col_index(&self) -> Option<String>;
+    #[cm("web:dom/element#set-aria-col-index")]
+    #[cm_params("self", "value")]
+    fn set_aria_col_index(&self, value: Option<String>);
+    #[cm("web:dom/element#aria-col-index-text")]
+    #[cm_params("self")]
+    fn aria_col_index_text(&self) -> Option<String>;
+    #[cm("web:dom/element#set-aria-col-index-text")]
+    #[cm_params("self", "value")]
+    fn set_aria_col_index_text(&self, value: Option<String>);
+    #[cm("web:dom/element#aria-col-span")]
+    #[cm_params("self")]
+    fn aria_col_span(&self) -> Option<String>;
+    #[cm("web:dom/element#set-aria-col-span")]
+    #[cm_params("self", "value")]
+    fn set_aria_col_span(&self, value: Option<String>);
+    #[cm("web:dom/element#aria-current")]
+    #[cm_params("self")]
+    fn aria_current(&self) -> Option<String>;
+    #[cm("web:dom/element#set-aria-current")]
+    #[cm_params("self", "value")]
+    fn set_aria_current(&self, value: Option<String>);
+    #[cm("web:dom/element#aria-description")]
+    #[cm_params("self")]
+    fn aria_description(&self) -> Option<String>;
+    #[cm("web:dom/element#set-aria-description")]
+    #[cm_params("self", "value")]
+    fn set_aria_description(&self, value: Option<String>);
+    #[cm("web:dom/element#aria-disabled")]
+    #[cm_params("self")]
+    fn aria_disabled(&self) -> Option<String>;
+    #[cm("web:dom/element#set-aria-disabled")]
+    #[cm_params("self", "value")]
+    fn set_aria_disabled(&self, value: Option<String>);
+    #[cm("web:dom/element#aria-expanded")]
+    #[cm_params("self")]
+    fn aria_expanded(&self) -> Option<String>;
+    #[cm("web:dom/element#set-aria-expanded")]
+    #[cm_params("self", "value")]
+    fn set_aria_expanded(&self, value: Option<String>);
+    #[cm("web:dom/element#aria-has-popup")]
+    #[cm_params("self")]
+    fn aria_has_popup(&self) -> Option<String>;
+    #[cm("web:dom/element#set-aria-has-popup")]
+    #[cm_params("self", "value")]
+    fn set_aria_has_popup(&self, value: Option<String>);
+    #[cm("web:dom/element#aria-hidden")]
+    #[cm_params("self")]
+    fn aria_hidden(&self) -> Option<String>;
+    #[cm("web:dom/element#set-aria-hidden")]
+    #[cm_params("self", "value")]
+    fn set_aria_hidden(&self, value: Option<String>);
+    #[cm("web:dom/element#aria-invalid")]
+    #[cm_params("self")]
+    fn aria_invalid(&self) -> Option<String>;
+    #[cm("web:dom/element#set-aria-invalid")]
+    #[cm_params("self", "value")]
+    fn set_aria_invalid(&self, value: Option<String>);
+    #[cm("web:dom/element#aria-key-shortcuts")]
+    #[cm_params("self")]
+    fn aria_key_shortcuts(&self) -> Option<String>;
+    #[cm("web:dom/element#set-aria-key-shortcuts")]
+    #[cm_params("self", "value")]
+    fn set_aria_key_shortcuts(&self, value: Option<String>);
+    #[cm("web:dom/element#aria-label")]
+    #[cm_params("self")]
+    fn aria_label(&self) -> Option<String>;
+    #[cm("web:dom/element#set-aria-label")]
+    #[cm_params("self", "value")]
+    fn set_aria_label(&self, value: Option<String>);
+    #[cm("web:dom/element#aria-level")]
+    #[cm_params("self")]
+    fn aria_level(&self) -> Option<String>;
+    #[cm("web:dom/element#set-aria-level")]
+    #[cm_params("self", "value")]
+    fn set_aria_level(&self, value: Option<String>);
+    #[cm("web:dom/element#aria-live")]
+    #[cm_params("self")]
+    fn aria_live(&self) -> Option<String>;
+    #[cm("web:dom/element#set-aria-live")]
+    #[cm_params("self", "value")]
+    fn set_aria_live(&self, value: Option<String>);
+    #[cm("web:dom/element#aria-modal")]
+    #[cm_params("self")]
+    fn aria_modal(&self) -> Option<String>;
+    #[cm("web:dom/element#set-aria-modal")]
+    #[cm_params("self", "value")]
+    fn set_aria_modal(&self, value: Option<String>);
+    #[cm("web:dom/element#aria-multi-line")]
+    #[cm_params("self")]
+    fn aria_multi_line(&self) -> Option<String>;
+    #[cm("web:dom/element#set-aria-multi-line")]
+    #[cm_params("self", "value")]
+    fn set_aria_multi_line(&self, value: Option<String>);
+    #[cm("web:dom/element#aria-multi-selectable")]
+    #[cm_params("self")]
+    fn aria_multi_selectable(&self) -> Option<String>;
+    #[cm("web:dom/element#set-aria-multi-selectable")]
+    #[cm_params("self", "value")]
+    fn set_aria_multi_selectable(&self, value: Option<String>);
+    #[cm("web:dom/element#aria-orientation")]
+    #[cm_params("self")]
+    fn aria_orientation(&self) -> Option<String>;
+    #[cm("web:dom/element#set-aria-orientation")]
+    #[cm_params("self", "value")]
+    fn set_aria_orientation(&self, value: Option<String>);
+    #[cm("web:dom/element#aria-placeholder")]
+    #[cm_params("self")]
+    fn aria_placeholder(&self) -> Option<String>;
+    #[cm("web:dom/element#set-aria-placeholder")]
+    #[cm_params("self", "value")]
+    fn set_aria_placeholder(&self, value: Option<String>);
+    #[cm("web:dom/element#aria-pos-in-set")]
+    #[cm_params("self")]
+    fn aria_pos_in_set(&self) -> Option<String>;
+    #[cm("web:dom/element#set-aria-pos-in-set")]
+    #[cm_params("self", "value")]
+    fn set_aria_pos_in_set(&self, value: Option<String>);
+    #[cm("web:dom/element#aria-pressed")]
+    #[cm_params("self")]
+    fn aria_pressed(&self) -> Option<String>;
+    #[cm("web:dom/element#set-aria-pressed")]
+    #[cm_params("self", "value")]
+    fn set_aria_pressed(&self, value: Option<String>);
+    #[cm("web:dom/element#aria-read-only")]
+    #[cm_params("self")]
+    fn aria_read_only(&self) -> Option<String>;
+    #[cm("web:dom/element#set-aria-read-only")]
+    #[cm_params("self", "value")]
+    fn set_aria_read_only(&self, value: Option<String>);
+    #[cm("web:dom/element#aria-relevant")]
+    #[cm_params("self")]
+    fn aria_relevant(&self) -> Option<String>;
+    #[cm("web:dom/element#set-aria-relevant")]
+    #[cm_params("self", "value")]
+    fn set_aria_relevant(&self, value: Option<String>);
+    #[cm("web:dom/element#aria-required")]
+    #[cm_params("self")]
+    fn aria_required(&self) -> Option<String>;
+    #[cm("web:dom/element#set-aria-required")]
+    #[cm_params("self", "value")]
+    fn set_aria_required(&self, value: Option<String>);
+    #[cm("web:dom/element#aria-role-description")]
+    #[cm_params("self")]
+    fn aria_role_description(&self) -> Option<String>;
+    #[cm("web:dom/element#set-aria-role-description")]
+    #[cm_params("self", "value")]
+    fn set_aria_role_description(&self, value: Option<String>);
+    #[cm("web:dom/element#aria-row-count")]
+    #[cm_params("self")]
+    fn aria_row_count(&self) -> Option<String>;
+    #[cm("web:dom/element#set-aria-row-count")]
+    #[cm_params("self", "value")]
+    fn set_aria_row_count(&self, value: Option<String>);
+    #[cm("web:dom/element#aria-row-index")]
+    #[cm_params("self")]
+    fn aria_row_index(&self) -> Option<String>;
+    #[cm("web:dom/element#set-aria-row-index")]
+    #[cm_params("self", "value")]
+    fn set_aria_row_index(&self, value: Option<String>);
+    #[cm("web:dom/element#aria-row-index-text")]
+    #[cm_params("self")]
+    fn aria_row_index_text(&self) -> Option<String>;
+    #[cm("web:dom/element#set-aria-row-index-text")]
+    #[cm_params("self", "value")]
+    fn set_aria_row_index_text(&self, value: Option<String>);
+    #[cm("web:dom/element#aria-row-span")]
+    #[cm_params("self")]
+    fn aria_row_span(&self) -> Option<String>;
+    #[cm("web:dom/element#set-aria-row-span")]
+    #[cm_params("self", "value")]
+    fn set_aria_row_span(&self, value: Option<String>);
+    #[cm("web:dom/element#aria-selected")]
+    #[cm_params("self")]
+    fn aria_selected(&self) -> Option<String>;
+    #[cm("web:dom/element#set-aria-selected")]
+    #[cm_params("self", "value")]
+    fn set_aria_selected(&self, value: Option<String>);
+    #[cm("web:dom/element#aria-set-size")]
+    #[cm_params("self")]
+    fn aria_set_size(&self) -> Option<String>;
+    #[cm("web:dom/element#set-aria-set-size")]
+    #[cm_params("self", "value")]
+    fn set_aria_set_size(&self, value: Option<String>);
+    #[cm("web:dom/element#aria-sort")]
+    #[cm_params("self")]
+    fn aria_sort(&self) -> Option<String>;
+    #[cm("web:dom/element#set-aria-sort")]
+    #[cm_params("self", "value")]
+    fn set_aria_sort(&self, value: Option<String>);
+    #[cm("web:dom/element#aria-value-max")]
+    #[cm_params("self")]
+    fn aria_value_max(&self) -> Option<String>;
+    #[cm("web:dom/element#set-aria-value-max")]
+    #[cm_params("self", "value")]
+    fn set_aria_value_max(&self, value: Option<String>);
+    #[cm("web:dom/element#aria-value-min")]
+    #[cm_params("self")]
+    fn aria_value_min(&self) -> Option<String>;
+    #[cm("web:dom/element#set-aria-value-min")]
+    #[cm_params("self", "value")]
+    fn set_aria_value_min(&self, value: Option<String>);
+    #[cm("web:dom/element#aria-value-now")]
+    #[cm_params("self")]
+    fn aria_value_now(&self) -> Option<String>;
+    #[cm("web:dom/element#set-aria-value-now")]
+    #[cm_params("self", "value")]
+    fn set_aria_value_now(&self, value: Option<String>);
+    #[cm("web:dom/element#aria-value-text")]
+    #[cm_params("self")]
+    fn aria_value_text(&self) -> Option<String>;
+    #[cm("web:dom/element#set-aria-value-text")]
+    #[cm_params("self", "value")]
+    fn set_aria_value_text(&self, value: Option<String>);
+    #[cm("web:dom/element#aria-notify")]
+    #[cm_params("self", "announcement")]
+    fn aria_notify(&self, announcement: String);
 }
 
 #[cm("web:dom/html-element", type = "extern-handle")]
 pub resource HtmlElement extends Element {
+    #[cm("web:dom/html-element#container-timing")]
+    #[cm_params("self")]
+    fn container_timing(&self) -> String;
+    #[cm("web:dom/html-element#set-container-timing")]
+    #[cm_params("self", "value")]
+    fn set_container_timing(&self, value: String);
+    #[cm("web:dom/html-element#container-timing-ignore")]
+    #[cm_params("self")]
+    fn container_timing_ignore(&self) -> bool;
+    #[cm("web:dom/html-element#set-container-timing-ignore")]
+    #[cm_params("self", "value")]
+    fn set_container_timing_ignore(&self, value: bool);
+    #[cm("web:dom/html-element#scroll-parent")]
+    #[cm_params("self")]
+    fn scroll_parent(&self) -> Option<Element>;
+    #[cm("web:dom/html-element#offset-parent")]
+    #[cm_params("self")]
+    fn offset_parent(&self) -> Option<Element>;
+    #[cm("web:dom/html-element#offset-top")]
+    #[cm_params("self")]
+    fn offset_top(&self) -> i32;
+    #[cm("web:dom/html-element#offset-left")]
+    #[cm_params("self")]
+    fn offset_left(&self) -> i32;
+    #[cm("web:dom/html-element#offset-width")]
+    #[cm_params("self")]
+    fn offset_width(&self) -> i32;
+    #[cm("web:dom/html-element#offset-height")]
+    #[cm_params("self")]
+    fn offset_height(&self) -> i32;
     #[cm("web:dom/html-element#title")]
     #[cm_params("self")]
     fn title(&self) -> String;
@@ -447,6 +786,12 @@ pub resource HtmlElement extends Element {
     #[cm("web:dom/html-element#set-input-mode")]
     #[cm_params("self", "value")]
     fn set_input_mode(&self, value: String);
+    #[cm("web:dom/html-element#virtual-keyboard-policy")]
+    #[cm_params("self")]
+    fn virtual_keyboard_policy(&self) -> String;
+    #[cm("web:dom/html-element#set-virtual-keyboard-policy")]
+    #[cm_params("self", "value")]
+    fn set_virtual_keyboard_policy(&self, value: String);
     #[cm("web:dom/html-element#nonce")]
     #[cm_params("self")]
     fn nonce(&self) -> String;
@@ -475,6 +820,12 @@ pub resource HtmlElement extends Element {
 
 #[cm("web:dom/html-input-element", type = "extern-handle")]
 pub resource HtmlInputElement extends HtmlElement {
+    #[cm("web:dom/html-input-element#webkitdirectory")]
+    #[cm_params("self")]
+    fn webkitdirectory(&self) -> bool;
+    #[cm("web:dom/html-input-element#set-webkitdirectory")]
+    #[cm_params("self", "value")]
+    fn set_webkitdirectory(&self, value: bool);
     #[cm("web:dom/html-input-element#accept")]
     #[cm_params("self")]
     fn accept(&self) -> String;
@@ -651,7 +1002,7 @@ pub resource HtmlInputElement extends HtmlElement {
     fn set_step(&self, value: String);
     #[cm("web:dom/html-input-element#type")]
     #[cm_params("self")]
-    fn type_(&self) -> String;
+    fn type(&self) -> String;
     #[cm("web:dom/html-input-element#set-type")]
     #[cm_params("self", "value")]
     fn set_type(&self, value: String);
@@ -739,6 +1090,12 @@ pub resource HtmlInputElement extends HtmlElement {
     #[cm("web:dom/html-input-element#set-use-map")]
     #[cm_params("self", "value")]
     fn set_use_map(&self, value: String);
+    #[cm("web:dom/html-input-element#capture")]
+    #[cm_params("self")]
+    fn capture(&self) -> String;
+    #[cm("web:dom/html-input-element#set-capture")]
+    #[cm_params("self", "value")]
+    fn set_capture(&self, value: String);
     #[cm("web:dom/html-input-element#popover-target-element")]
     #[cm_params("self")]
     fn popover_target_element(&self) -> Option<Element>;
@@ -755,6 +1112,12 @@ pub resource HtmlInputElement extends HtmlElement {
 
 #[cm("web:dom/document", type = "extern-handle")]
 pub resource Document extends Node {
+    #[cm("web:dom/document#element-from-point")]
+    #[cm_params("self", "x", "y")]
+    fn element_from_point(&self, x: f64, y: f64) -> Option<Element>;
+    #[cm("web:dom/document#scrolling-element")]
+    #[cm_params("self")]
+    fn scrolling_element(&self) -> Option<Element>;
     #[cm("web:dom/document#new")]
     fn new() -> Document;
     #[cm("web:dom/document#url")]
@@ -796,6 +1159,12 @@ pub resource Document extends Node {
     #[cm("web:dom/document#create-event")]
     #[cm_params("self", "interface")]
     fn create_event(&self, interface_: String) -> Event;
+    #[cm("web:dom/document#fullscreen-enabled")]
+    #[cm_params("self")]
+    fn fullscreen_enabled(&self) -> bool;
+    #[cm("web:dom/document#fullscreen")]
+    #[cm_params("self")]
+    fn fullscreen(&self) -> bool;
     #[cm("web:dom/document#parse-html-unsafe")]
     #[cm_params("html")]
     fn parse_html_unsafe(html: String) -> Document;
@@ -844,12 +1213,6 @@ pub resource Document extends Node {
     #[cm("web:dom/document#close")]
     #[cm_params("self")]
     fn close(&self);
-    #[cm("web:dom/document#write")]
-    #[cm_params("self")]
-    fn write(&self);
-    #[cm("web:dom/document#writeln")]
-    #[cm_params("self")]
-    fn writeln(&self);
     #[cm("web:dom/document#has-focus")]
     #[cm_params("self")]
     fn has_focus(&self) -> bool;
@@ -919,12 +1282,33 @@ pub resource Document extends Node {
     #[cm("web:dom/document#release-events")]
     #[cm_params("self")]
     fn release_events(&self);
+    #[cm("web:dom/document#was-discarded")]
+    #[cm_params("self")]
+    fn was_discarded(&self) -> bool;
+    #[cm("web:dom/document#picture-in-picture-enabled")]
+    #[cm_params("self")]
+    fn picture_in_picture_enabled(&self) -> bool;
+    #[cm("web:dom/document#exit-pointer-lock")]
+    #[cm_params("self")]
+    fn exit_pointer_lock(&self);
+    #[cm("web:dom/document#prerendering")]
+    #[cm_params("self")]
+    fn prerendering(&self) -> bool;
     #[cm("web:dom/document#get-element-by-id")]
     #[cm_params("self", "element-id")]
     fn get_element_by_id(&self, element_id: String) -> Option<Element>;
+    #[cm("web:dom/document#fullscreen-element")]
+    #[cm_params("self")]
+    fn fullscreen_element(&self) -> Option<Element>;
     #[cm("web:dom/document#active-element")]
     #[cm_params("self")]
     fn active_element(&self) -> Option<Element>;
+    #[cm("web:dom/document#picture-in-picture-element")]
+    #[cm_params("self")]
+    fn picture_in_picture_element(&self) -> Option<Element>;
+    #[cm("web:dom/document#pointer-lock-element")]
+    #[cm_params("self")]
+    fn pointer_lock_element(&self) -> Option<Element>;
     #[cm("web:dom/document#first-element-child")]
     #[cm_params("self")]
     fn first_element_child(&self) -> Option<Element>;
@@ -934,15 +1318,6 @@ pub resource Document extends Node {
     #[cm("web:dom/document#child-element-count")]
     #[cm_params("self")]
     fn child_element_count(&self) -> u32;
-    #[cm("web:dom/document#prepend")]
-    #[cm_params("self")]
-    fn prepend(&self);
-    #[cm("web:dom/document#append")]
-    #[cm_params("self")]
-    fn append(&self);
-    #[cm("web:dom/document#replace-children")]
-    #[cm_params("self")]
-    fn replace_children(&self);
     #[cm("web:dom/document#move-before")]
     #[cm_params("self", "node", "child")]
     fn move_before(&self, node: Node, child: Option<Node>);
@@ -952,10 +1327,73 @@ pub resource Document extends Node {
     #[cm("web:dom/document#create-ns-resolver")]
     #[cm_params("self", "node-resolver")]
     fn create_ns_resolver(&self, node_resolver: Node) -> Node;
+    #[cm("web:dom/document#aria-notify")]
+    #[cm_params("self", "announcement")]
+    fn aria_notify(&self, announcement: String);
 }
 
 #[cm("web:dom/window", type = "extern-handle")]
 pub resource Window extends EventTarget {
+    #[cm("web:dom/window#credentialless")]
+    #[cm_params("self")]
+    fn credentialless(&self) -> bool;
+    #[cm("web:dom/window#orientation")]
+    #[cm_params("self")]
+    fn orientation(&self) -> i16;
+    #[cm("web:dom/window#request-resize")]
+    #[cm_params("self")]
+    fn request_resize(&self);
+    #[cm("web:dom/window#move-to")]
+    #[cm_params("self", "x", "y")]
+    fn move_to(&self, x: i32, y: i32);
+    #[cm("web:dom/window#move-by")]
+    #[cm_params("self", "x", "y")]
+    fn move_by(&self, x: i32, y: i32);
+    #[cm("web:dom/window#resize-to")]
+    #[cm_params("self", "width", "height")]
+    fn resize_to(&self, width: i32, height: i32);
+    #[cm("web:dom/window#resize-by")]
+    #[cm_params("self", "x", "y")]
+    fn resize_by(&self, x: i32, y: i32);
+    #[cm("web:dom/window#inner-width")]
+    #[cm_params("self")]
+    fn inner_width(&self) -> i32;
+    #[cm("web:dom/window#inner-height")]
+    #[cm_params("self")]
+    fn inner_height(&self) -> i32;
+    #[cm("web:dom/window#scroll-x")]
+    #[cm_params("self")]
+    fn scroll_x(&self) -> f64;
+    #[cm("web:dom/window#page-x-offset")]
+    #[cm_params("self")]
+    fn page_x_offset(&self) -> f64;
+    #[cm("web:dom/window#scroll-y")]
+    #[cm_params("self")]
+    fn scroll_y(&self) -> f64;
+    #[cm("web:dom/window#page-y-offset")]
+    #[cm_params("self")]
+    fn page_y_offset(&self) -> f64;
+    #[cm("web:dom/window#screen-x")]
+    #[cm_params("self")]
+    fn screen_x(&self) -> i32;
+    #[cm("web:dom/window#screen-left")]
+    #[cm_params("self")]
+    fn screen_left(&self) -> i32;
+    #[cm("web:dom/window#screen-y")]
+    #[cm_params("self")]
+    fn screen_y(&self) -> i32;
+    #[cm("web:dom/window#screen-top")]
+    #[cm_params("self")]
+    fn screen_top(&self) -> i32;
+    #[cm("web:dom/window#outer-width")]
+    #[cm_params("self")]
+    fn outer_width(&self) -> i32;
+    #[cm("web:dom/window#outer-height")]
+    #[cm_params("self")]
+    fn outer_height(&self) -> i32;
+    #[cm("web:dom/window#device-pixel-ratio")]
+    #[cm_params("self")]
+    fn device_pixel_ratio(&self) -> f64;
     #[cm("web:dom/window#event")]
     #[cm_params("self")]
     fn event(&self) -> Option<Event>;
@@ -1013,6 +1451,9 @@ pub resource Window extends EventTarget {
     #[cm("web:dom/window#release-events")]
     #[cm_params("self")]
     fn release_events(&self);
+    #[cm("web:dom/window#cancel-idle-callback")]
+    #[cm_params("self", "handle")]
+    fn cancel_idle_callback(&self, handle: u32);
     #[cm("web:dom/window#origin")]
     #[cm_params("self")]
     fn origin(&self) -> String;
@@ -1028,15 +1469,9 @@ pub resource Window extends EventTarget {
     #[cm("web:dom/window#atob")]
     #[cm_params("self", "data")]
     fn atob(&self, data: String) -> String;
-    #[cm("web:dom/window#set-timeout")]
-    #[cm_params("self", "handler", "timeout")]
-    fn set_timeout(&self, handler: String, timeout: Option<i32>) -> i32;
     #[cm("web:dom/window#clear-timeout")]
     #[cm_params("self", "id")]
     fn clear_timeout(&self, id: Option<i32>);
-    #[cm("web:dom/window#set-interval")]
-    #[cm_params("self", "handler", "timeout")]
-    fn set_interval(&self, handler: String, timeout: Option<i32>) -> i32;
     #[cm("web:dom/window#clear-interval")]
     #[cm_params("self", "id")]
     fn clear_interval(&self, id: Option<i32>);
@@ -1045,7 +1480,7 @@ pub resource Window extends EventTarget {
     fn cancel_animation_frame(&self, handle: u32);
 }
 
-/// The DOM entry points, which hand out the first handle.
+/// The `web:dom` entry points, which hand out the first handle.
 #[cm("web:dom/global")]
 pub interface Dom {
     #[cm("web:dom/global#window")]

--- a/wado-compiler/lib/web/dom.webidl.json
+++ b/wado-compiler/lib/web/dom.webidl.json
@@ -13,7 +13,2644 @@
   ],
   "interfaces": [
     {
-      "spec": "dom",
+      "type": "interface",
+      "name": "Document",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "rootElement",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "SVGSVGElement"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Window",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "credentialless",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Window",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "orientation",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "short"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "onorientationchange",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "HTMLElement",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "containerTiming",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "containerTimingIgnore",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Window",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "cookieStore",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "CookieStore"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "SameObject",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        }
+      ],
+      "extAttrs": [
+        {
+          "type": "extended-attribute",
+          "name": "SecureContext",
+          "rhs": null,
+          "arguments": []
+        }
+      ],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Window",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "crashReport",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "CrashReportContext"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Window",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "operation",
+          "name": "navigate",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "dir",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "SpatialNavigationDirection"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Element",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "operation",
+          "name": "getSpatialNavigationContainer",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "Node"
+          },
+          "arguments": [],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "focusableAreas",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "sequence",
+            "nullable": false,
+            "union": false,
+            "idlType": [
+              {
+                "type": "return-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "Node"
+              }
+            ]
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "option",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "FocusableAreasOption"
+              },
+              "default": {
+                "type": "dictionary"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "spatialNavigationSearch",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "Node"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "dir",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "SpatialNavigationDirection"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "options",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "SpatialNavigationSearchOptions"
+              },
+              "default": {
+                "type": "dictionary"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Element",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "operation",
+          "name": "pseudo",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "CSSPseudoElement"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "type",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "CSSOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Document",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "namedFlows",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "NamedFlowMap"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Element",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "part",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMTokenList"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "SameObject",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "PutForwards",
+              "rhs": {
+                "type": "identifier",
+                "value": "value"
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Window",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "operation",
+          "name": "requestResize",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [],
+          "extAttrs": [],
+          "special": ""
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Element",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "operation",
+          "name": "computedStyleMap",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "StylePropertyMapReadOnly"
+          },
+          "arguments": [],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "SameObject",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Document",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "operation",
+          "name": "startViewTransition",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "ViewTransition"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "callbackOptions",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": true,
+                "idlType": [
+                  {
+                    "type": "argument-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "ViewTransitionUpdateCallback"
+                  },
+                  {
+                    "type": "argument-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "StartViewTransitionOptions"
+                  }
+                ]
+              },
+              "default": {
+                "type": "dictionary"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "attribute",
+          "name": "activeViewTransition",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "ViewTransition"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Element",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "operation",
+          "name": "startViewTransition",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "ViewTransition"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "callbackOptions",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": true,
+                "idlType": [
+                  {
+                    "type": "argument-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "ViewTransitionUpdateCallback"
+                  },
+                  {
+                    "type": "argument-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "StartViewTransitionOptions"
+                  }
+                ]
+              },
+              "default": {
+                "type": "dictionary"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "attribute",
+          "name": "activeViewTransition",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "ViewTransition"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Window",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "viewport",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "Viewport"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "SameObject",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Replaceable",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Window",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "operation",
+          "name": "getComputedStyle",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "CSSStyleProperties"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "elt",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "Element"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "pseudoElt",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": true,
+                "union": false,
+                "idlType": "CSSOMString"
+              },
+              "default": null,
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "NewObject",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Window",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "operation",
+          "name": "matchMedia",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "MediaQueryList"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "query",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "CSSOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "NewObject",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        },
+        {
+          "type": "attribute",
+          "name": "screen",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "Screen"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "SameObject",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Replaceable",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "visualViewport",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "VisualViewport"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "SameObject",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Replaceable",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "operation",
+          "name": "moveTo",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "x",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "long"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "y",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "long"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "moveBy",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "x",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "long"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "y",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "long"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "resizeTo",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "width",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "long"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "height",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "long"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "resizeBy",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "x",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "long"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "y",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "long"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "attribute",
+          "name": "innerWidth",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "long"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "Replaceable",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "innerHeight",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "long"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "Replaceable",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "scrollX",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "double"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "Replaceable",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "pageXOffset",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "double"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "Replaceable",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "scrollY",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "double"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "Replaceable",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "pageYOffset",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "double"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "Replaceable",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "operation",
+          "name": "scroll",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "Promise",
+            "nullable": false,
+            "union": false,
+            "idlType": [
+              {
+                "type": "return-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "undefined"
+              }
+            ]
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "options",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "ScrollToOptions"
+              },
+              "default": {
+                "type": "dictionary"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "scroll",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "Promise",
+            "nullable": false,
+            "union": false,
+            "idlType": [
+              {
+                "type": "return-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "undefined"
+              }
+            ]
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "x",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "unrestricted double"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "y",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "unrestricted double"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "scrollTo",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "Promise",
+            "nullable": false,
+            "union": false,
+            "idlType": [
+              {
+                "type": "return-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "undefined"
+              }
+            ]
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "options",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "ScrollToOptions"
+              },
+              "default": {
+                "type": "dictionary"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "scrollTo",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "Promise",
+            "nullable": false,
+            "union": false,
+            "idlType": [
+              {
+                "type": "return-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "undefined"
+              }
+            ]
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "x",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "unrestricted double"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "y",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "unrestricted double"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "scrollBy",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "Promise",
+            "nullable": false,
+            "union": false,
+            "idlType": [
+              {
+                "type": "return-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "undefined"
+              }
+            ]
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "options",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "ScrollToOptions"
+              },
+              "default": {
+                "type": "dictionary"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "scrollBy",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "Promise",
+            "nullable": false,
+            "union": false,
+            "idlType": [
+              {
+                "type": "return-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "undefined"
+              }
+            ]
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "x",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "unrestricted double"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "y",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "unrestricted double"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "attribute",
+          "name": "screenX",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "long"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "Replaceable",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "screenLeft",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "long"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "Replaceable",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "screenY",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "long"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "Replaceable",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "screenTop",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "long"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "Replaceable",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "outerWidth",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "long"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "Replaceable",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "outerHeight",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "long"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "Replaceable",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "devicePixelRatio",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "double"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "Replaceable",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Document",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "operation",
+          "name": "elementFromPoint",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "Element"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "x",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "double"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "y",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "double"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "elementsFromPoint",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "sequence",
+            "nullable": false,
+            "union": false,
+            "idlType": [
+              {
+                "type": "return-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "Element"
+              }
+            ]
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "x",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "double"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "y",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "double"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "caretPositionFromPoint",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "CaretPosition"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "x",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "double"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "y",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "double"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "options",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "CaretPositionFromPointOptions"
+              },
+              "default": {
+                "type": "dictionary"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "attribute",
+          "name": "scrollingElement",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "Element"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Element",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "operation",
+          "name": "getClientRects",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMRectList"
+          },
+          "arguments": [],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "getBoundingClientRect",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMRect"
+          },
+          "arguments": [],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "NewObject",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "checkVisibility",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "options",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "CheckVisibilityOptions"
+              },
+              "default": {
+                "type": "dictionary"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "scrollIntoView",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "Promise",
+            "nullable": false,
+            "union": false,
+            "idlType": [
+              {
+                "type": "return-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "undefined"
+              }
+            ]
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "arg",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": true,
+                "idlType": [
+                  {
+                    "type": "argument-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "boolean"
+                  },
+                  {
+                    "type": "argument-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "ScrollIntoViewOptions"
+                  }
+                ]
+              },
+              "default": {
+                "type": "dictionary"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "scroll",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "Promise",
+            "nullable": false,
+            "union": false,
+            "idlType": [
+              {
+                "type": "return-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "undefined"
+              }
+            ]
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "options",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "ScrollToOptions"
+              },
+              "default": {
+                "type": "dictionary"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "scroll",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "Promise",
+            "nullable": false,
+            "union": false,
+            "idlType": [
+              {
+                "type": "return-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "undefined"
+              }
+            ]
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "x",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "unrestricted double"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "y",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "unrestricted double"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "scrollTo",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "Promise",
+            "nullable": false,
+            "union": false,
+            "idlType": [
+              {
+                "type": "return-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "undefined"
+              }
+            ]
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "options",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "ScrollToOptions"
+              },
+              "default": {
+                "type": "dictionary"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "scrollTo",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "Promise",
+            "nullable": false,
+            "union": false,
+            "idlType": [
+              {
+                "type": "return-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "undefined"
+              }
+            ]
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "x",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "unrestricted double"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "y",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "unrestricted double"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "scrollBy",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "Promise",
+            "nullable": false,
+            "union": false,
+            "idlType": [
+              {
+                "type": "return-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "undefined"
+              }
+            ]
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "options",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "ScrollToOptions"
+              },
+              "default": {
+                "type": "dictionary"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "scrollBy",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "Promise",
+            "nullable": false,
+            "union": false,
+            "idlType": [
+              {
+                "type": "return-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "undefined"
+              }
+            ]
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "x",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "unrestricted double"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "y",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "unrestricted double"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "attribute",
+          "name": "scrollTop",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "unrestricted double"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "scrollLeft",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "unrestricted double"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "scrollWidth",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "long"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "scrollHeight",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "long"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "clientTop",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "long"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "clientLeft",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "long"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "clientWidth",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "long"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "clientHeight",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "long"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "currentCSSZoom",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "double"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "HTMLElement",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "scrollParent",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "Element"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "offsetParent",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "Element"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "offsetTop",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "long"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "offsetLeft",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "long"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "offsetWidth",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "long"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "offsetHeight",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "long"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Window",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "operation",
+          "name": "getDigitalGoodsService",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "Promise",
+            "nullable": false,
+            "union": false,
+            "idlType": [
+              {
+                "type": "return-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DigitalGoodsService"
+              }
+            ]
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "serviceProvider",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "SecureContext",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Window",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "documentPictureInPicture",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DocumentPictureInPicture"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "SameObject",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "SecureContext",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        }
+      ],
+      "extAttrs": [
+        {
+          "type": "extended-attribute",
+          "name": "Exposed",
+          "rhs": {
+            "type": "identifier",
+            "value": "Window"
+          },
+          "arguments": []
+        }
+      ],
+      "partial": true
+    },
+    {
       "type": "interface",
       "name": "Event",
       "inheritance": null,
@@ -482,7 +3119,6 @@
       "partial": false
     },
     {
-      "spec": "dom",
       "type": "interface",
       "name": "Window",
       "inheritance": null,
@@ -531,7 +3167,6 @@
       "partial": true
     },
     {
-      "spec": "dom",
       "type": "interface",
       "name": "EventTarget",
       "inheritance": null,
@@ -754,7 +3389,6 @@
       "partial": false
     },
     {
-      "spec": "dom",
       "type": "interface",
       "name": "Node",
       "inheritance": "EventTarget",
@@ -1842,7 +4476,6 @@
       "partial": false
     },
     {
-      "spec": "dom",
       "type": "interface",
       "name": "Document",
       "inheritance": "Node",
@@ -2933,7 +5566,6 @@
       "partial": false
     },
     {
-      "spec": "dom",
       "type": "interface",
       "name": "Element",
       "inheritance": "Node",
@@ -4216,7 +6848,649 @@
       "partial": false
     },
     {
-      "spec": "html",
+      "type": "interface",
+      "name": "HTMLElement",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "editContext",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "EditContext"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Element",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "elementTiming",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "HTMLInputElement",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "webkitdirectory",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "webkitEntries",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "FrozenArray",
+            "nullable": false,
+            "union": false,
+            "idlType": [
+              {
+                "type": "attribute-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "FileSystemEntry"
+              }
+            ]
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Window",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "fence",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "Fence"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Window",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "operation",
+          "name": "fetchLater",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "FetchLaterResult"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "input",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "RequestInfo"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "init",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DeferredRequestInit"
+              },
+              "default": {
+                "type": "dictionary"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "NewObject",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "SecureContext",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Window",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "operation",
+          "name": "showOpenFilePicker",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "Promise",
+            "nullable": false,
+            "union": false,
+            "idlType": [
+              {
+                "type": "return-type",
+                "extAttrs": [],
+                "generic": "sequence",
+                "nullable": false,
+                "union": false,
+                "idlType": [
+                  {
+                    "type": "return-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "FileSystemFileHandle"
+                  }
+                ]
+              }
+            ]
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "options",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "OpenFilePickerOptions"
+              },
+              "default": {
+                "type": "dictionary"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "showSaveFilePicker",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "Promise",
+            "nullable": false,
+            "union": false,
+            "idlType": [
+              {
+                "type": "return-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "FileSystemFileHandle"
+              }
+            ]
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "options",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "SaveFilePickerOptions"
+              },
+              "default": {
+                "type": "dictionary"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "showDirectoryPicker",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "Promise",
+            "nullable": false,
+            "union": false,
+            "idlType": [
+              {
+                "type": "return-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "FileSystemDirectoryHandle"
+              }
+            ]
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "options",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DirectoryPickerOptions"
+              },
+              "default": {
+                "type": "dictionary"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        }
+      ],
+      "extAttrs": [
+        {
+          "type": "extended-attribute",
+          "name": "SecureContext",
+          "rhs": null,
+          "arguments": []
+        }
+      ],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Document",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "operation",
+          "name": "measureElement",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "FontMetrics"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "element",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "Element"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "measureText",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "FontMetrics"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "text",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "styleMap",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "StylePropertyMapReadOnly"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Element",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "operation",
+          "name": "requestFullscreen",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "Promise",
+            "nullable": false,
+            "union": false,
+            "idlType": [
+              {
+                "type": "return-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "undefined"
+              }
+            ]
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "options",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "FullscreenOptions"
+              },
+              "default": {
+                "type": "dictionary"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "attribute",
+          "name": "onfullscreenchange",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onfullscreenerror",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Document",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "fullscreenEnabled",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "LegacyLenientSetter",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "fullscreen",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "LegacyLenientSetter",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Unscopable",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "operation",
+          "name": "exitFullscreen",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "Promise",
+            "nullable": false,
+            "union": false,
+            "idlType": [
+              {
+                "type": "return-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "undefined"
+              }
+            ]
+          },
+          "arguments": [],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "attribute",
+          "name": "onfullscreenchange",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onfullscreenerror",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
       "type": "interface",
       "name": "Document",
       "inheritance": null,
@@ -5357,7 +8631,6 @@
       "partial": true
     },
     {
-      "spec": "html",
       "type": "interface",
       "name": "HTMLElement",
       "inheritance": "Element",
@@ -6011,7 +9284,6 @@
       "partial": false
     },
     {
-      "spec": "html",
       "type": "interface",
       "name": "HTMLInputElement",
       "inheritance": "HTMLElement",
@@ -7445,7 +10717,6 @@
       "partial": false
     },
     {
-      "spec": "html",
       "type": "interface",
       "name": "Window",
       "inheritance": "EventTarget",
@@ -8425,7 +11696,6 @@
       "partial": false
     },
     {
-      "spec": "html",
       "type": "interface",
       "name": "Element",
       "inheritance": null,
@@ -8764,7 +12034,6 @@
       "partial": true
     },
     {
-      "spec": "html",
       "type": "interface",
       "name": "HTMLInputElement",
       "inheritance": null,
@@ -8830,7 +12099,6 @@
       "partial": true
     },
     {
-      "spec": "html",
       "type": "interface",
       "name": "Document",
       "inheritance": null,
@@ -9096,7 +12364,6 @@
       "partial": true
     },
     {
-      "spec": "html",
       "type": "interface",
       "name": "Window",
       "inheritance": null,
@@ -9162,11 +12429,2018 @@
       ],
       "extAttrs": [],
       "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "HTMLInputElement",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "capture",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Window",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "operation",
+          "name": "queryLocalFonts",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "Promise",
+            "nullable": false,
+            "union": false,
+            "idlType": [
+              {
+                "type": "return-type",
+                "extAttrs": [],
+                "generic": "sequence",
+                "nullable": false,
+                "union": false,
+                "idlType": [
+                  {
+                    "type": "return-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "FontData"
+                  }
+                ]
+              }
+            ]
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "options",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "QueryOptions"
+              },
+              "default": {
+                "type": "dictionary"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        }
+      ],
+      "extAttrs": [
+        {
+          "type": "extended-attribute",
+          "name": "SecureContext",
+          "rhs": null,
+          "arguments": []
+        }
+      ],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Window",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "onappinstalled",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onbeforeinstallprompt",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "EventTarget",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "operation",
+          "name": "when",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "Observable"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "type",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "options",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "ObservableEventListenerOptions"
+              },
+              "default": {
+                "type": "dictionary"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Window",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "ondeviceorientation",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "SecureContext",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Window",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "ondeviceorientationabsolute",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "SecureContext",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Window",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "ondevicemotion",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "SecureContext",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Document",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "onfreeze",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onresume",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "wasDiscarded",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Document",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "permissionsPolicy",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "PermissionsPolicy"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "SameObject",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Document",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "pictureInPictureEnabled",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "operation",
+          "name": "exitPictureInPicture",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "Promise",
+            "nullable": false,
+            "union": false,
+            "idlType": [
+              {
+                "type": "return-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "undefined"
+              }
+            ]
+          },
+          "arguments": [],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "NewObject",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Element",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "operation",
+          "name": "setPointerCapture",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "pointerId",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "long"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "releasePointerCapture",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "pointerId",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "long"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "hasPointerCapture",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "pointerId",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "long"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Element",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "operation",
+          "name": "requestPointerLock",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "Promise",
+            "nullable": false,
+            "union": false,
+            "idlType": [
+              {
+                "type": "return-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "undefined"
+              }
+            ]
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "options",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "PointerLockOptions"
+              },
+              "default": {
+                "type": "dictionary"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Document",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "onpointerlockchange",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onpointerlockerror",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "operation",
+          "name": "exitPointerLock",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [],
+          "extAttrs": [],
+          "special": ""
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Window",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "portalHost",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "PortalHost"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Document",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "prerendering",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "onprerenderingchange",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Window",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "operation",
+          "name": "requestIdleCallback",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "unsigned long"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "callback",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "IdleRequestCallback"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "options",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "IdleRequestOptions"
+              },
+              "default": {
+                "type": "dictionary"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "cancelIdleCallback",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "handle",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "unsigned long"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Document",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "operation",
+          "name": "hasUnpartitionedCookieAccess",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "Promise",
+            "nullable": false,
+            "union": false,
+            "idlType": [
+              {
+                "type": "return-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "boolean"
+              }
+            ]
+          },
+          "arguments": [],
+          "extAttrs": [],
+          "special": ""
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Document",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "fragmentDirective",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "FragmentDirective"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "SameObject",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Document",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "operation",
+          "name": "getSelection",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "Selection"
+          },
+          "arguments": [],
+          "extAttrs": [],
+          "special": ""
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Window",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "operation",
+          "name": "getSelection",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "Selection"
+          },
+          "arguments": [],
+          "extAttrs": [],
+          "special": ""
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Window",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "speechSynthesis",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "SpeechSynthesis"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "SameObject",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Document",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "operation",
+          "name": "hasStorageAccess",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "Promise",
+            "nullable": false,
+            "union": false,
+            "idlType": [
+              {
+                "type": "return-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "boolean"
+              }
+            ]
+          },
+          "arguments": [],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "requestStorageAccess",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "Promise",
+            "nullable": false,
+            "union": false,
+            "idlType": [
+              {
+                "type": "return-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "undefined"
+              }
+            ]
+          },
+          "arguments": [],
+          "extAttrs": [],
+          "special": ""
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Document",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "operation",
+          "name": "hasPrivateToken",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "Promise",
+            "nullable": false,
+            "union": false,
+            "idlType": [
+              {
+                "type": "return-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "boolean"
+              }
+            ]
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "issuer",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "USVString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "hasRedemptionRecord",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "Promise",
+            "nullable": false,
+            "union": false,
+            "idlType": [
+              {
+                "type": "return-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "boolean"
+              }
+            ]
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "issuer",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "USVString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Document",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "timeline",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DocumentTimeline"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Window",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "launchQueue",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "LaunchQueue"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Document",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "modelContext",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "ModelContext"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "SecureContext",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "SameObject",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface",
+      "name": "Window",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "operation",
+          "name": "getScreenDetails",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "Promise",
+            "nullable": false,
+            "union": false,
+            "idlType": [
+              {
+                "type": "return-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "ScreenDetails"
+              }
+            ]
+          },
+          "arguments": [],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "SecureContext",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "minimize",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "Promise",
+            "nullable": false,
+            "union": false,
+            "idlType": [
+              {
+                "type": "return-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "undefined"
+              }
+            ]
+          },
+          "arguments": [],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "SecureContext",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "maximize",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "Promise",
+            "nullable": false,
+            "union": false,
+            "idlType": [
+              {
+                "type": "return-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "undefined"
+              }
+            ]
+          },
+          "arguments": [],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "SecureContext",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "restore",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "Promise",
+            "nullable": false,
+            "union": false,
+            "idlType": [
+              {
+                "type": "return-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "undefined"
+              }
+            ]
+          },
+          "arguments": [],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "SecureContext",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "setResizable",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "Promise",
+            "nullable": false,
+            "union": false,
+            "idlType": [
+              {
+                "type": "return-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "undefined"
+              }
+            ]
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "resizable",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "boolean"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "SecureContext",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
     }
   ],
   "mixins": [
     {
-      "spec": "dom",
+      "type": "interface mixin",
+      "name": "WindowOrWorkerGlobalScope",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "indexedDB",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "IDBFactory"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "SameObject",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface mixin",
+      "name": "GlobalEventHandlers",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "onanimationstart",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onanimationiteration",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onanimationend",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onanimationcancel",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface mixin",
+      "name": "FontFaceSource",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "fonts",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "FontFaceSet"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        }
+      ],
+      "extAttrs": [],
+      "partial": false
+    },
+    {
+      "type": "interface mixin",
+      "name": "Region",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "regionOverset",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "CSSOMString"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "operation",
+          "name": "getRegionFlowRanges",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "sequence",
+            "nullable": true,
+            "union": false,
+            "idlType": [
+              {
+                "type": "return-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "Range"
+              }
+            ]
+          },
+          "arguments": [],
+          "extAttrs": [],
+          "special": ""
+        }
+      ],
+      "extAttrs": [],
+      "partial": false
+    },
+    {
+      "type": "interface mixin",
+      "name": "GlobalEventHandlers",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "onsnapchanged",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onsnapchanging",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface mixin",
+      "name": "GlobalEventHandlers",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "ontransitionrun",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ontransitionstart",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ontransitionend",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ontransitioncancel",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface mixin",
+      "name": "ElementCSSInlineStyle",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "attributeStyleMap",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "StylePropertyMap"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "SameObject",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface mixin",
+      "name": "DocumentOrShadowRoot",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "styleSheets",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "StyleSheetList"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "SameObject",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "adoptedStyleSheets",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "ObservableArray",
+            "nullable": false,
+            "union": false,
+            "idlType": [
+              {
+                "type": "attribute-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "CSSStyleSheet"
+              }
+            ]
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface mixin",
+      "name": "ElementCSSInlineStyle",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "style",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "CSSStyleProperties"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "SameObject",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "PutForwards",
+              "rhs": {
+                "type": "identifier",
+                "value": "cssText"
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        }
+      ],
+      "extAttrs": [],
+      "partial": false
+    },
+    {
+      "type": "interface mixin",
+      "name": "GeometryUtils",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "operation",
+          "name": "getBoxQuads",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "sequence",
+            "nullable": false,
+            "union": false,
+            "idlType": [
+              {
+                "type": "return-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMQuad"
+              }
+            ]
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "options",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "BoxQuadOptions"
+              },
+              "default": {
+                "type": "dictionary"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "convertQuadFromNode",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMQuad"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "quad",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMQuadInit"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "from",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "GeometryNode"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "options",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "ConvertCoordinateOptions"
+              },
+              "default": {
+                "type": "dictionary"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "convertRectFromNode",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMQuad"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "rect",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMRectReadOnly"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "from",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "GeometryNode"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "options",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "ConvertCoordinateOptions"
+              },
+              "default": {
+                "type": "dictionary"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "convertPointFromNode",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMPoint"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "point",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMPointInit"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "from",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "GeometryNode"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "options",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "ConvertCoordinateOptions"
+              },
+              "default": {
+                "type": "dictionary"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        }
+      ],
+      "extAttrs": [],
+      "partial": false
+    },
+    {
       "type": "interface mixin",
       "name": "NonElementParentNode",
       "inheritance": null,
@@ -9208,7 +14482,6 @@
       "partial": false
     },
     {
-      "spec": "dom",
       "type": "interface mixin",
       "name": "DocumentOrShadowRoot",
       "inheritance": null,
@@ -9233,7 +14506,6 @@
       "partial": false
     },
     {
-      "spec": "dom",
       "type": "interface mixin",
       "name": "ParentNode",
       "inheritance": null,
@@ -9622,7 +14894,6 @@
       "partial": false
     },
     {
-      "spec": "dom",
       "type": "interface mixin",
       "name": "NonDocumentTypeChildNode",
       "inheritance": null,
@@ -9662,7 +14933,6 @@
       "partial": false
     },
     {
-      "spec": "dom",
       "type": "interface mixin",
       "name": "ChildNode",
       "inheritance": null,
@@ -9886,7 +15156,6 @@
       "partial": false
     },
     {
-      "spec": "dom",
       "type": "interface mixin",
       "name": "Slottable",
       "inheritance": null,
@@ -9911,7 +15180,6 @@
       "partial": false
     },
     {
-      "spec": "dom",
       "type": "interface mixin",
       "name": "XPathEvaluatorBase",
       "inheritance": null,
@@ -10113,7 +15381,206 @@
       "partial": false
     },
     {
-      "spec": "html",
+      "type": "interface mixin",
+      "name": "GlobalEventHandlers",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "onfencedtreeclick",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface mixin",
+      "name": "WindowOrWorkerGlobalScope",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "operation",
+          "name": "fetch",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "Promise",
+            "nullable": false,
+            "union": false,
+            "idlType": [
+              {
+                "type": "return-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "Response"
+              }
+            ]
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "input",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "RequestInfo"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "init",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "RequestInit"
+              },
+              "default": {
+                "type": "dictionary"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "NewObject",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface mixin",
+      "name": "DocumentOrShadowRoot",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "fullscreenElement",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "Element"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "LegacyLenientSetter",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface mixin",
+      "name": "WindowEventHandlers",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "ongamepadconnected",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ongamepaddisconnected",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface mixin",
+      "name": "WindowOrWorkerGlobalScope",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "performance",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "Performance"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "Replaceable",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
       "type": "interface mixin",
       "name": "DocumentOrShadowRoot",
       "inheritance": null,
@@ -10138,7 +15605,6 @@
       "partial": true
     },
     {
-      "spec": "html",
       "type": "interface mixin",
       "name": "HTMLOrSVGOrMathMLElement",
       "inheritance": null,
@@ -10290,7 +15756,6 @@
       "partial": false
     },
     {
-      "spec": "html",
       "type": "interface mixin",
       "name": "ElementContentEditable",
       "inheritance": null,
@@ -10381,7 +15846,6 @@
       "partial": false
     },
     {
-      "spec": "html",
       "type": "interface mixin",
       "name": "PopoverTargetAttributes",
       "inheritance": null,
@@ -10444,7 +15908,6 @@
       "partial": false
     },
     {
-      "spec": "html",
       "type": "interface mixin",
       "name": "GlobalEventHandlers",
       "inheritance": null,
@@ -11608,7 +17071,6 @@
       "partial": false
     },
     {
-      "spec": "html",
       "type": "interface mixin",
       "name": "WindowEventHandlers",
       "inheritance": null,
@@ -11888,7 +17350,6 @@
       "partial": false
     },
     {
-      "spec": "html",
       "type": "interface mixin",
       "name": "WindowOrWorkerGlobalScope",
       "inheritance": null,
@@ -12514,7 +17975,6 @@
       "partial": false
     },
     {
-      "spec": "html",
       "type": "interface mixin",
       "name": "AnimationFrameProvider",
       "inheritance": null,
@@ -12588,7 +18048,6 @@
       "partial": false
     },
     {
-      "spec": "html",
       "type": "interface mixin",
       "name": "WindowSessionStorage",
       "inheritance": null,
@@ -12613,7 +18072,6 @@
       "partial": false
     },
     {
-      "spec": "html",
       "type": "interface mixin",
       "name": "WindowLocalStorage",
       "inheritance": null,
@@ -12636,146 +18094,2648 @@
       ],
       "extAttrs": [],
       "partial": false
+    },
+    {
+      "type": "interface mixin",
+      "name": "DocumentOrShadowRoot",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "pictureInPictureElement",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "Element"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface mixin",
+      "name": "GlobalEventHandlers",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "onpointerover",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onpointerenter",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onpointerdown",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onpointermove",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onpointerrawupdate",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "SecureContext",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onpointerup",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onpointercancel",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onpointerout",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onpointerleave",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ongotpointercapture",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onlostpointercapture",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface mixin",
+      "name": "DocumentOrShadowRoot",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "pointerLockElement",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "Element"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface mixin",
+      "name": "WindowEventHandlers",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "onportalactivate",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface mixin",
+      "name": "PushManagerAttribute",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "pushManager",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "PushManager"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        }
+      ],
+      "extAttrs": [
+        {
+          "type": "extended-attribute",
+          "name": "SecureContext",
+          "rhs": null,
+          "arguments": []
+        }
+      ],
+      "partial": false
+    },
+    {
+      "type": "interface mixin",
+      "name": "WindowOrWorkerGlobalScope",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "scheduler",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "Scheduler"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "Replaceable",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface mixin",
+      "name": "GlobalEventHandlers",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "onselectstart",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onselectionchange",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface mixin",
+      "name": "WindowOrWorkerGlobalScope",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "caches",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "CacheStorage"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "SecureContext",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "SameObject",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface mixin",
+      "name": "GlobalEventHandlers",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "ontouchstart",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ontouchend",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ontouchmove",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ontouchcancel",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface mixin",
+      "name": "WindowOrWorkerGlobalScope",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "trustedTypes",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "TrustedTypePolicyFactory"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface mixin",
+      "name": "ElementContentEditable",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "virtualKeyboardPolicy",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface mixin",
+      "name": "ARIAMixin",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "role",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ariaActiveDescendantElement",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "Element"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"aria-activedescendant\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ariaAtomic",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"aria-atomic\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ariaAutoComplete",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"aria-autocomplete\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ariaBrailleLabel",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"aria-braillelabel\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ariaBrailleRoleDescription",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"aria-brailleroledescription\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ariaBusy",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"aria-busy\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ariaChecked",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"aria-checked\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ariaColCount",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"aria-colcount\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ariaColIndex",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"aria-colindex\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ariaColIndexText",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"aria-colindextext\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ariaColSpan",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"aria-colspan\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ariaControlsElements",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "FrozenArray",
+            "nullable": true,
+            "union": false,
+            "idlType": [
+              {
+                "type": "attribute-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "Element"
+              }
+            ]
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"aria-controls\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ariaCurrent",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"aria-current\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ariaDescribedByElements",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "FrozenArray",
+            "nullable": true,
+            "union": false,
+            "idlType": [
+              {
+                "type": "attribute-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "Element"
+              }
+            ]
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"aria-describedby\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ariaDescription",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"aria-description\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ariaDetailsElements",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "FrozenArray",
+            "nullable": true,
+            "union": false,
+            "idlType": [
+              {
+                "type": "attribute-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "Element"
+              }
+            ]
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"aria-details\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ariaDisabled",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"aria-disabled\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ariaErrorMessageElements",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "FrozenArray",
+            "nullable": true,
+            "union": false,
+            "idlType": [
+              {
+                "type": "attribute-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "Element"
+              }
+            ]
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"aria-errormessage\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ariaExpanded",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"aria-expanded\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ariaFlowToElements",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "FrozenArray",
+            "nullable": true,
+            "union": false,
+            "idlType": [
+              {
+                "type": "attribute-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "Element"
+              }
+            ]
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"aria-flowto\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ariaHasPopup",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"aria-haspopup\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ariaHidden",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"aria-hidden\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ariaInvalid",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"aria-invalid\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ariaKeyShortcuts",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"aria-keyshortcuts\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ariaLabel",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"aria-label\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ariaLabelledByElements",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "FrozenArray",
+            "nullable": true,
+            "union": false,
+            "idlType": [
+              {
+                "type": "attribute-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "Element"
+              }
+            ]
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"aria-labelledby\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ariaLevel",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"aria-level\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ariaLive",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"aria-live\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ariaModal",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"aria-modal\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ariaMultiLine",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"aria-multiline\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ariaMultiSelectable",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"aria-multiselectable\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ariaOrientation",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"aria-orientation\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ariaOwnsElements",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "FrozenArray",
+            "nullable": true,
+            "union": false,
+            "idlType": [
+              {
+                "type": "attribute-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "Element"
+              }
+            ]
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"aria-owns\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ariaPlaceholder",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"aria-placeholder\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ariaPosInSet",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"aria-posinset\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ariaPressed",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"aria-pressed\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ariaReadOnly",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"aria-readonly\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ariaRelevant",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"aria-relevant\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ariaRequired",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"aria-required\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ariaRoleDescription",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"aria-roledescription\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ariaRowCount",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"aria-rowcount\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ariaRowIndex",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"aria-rowindex\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ariaRowIndexText",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"aria-rowindextext\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ariaRowSpan",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"aria-rowspan\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ariaSelected",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"aria-selected\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ariaSetSize",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"aria-setsize\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ariaSort",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"aria-sort\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ariaValueMax",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"aria-valuemax\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ariaValueMin",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"aria-valuemin\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ariaValueNow",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"aria-valuenow\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ariaValueText",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"aria-valuetext\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        }
+      ],
+      "extAttrs": [],
+      "partial": false
+    },
+    {
+      "type": "interface mixin",
+      "name": "ARIANotifyMixin",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "operation",
+          "name": "ariaNotify",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "announcement",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "options",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "AriaNotificationOptions"
+              },
+              "default": {
+                "type": "dictionary"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        }
+      ],
+      "extAttrs": [],
+      "partial": false
+    },
+    {
+      "type": "interface mixin",
+      "name": "Animatable",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "operation",
+          "name": "animate",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "Animation"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "keyframes",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": true,
+                "union": false,
+                "idlType": "object"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "options",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": true,
+                "idlType": [
+                  {
+                    "type": "argument-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "unrestricted double"
+                  },
+                  {
+                    "type": "argument-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "KeyframeAnimationOptions"
+                  }
+                ]
+              },
+              "default": {
+                "type": "dictionary"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "getAnimations",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "sequence",
+            "nullable": false,
+            "union": false,
+            "idlType": [
+              {
+                "type": "return-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "Animation"
+              }
+            ]
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "options",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "GetAnimationsOptions"
+              },
+              "default": {
+                "type": "dictionary"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        }
+      ],
+      "extAttrs": [],
+      "partial": false
+    },
+    {
+      "type": "interface mixin",
+      "name": "DocumentOrShadowRoot",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "operation",
+          "name": "getAnimations",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "sequence",
+            "nullable": false,
+            "union": false,
+            "idlType": [
+              {
+                "type": "return-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "Animation"
+              }
+            ]
+          },
+          "arguments": [],
+          "extAttrs": [],
+          "special": ""
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface mixin",
+      "name": "WindowOrWorkerGlobalScope",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "crypto",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "Crypto"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "SameObject",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "type": "interface mixin",
+      "name": "GlobalEventHandlers",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "onbeforexrselect",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
     }
   ],
   "includes": [
     {
-      "spec": "dom",
+      "type": "includes",
+      "extAttrs": [],
+      "target": "Document",
+      "includes": "FontFaceSource"
+    },
+    {
+      "type": "includes",
+      "extAttrs": [],
+      "target": "Element",
+      "includes": "Region"
+    },
+    {
+      "type": "includes",
+      "extAttrs": [],
+      "target": "HTMLElement",
+      "includes": "ElementCSSInlineStyle"
+    },
+    {
+      "type": "includes",
+      "extAttrs": [],
+      "target": "Element",
+      "includes": "GeometryUtils"
+    },
+    {
+      "type": "includes",
+      "extAttrs": [],
+      "target": "Document",
+      "includes": "GeometryUtils"
+    },
+    {
       "type": "includes",
       "extAttrs": [],
       "target": "Document",
       "includes": "NonElementParentNode"
     },
     {
-      "spec": "dom",
       "type": "includes",
       "extAttrs": [],
       "target": "Document",
       "includes": "DocumentOrShadowRoot"
     },
     {
-      "spec": "dom",
       "type": "includes",
       "extAttrs": [],
       "target": "Document",
       "includes": "ParentNode"
     },
     {
-      "spec": "dom",
       "type": "includes",
       "extAttrs": [],
       "target": "Element",
       "includes": "ParentNode"
     },
     {
-      "spec": "dom",
       "type": "includes",
       "extAttrs": [],
       "target": "Element",
       "includes": "NonDocumentTypeChildNode"
     },
     {
-      "spec": "dom",
       "type": "includes",
       "extAttrs": [],
       "target": "Element",
       "includes": "ChildNode"
     },
     {
-      "spec": "dom",
       "type": "includes",
       "extAttrs": [],
       "target": "Element",
       "includes": "Slottable"
     },
     {
-      "spec": "dom",
       "type": "includes",
       "extAttrs": [],
       "target": "Document",
       "includes": "XPathEvaluatorBase"
     },
     {
-      "spec": "html",
       "type": "includes",
       "extAttrs": [],
       "target": "Document",
       "includes": "GlobalEventHandlers"
     },
     {
-      "spec": "html",
       "type": "includes",
       "extAttrs": [],
       "target": "HTMLElement",
       "includes": "GlobalEventHandlers"
     },
     {
-      "spec": "html",
       "type": "includes",
       "extAttrs": [],
       "target": "HTMLElement",
       "includes": "ElementContentEditable"
     },
     {
-      "spec": "html",
       "type": "includes",
       "extAttrs": [],
       "target": "HTMLElement",
       "includes": "HTMLOrSVGOrMathMLElement"
     },
     {
-      "spec": "html",
       "type": "includes",
       "extAttrs": [],
       "target": "HTMLInputElement",
       "includes": "PopoverTargetAttributes"
     },
     {
-      "spec": "html",
       "type": "includes",
       "extAttrs": [],
       "target": "Window",
       "includes": "GlobalEventHandlers"
     },
     {
-      "spec": "html",
       "type": "includes",
       "extAttrs": [],
       "target": "Window",
       "includes": "WindowEventHandlers"
     },
     {
-      "spec": "html",
       "type": "includes",
       "extAttrs": [],
       "target": "Window",
       "includes": "WindowOrWorkerGlobalScope"
     },
     {
-      "spec": "html",
       "type": "includes",
       "extAttrs": [],
       "target": "Window",
       "includes": "AnimationFrameProvider"
     },
     {
-      "spec": "html",
       "type": "includes",
       "extAttrs": [],
       "target": "Window",
       "includes": "WindowSessionStorage"
     },
     {
-      "spec": "html",
       "type": "includes",
       "extAttrs": [],
       "target": "Window",
       "includes": "WindowLocalStorage"
+    },
+    {
+      "type": "includes",
+      "extAttrs": [],
+      "target": "Window",
+      "includes": "PushManagerAttribute"
+    },
+    {
+      "type": "includes",
+      "extAttrs": [],
+      "target": "Element",
+      "includes": "ARIAMixin"
+    },
+    {
+      "type": "includes",
+      "extAttrs": [],
+      "target": "Element",
+      "includes": "ARIANotifyMixin"
+    },
+    {
+      "type": "includes",
+      "extAttrs": [],
+      "target": "Document",
+      "includes": "ARIANotifyMixin"
+    },
+    {
+      "type": "includes",
+      "extAttrs": [],
+      "target": "Element",
+      "includes": "Animatable"
     }
   ],
   "typedefs": [
     {
-      "spec": "html",
       "type": "typedef",
       "name": "CanvasImageSource",
       "idlType": {
@@ -12838,7 +20798,6 @@
       "extAttrs": []
     },
     {
-      "spec": "hr-time",
       "type": "typedef",
       "name": "DOMHighResTimeStamp",
       "idlType": {
@@ -12852,7 +20811,6 @@
       "extAttrs": []
     },
     {
-      "spec": "html",
       "type": "typedef",
       "name": "EventHandler",
       "idlType": {
@@ -12866,7 +20824,52 @@
       "extAttrs": []
     },
     {
-      "spec": "html",
+      "type": "typedef",
+      "name": "GeometryNode",
+      "idlType": {
+        "type": "typedef-type",
+        "extAttrs": [],
+        "generic": "",
+        "nullable": false,
+        "union": true,
+        "idlType": [
+          {
+            "type": "typedef-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "Text"
+          },
+          {
+            "type": "typedef-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "Element"
+          },
+          {
+            "type": "typedef-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "CSSPseudoElement"
+          },
+          {
+            "type": "typedef-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "Document"
+          }
+        ]
+      },
+      "extAttrs": []
+    },
+    {
       "type": "typedef",
       "name": "HTMLOrSVGImageElement",
       "idlType": {
@@ -12897,7 +20900,6 @@
       "extAttrs": []
     },
     {
-      "spec": "html",
       "type": "typedef",
       "name": "HTMLOrSVGScriptElement",
       "idlType": {
@@ -12928,7 +20930,6 @@
       "extAttrs": []
     },
     {
-      "spec": "html",
       "type": "typedef",
       "name": "ImageBitmapSource",
       "idlType": {
@@ -12967,7 +20968,6 @@
       "extAttrs": []
     },
     {
-      "spec": "html",
       "type": "typedef",
       "name": "OnBeforeUnloadEventHandler",
       "idlType": {
@@ -12981,7 +20981,6 @@
       "extAttrs": []
     },
     {
-      "spec": "html",
       "type": "typedef",
       "name": "OnErrorEventHandler",
       "idlType": {
@@ -12995,7 +20994,36 @@
       "extAttrs": []
     },
     {
-      "spec": "html",
+      "type": "typedef",
+      "name": "RequestInfo",
+      "idlType": {
+        "type": "typedef-type",
+        "extAttrs": [],
+        "generic": "",
+        "nullable": false,
+        "union": true,
+        "idlType": [
+          {
+            "type": "typedef-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "Request"
+          },
+          {
+            "type": "typedef-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "USVString"
+          }
+        ]
+      },
+      "extAttrs": []
+    },
+    {
       "type": "typedef",
       "name": "TimerHandler",
       "idlType": {
@@ -13034,7 +21062,6 @@
       "extAttrs": []
     },
     {
-      "spec": "trusted-types",
       "type": "typedef",
       "name": "TrustedType",
       "idlType": {

--- a/wado-compiler/lib/web/dom.webidl.json
+++ b/wado-compiler/lib/web/dom.webidl.json
@@ -1,0 +1,13076 @@
+{
+  "webref": "3.83.1",
+  "package": "dom",
+  "slice": [
+    "EventTarget",
+    "Event",
+    "Node",
+    "Element",
+    "HTMLElement",
+    "HTMLInputElement",
+    "Document",
+    "Window"
+  ],
+  "interfaces": [
+    {
+      "spec": "dom",
+      "type": "interface",
+      "name": "Event",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "constructor",
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "type",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "eventInitDict",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "EventInit"
+              },
+              "default": {
+                "type": "dictionary"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": []
+        },
+        {
+          "type": "attribute",
+          "name": "type",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "target",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "EventTarget"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "srcElement",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "EventTarget"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "currentTarget",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "EventTarget"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "operation",
+          "name": "composedPath",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "sequence",
+            "nullable": false,
+            "union": false,
+            "idlType": [
+              {
+                "type": "return-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "EventTarget"
+              }
+            ]
+          },
+          "arguments": [],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "const",
+          "name": "NONE",
+          "idlType": {
+            "type": "const-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "unsigned short"
+          },
+          "extAttrs": [],
+          "value": {
+            "type": "number",
+            "value": "0"
+          }
+        },
+        {
+          "type": "const",
+          "name": "CAPTURING_PHASE",
+          "idlType": {
+            "type": "const-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "unsigned short"
+          },
+          "extAttrs": [],
+          "value": {
+            "type": "number",
+            "value": "1"
+          }
+        },
+        {
+          "type": "const",
+          "name": "AT_TARGET",
+          "idlType": {
+            "type": "const-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "unsigned short"
+          },
+          "extAttrs": [],
+          "value": {
+            "type": "number",
+            "value": "2"
+          }
+        },
+        {
+          "type": "const",
+          "name": "BUBBLING_PHASE",
+          "idlType": {
+            "type": "const-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "unsigned short"
+          },
+          "extAttrs": [],
+          "value": {
+            "type": "number",
+            "value": "3"
+          }
+        },
+        {
+          "type": "attribute",
+          "name": "eventPhase",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "unsigned short"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "operation",
+          "name": "stopPropagation",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "attribute",
+          "name": "cancelBubble",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "operation",
+          "name": "stopImmediatePropagation",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "attribute",
+          "name": "bubbles",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "cancelable",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "returnValue",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "operation",
+          "name": "preventDefault",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "attribute",
+          "name": "defaultPrevented",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "composed",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "isTrusted",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "LegacyUnforgeable",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "timeStamp",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMHighResTimeStamp"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "operation",
+          "name": "initEvent",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "type",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "bubbles",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "boolean"
+              },
+              "default": {
+                "type": "boolean",
+                "value": false
+              },
+              "optional": true,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "cancelable",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "boolean"
+              },
+              "default": {
+                "type": "boolean",
+                "value": false
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        }
+      ],
+      "extAttrs": [
+        {
+          "type": "extended-attribute",
+          "name": "Exposed",
+          "rhs": {
+            "type": "*",
+            "value": null
+          },
+          "arguments": []
+        }
+      ],
+      "partial": false
+    },
+    {
+      "spec": "dom",
+      "type": "interface",
+      "name": "Window",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "event",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": true,
+            "idlType": [
+              {
+                "type": "attribute-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "Event"
+              },
+              {
+                "type": "attribute-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "undefined"
+              }
+            ]
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "Replaceable",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "spec": "dom",
+      "type": "interface",
+      "name": "EventTarget",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "constructor",
+          "arguments": [],
+          "extAttrs": []
+        },
+        {
+          "type": "operation",
+          "name": "addEventListener",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "type",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "callback",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": true,
+                "union": false,
+                "idlType": "EventListener"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "options",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": true,
+                "idlType": [
+                  {
+                    "type": "argument-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "AddEventListenerOptions"
+                  },
+                  {
+                    "type": "argument-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "boolean"
+                  }
+                ]
+              },
+              "default": {
+                "type": "dictionary"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "removeEventListener",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "type",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "callback",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": true,
+                "union": false,
+                "idlType": "EventListener"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "options",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": true,
+                "idlType": [
+                  {
+                    "type": "argument-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "EventListenerOptions"
+                  },
+                  {
+                    "type": "argument-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "boolean"
+                  }
+                ]
+              },
+              "default": {
+                "type": "dictionary"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "dispatchEvent",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "event",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "Event"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        }
+      ],
+      "extAttrs": [
+        {
+          "type": "extended-attribute",
+          "name": "Exposed",
+          "rhs": {
+            "type": "*",
+            "value": null
+          },
+          "arguments": []
+        }
+      ],
+      "partial": false
+    },
+    {
+      "spec": "dom",
+      "type": "interface",
+      "name": "Node",
+      "inheritance": "EventTarget",
+      "members": [
+        {
+          "type": "const",
+          "name": "ELEMENT_NODE",
+          "idlType": {
+            "type": "const-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "unsigned short"
+          },
+          "extAttrs": [],
+          "value": {
+            "type": "number",
+            "value": "1"
+          }
+        },
+        {
+          "type": "const",
+          "name": "ATTRIBUTE_NODE",
+          "idlType": {
+            "type": "const-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "unsigned short"
+          },
+          "extAttrs": [],
+          "value": {
+            "type": "number",
+            "value": "2"
+          }
+        },
+        {
+          "type": "const",
+          "name": "TEXT_NODE",
+          "idlType": {
+            "type": "const-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "unsigned short"
+          },
+          "extAttrs": [],
+          "value": {
+            "type": "number",
+            "value": "3"
+          }
+        },
+        {
+          "type": "const",
+          "name": "CDATA_SECTION_NODE",
+          "idlType": {
+            "type": "const-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "unsigned short"
+          },
+          "extAttrs": [],
+          "value": {
+            "type": "number",
+            "value": "4"
+          }
+        },
+        {
+          "type": "const",
+          "name": "ENTITY_REFERENCE_NODE",
+          "idlType": {
+            "type": "const-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "unsigned short"
+          },
+          "extAttrs": [],
+          "value": {
+            "type": "number",
+            "value": "5"
+          }
+        },
+        {
+          "type": "const",
+          "name": "ENTITY_NODE",
+          "idlType": {
+            "type": "const-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "unsigned short"
+          },
+          "extAttrs": [],
+          "value": {
+            "type": "number",
+            "value": "6"
+          }
+        },
+        {
+          "type": "const",
+          "name": "PROCESSING_INSTRUCTION_NODE",
+          "idlType": {
+            "type": "const-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "unsigned short"
+          },
+          "extAttrs": [],
+          "value": {
+            "type": "number",
+            "value": "7"
+          }
+        },
+        {
+          "type": "const",
+          "name": "COMMENT_NODE",
+          "idlType": {
+            "type": "const-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "unsigned short"
+          },
+          "extAttrs": [],
+          "value": {
+            "type": "number",
+            "value": "8"
+          }
+        },
+        {
+          "type": "const",
+          "name": "DOCUMENT_NODE",
+          "idlType": {
+            "type": "const-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "unsigned short"
+          },
+          "extAttrs": [],
+          "value": {
+            "type": "number",
+            "value": "9"
+          }
+        },
+        {
+          "type": "const",
+          "name": "DOCUMENT_TYPE_NODE",
+          "idlType": {
+            "type": "const-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "unsigned short"
+          },
+          "extAttrs": [],
+          "value": {
+            "type": "number",
+            "value": "10"
+          }
+        },
+        {
+          "type": "const",
+          "name": "DOCUMENT_FRAGMENT_NODE",
+          "idlType": {
+            "type": "const-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "unsigned short"
+          },
+          "extAttrs": [],
+          "value": {
+            "type": "number",
+            "value": "11"
+          }
+        },
+        {
+          "type": "const",
+          "name": "NOTATION_NODE",
+          "idlType": {
+            "type": "const-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "unsigned short"
+          },
+          "extAttrs": [],
+          "value": {
+            "type": "number",
+            "value": "12"
+          }
+        },
+        {
+          "type": "attribute",
+          "name": "nodeType",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "unsigned short"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "nodeName",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "baseURI",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "USVString"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "isConnected",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "ownerDocument",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "Document"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "operation",
+          "name": "getRootNode",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "Node"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "options",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "GetRootNodeOptions"
+              },
+              "default": {
+                "type": "dictionary"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "attribute",
+          "name": "parentNode",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "Node"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "parentElement",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "Element"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "operation",
+          "name": "hasChildNodes",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "arguments": [],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "attribute",
+          "name": "childNodes",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "NodeList"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "SameObject",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "firstChild",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "Node"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "lastChild",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "Node"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "previousSibling",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "Node"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "nextSibling",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "Node"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "nodeValue",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "textContent",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "operation",
+          "name": "normalize",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "cloneNode",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "Node"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "subtree",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "boolean"
+              },
+              "default": {
+                "type": "boolean",
+                "value": false
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "NewObject",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "isEqualNode",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "otherNode",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": true,
+                "union": false,
+                "idlType": "Node"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "isSameNode",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "otherNode",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": true,
+                "union": false,
+                "idlType": "Node"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "const",
+          "name": "DOCUMENT_POSITION_DISCONNECTED",
+          "idlType": {
+            "type": "const-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "unsigned short"
+          },
+          "extAttrs": [],
+          "value": {
+            "type": "number",
+            "value": "0x01"
+          }
+        },
+        {
+          "type": "const",
+          "name": "DOCUMENT_POSITION_PRECEDING",
+          "idlType": {
+            "type": "const-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "unsigned short"
+          },
+          "extAttrs": [],
+          "value": {
+            "type": "number",
+            "value": "0x02"
+          }
+        },
+        {
+          "type": "const",
+          "name": "DOCUMENT_POSITION_FOLLOWING",
+          "idlType": {
+            "type": "const-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "unsigned short"
+          },
+          "extAttrs": [],
+          "value": {
+            "type": "number",
+            "value": "0x04"
+          }
+        },
+        {
+          "type": "const",
+          "name": "DOCUMENT_POSITION_CONTAINS",
+          "idlType": {
+            "type": "const-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "unsigned short"
+          },
+          "extAttrs": [],
+          "value": {
+            "type": "number",
+            "value": "0x08"
+          }
+        },
+        {
+          "type": "const",
+          "name": "DOCUMENT_POSITION_CONTAINED_BY",
+          "idlType": {
+            "type": "const-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "unsigned short"
+          },
+          "extAttrs": [],
+          "value": {
+            "type": "number",
+            "value": "0x10"
+          }
+        },
+        {
+          "type": "const",
+          "name": "DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC",
+          "idlType": {
+            "type": "const-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "unsigned short"
+          },
+          "extAttrs": [],
+          "value": {
+            "type": "number",
+            "value": "0x20"
+          }
+        },
+        {
+          "type": "operation",
+          "name": "compareDocumentPosition",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "unsigned short"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "other",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "Node"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "contains",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "other",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": true,
+                "union": false,
+                "idlType": "Node"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "lookupPrefix",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "namespace",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": true,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "lookupNamespaceURI",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "prefix",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": true,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "isDefaultNamespace",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "namespace",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": true,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "insertBefore",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "Node"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "node",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "Node"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "child",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": true,
+                "union": false,
+                "idlType": "Node"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "appendChild",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "Node"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "node",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "Node"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "replaceChild",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "Node"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "node",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "Node"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "child",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "Node"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "removeChild",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "Node"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "child",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "Node"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        }
+      ],
+      "extAttrs": [
+        {
+          "type": "extended-attribute",
+          "name": "Exposed",
+          "rhs": {
+            "type": "identifier",
+            "value": "Window"
+          },
+          "arguments": []
+        }
+      ],
+      "partial": false
+    },
+    {
+      "spec": "dom",
+      "type": "interface",
+      "name": "Document",
+      "inheritance": "Node",
+      "members": [
+        {
+          "type": "constructor",
+          "arguments": [],
+          "extAttrs": []
+        },
+        {
+          "type": "attribute",
+          "name": "implementation",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMImplementation"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "SameObject",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "URL",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "USVString"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "documentURI",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "USVString"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "compatMode",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "characterSet",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "charset",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "inputEncoding",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "contentType",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "doctype",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DocumentType"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "documentElement",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "Element"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "operation",
+          "name": "getElementsByTagName",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "HTMLCollection"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "qualifiedName",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "getElementsByTagNameNS",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "HTMLCollection"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "namespace",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": true,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "localName",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "getElementsByClassName",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "HTMLCollection"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "classNames",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "createElement",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "Element"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "localName",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "options",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": true,
+                "idlType": [
+                  {
+                    "type": "argument-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "DOMString"
+                  },
+                  {
+                    "type": "argument-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "ElementCreationOptions"
+                  }
+                ]
+              },
+              "default": {
+                "type": "dictionary"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "NewObject",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "createElementNS",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "Element"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "namespace",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": true,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "qualifiedName",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "options",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": true,
+                "idlType": [
+                  {
+                    "type": "argument-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "DOMString"
+                  },
+                  {
+                    "type": "argument-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "ElementCreationOptions"
+                  }
+                ]
+              },
+              "default": {
+                "type": "dictionary"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "NewObject",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "createDocumentFragment",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DocumentFragment"
+          },
+          "arguments": [],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "NewObject",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "createTextNode",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "Text"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "data",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "NewObject",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "createCDATASection",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "CDATASection"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "data",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "NewObject",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "createComment",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "Comment"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "data",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "NewObject",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "createProcessingInstruction",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "ProcessingInstruction"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "target",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "data",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "NewObject",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "importNode",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "Node"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "node",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "Node"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "options",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": true,
+                "idlType": [
+                  {
+                    "type": "argument-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "boolean"
+                  },
+                  {
+                    "type": "argument-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "ImportNodeOptions"
+                  }
+                ]
+              },
+              "default": {
+                "type": "boolean",
+                "value": false
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "NewObject",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "adoptNode",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "Node"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "node",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "Node"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "createAttribute",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "Attr"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "localName",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "NewObject",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "createAttributeNS",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "Attr"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "namespace",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": true,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "qualifiedName",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "NewObject",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "createEvent",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "Event"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "interface",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "NewObject",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "createRange",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "Range"
+          },
+          "arguments": [],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "NewObject",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "createNodeIterator",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "NodeIterator"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "root",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "Node"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "whatToShow",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "unsigned long"
+              },
+              "default": {
+                "type": "number",
+                "value": "0xFFFFFFFF"
+              },
+              "optional": true,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "filter",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": true,
+                "union": false,
+                "idlType": "NodeFilter"
+              },
+              "default": {
+                "type": "null"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "NewObject",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "createTreeWalker",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "TreeWalker"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "root",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "Node"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "whatToShow",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "unsigned long"
+              },
+              "default": {
+                "type": "number",
+                "value": "0xFFFFFFFF"
+              },
+              "optional": true,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "filter",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": true,
+                "union": false,
+                "idlType": "NodeFilter"
+              },
+              "default": {
+                "type": "null"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "NewObject",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        }
+      ],
+      "extAttrs": [
+        {
+          "type": "extended-attribute",
+          "name": "Exposed",
+          "rhs": {
+            "type": "identifier",
+            "value": "Window"
+          },
+          "arguments": []
+        }
+      ],
+      "partial": false
+    },
+    {
+      "spec": "dom",
+      "type": "interface",
+      "name": "Element",
+      "inheritance": "Node",
+      "members": [
+        {
+          "type": "attribute",
+          "name": "namespaceURI",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "prefix",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "localName",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "tagName",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "id",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "className",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "classList",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMTokenList"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "SameObject",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "PutForwards",
+              "rhs": {
+                "type": "identifier",
+                "value": "value"
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "slot",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Unscopable",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "operation",
+          "name": "hasAttributes",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "arguments": [],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "attribute",
+          "name": "attributes",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "NamedNodeMap"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "SameObject",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "operation",
+          "name": "getAttributeNames",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "sequence",
+            "nullable": false,
+            "union": false,
+            "idlType": [
+              {
+                "type": "return-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              }
+            ]
+          },
+          "arguments": [],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "getAttribute",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "qualifiedName",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "getAttributeNS",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "namespace",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": true,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "localName",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "setAttribute",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "qualifiedName",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "value",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": true,
+                "idlType": [
+                  {
+                    "type": "argument-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "TrustedType"
+                  },
+                  {
+                    "type": "argument-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "DOMString"
+                  }
+                ]
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "setAttributeNS",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "namespace",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": true,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "qualifiedName",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "value",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": true,
+                "idlType": [
+                  {
+                    "type": "argument-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "TrustedType"
+                  },
+                  {
+                    "type": "argument-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "DOMString"
+                  }
+                ]
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "removeAttribute",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "qualifiedName",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "removeAttributeNS",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "namespace",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": true,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "localName",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "toggleAttribute",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "qualifiedName",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "force",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "boolean"
+              },
+              "default": null,
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "hasAttribute",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "qualifiedName",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "hasAttributeNS",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "namespace",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": true,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "localName",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "getAttributeNode",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "Attr"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "qualifiedName",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "getAttributeNodeNS",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "Attr"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "namespace",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": true,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "localName",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "setAttributeNode",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "Attr"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "attr",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "Attr"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "setAttributeNodeNS",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "Attr"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "attr",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "Attr"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "removeAttributeNode",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "Attr"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "attr",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "Attr"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "attachShadow",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "ShadowRoot"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "init",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "ShadowRootInit"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "attribute",
+          "name": "shadowRoot",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "ShadowRoot"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "customElementRegistry",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "CustomElementRegistry"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "operation",
+          "name": "closest",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "Element"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "selectors",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "matches",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "selectors",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "webkitMatchesSelector",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "selectors",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "getElementsByTagName",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "HTMLCollection"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "qualifiedName",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "getElementsByTagNameNS",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "HTMLCollection"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "namespace",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": true,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "localName",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "getElementsByClassName",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "HTMLCollection"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "classNames",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "insertAdjacentElement",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "Element"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "where",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "element",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "Element"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "insertAdjacentText",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "where",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "data",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        }
+      ],
+      "extAttrs": [
+        {
+          "type": "extended-attribute",
+          "name": "Exposed",
+          "rhs": {
+            "type": "identifier",
+            "value": "Window"
+          },
+          "arguments": []
+        }
+      ],
+      "partial": false
+    },
+    {
+      "spec": "html",
+      "type": "interface",
+      "name": "Document",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "operation",
+          "name": "parseHTMLUnsafe",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "Document"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "html",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": true,
+                "idlType": [
+                  {
+                    "type": "argument-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "TrustedHTML"
+                  },
+                  {
+                    "type": "argument-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "DOMString"
+                  }
+                ]
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "options",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "ParseHTMLUnsafeOptions"
+              },
+              "default": {
+                "type": "dictionary"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": "static"
+        },
+        {
+          "type": "operation",
+          "name": "parseHTML",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "Document"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "html",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "options",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "SetHTMLOptions"
+              },
+              "default": {
+                "type": "dictionary"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": "static"
+        },
+        {
+          "type": "attribute",
+          "name": "location",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "Location"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "PutForwards",
+              "rhs": {
+                "type": "identifier",
+                "value": "href"
+              },
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "LegacyUnforgeable",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "domain",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "USVString"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "referrer",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "USVString"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "cookie",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "USVString"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "lastModified",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "readyState",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DocumentReadyState"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "operation",
+          "name": "",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "object"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "name",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": "getter"
+        },
+        {
+          "type": "attribute",
+          "name": "title",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "dir",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "body",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "HTMLElement"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "head",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "HTMLHeadElement"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "images",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "HTMLCollection"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "SameObject",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "embeds",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "HTMLCollection"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "SameObject",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "plugins",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "HTMLCollection"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "SameObject",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "links",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "HTMLCollection"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "SameObject",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "forms",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "HTMLCollection"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "SameObject",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "scripts",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "HTMLCollection"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "SameObject",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "operation",
+          "name": "getElementsByName",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "NodeList"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "elementName",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "attribute",
+          "name": "currentScript",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "HTMLOrSVGScriptElement"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "operation",
+          "name": "open",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "Document"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "unused1",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": true,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "unused2",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "open",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "WindowProxy"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "url",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "USVString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "name",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "features",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "close",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "write",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "text",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": true,
+                "idlType": [
+                  {
+                    "type": "argument-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "TrustedHTML"
+                  },
+                  {
+                    "type": "argument-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "DOMString"
+                  }
+                ]
+              },
+              "default": null,
+              "optional": false,
+              "variadic": true
+            }
+          ],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "writeln",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "text",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": true,
+                "idlType": [
+                  {
+                    "type": "argument-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "TrustedHTML"
+                  },
+                  {
+                    "type": "argument-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "DOMString"
+                  }
+                ]
+              },
+              "default": null,
+              "optional": false,
+              "variadic": true
+            }
+          ],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        },
+        {
+          "type": "attribute",
+          "name": "defaultView",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "WindowProxy"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "operation",
+          "name": "hasFocus",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "arguments": [],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "attribute",
+          "name": "designMode",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "operation",
+          "name": "execCommand",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "commandId",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "showUI",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "boolean"
+              },
+              "default": {
+                "type": "boolean",
+                "value": false
+              },
+              "optional": true,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "value",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": {
+                "type": "string",
+                "value": ""
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "queryCommandEnabled",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "commandId",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "queryCommandIndeterm",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "commandId",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "queryCommandState",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "commandId",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "queryCommandSupported",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "commandId",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "queryCommandValue",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "commandId",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "attribute",
+          "name": "hidden",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "visibilityState",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DocumentVisibilityState"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "onreadystatechange",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "LegacyLenientThis",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onvisibilitychange",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        }
+      ],
+      "extAttrs": [
+        {
+          "type": "extended-attribute",
+          "name": "LegacyOverrideBuiltIns",
+          "rhs": null,
+          "arguments": []
+        }
+      ],
+      "partial": true
+    },
+    {
+      "spec": "html",
+      "type": "interface",
+      "name": "HTMLElement",
+      "inheritance": "Element",
+      "members": [
+        {
+          "type": "constructor",
+          "arguments": [],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "HTMLConstructor",
+              "rhs": null,
+              "arguments": []
+            }
+          ]
+        },
+        {
+          "type": "attribute",
+          "name": "title",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "lang",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "translate",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "dir",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "hidden",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": true,
+            "idlType": [
+              {
+                "type": "attribute-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "boolean"
+              },
+              {
+                "type": "attribute-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "unrestricted double"
+              },
+              {
+                "type": "attribute-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              }
+            ]
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "inert",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "operation",
+          "name": "click",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "attribute",
+          "name": "accessKey",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "accessKeyLabel",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "draggable",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "spellcheck",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "writingSuggestions",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "ReflectSetter",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "autocapitalize",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "ReflectSetter",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "autocorrect",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "innerText",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [
+              {
+                "type": "extended-attribute",
+                "name": "LegacyNullToEmptyString",
+                "rhs": null,
+                "arguments": []
+              }
+            ],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "outerText",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [
+              {
+                "type": "extended-attribute",
+                "name": "LegacyNullToEmptyString",
+                "rhs": null,
+                "arguments": []
+              }
+            ],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "operation",
+          "name": "attachInternals",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "ElementInternals"
+          },
+          "arguments": [],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "showPopover",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "options",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "ShowPopoverOptions"
+              },
+              "default": {
+                "type": "dictionary"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "hidePopover",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "togglePopover",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "options",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": true,
+                "idlType": [
+                  {
+                    "type": "argument-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "TogglePopoverOptions"
+                  },
+                  {
+                    "type": "argument-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "boolean"
+                  }
+                ]
+              },
+              "default": {
+                "type": "dictionary"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "attribute",
+          "name": "popover",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "headingOffset",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "unsigned long"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "ReflectRange",
+              "rhs": {
+                "type": "integer-list",
+                "value": [
+                  {
+                    "value": "0"
+                  },
+                  {
+                    "value": "8"
+                  }
+                ]
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "headingReset",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        }
+      ],
+      "extAttrs": [
+        {
+          "type": "extended-attribute",
+          "name": "Exposed",
+          "rhs": {
+            "type": "identifier",
+            "value": "Window"
+          },
+          "arguments": []
+        }
+      ],
+      "partial": false
+    },
+    {
+      "spec": "html",
+      "type": "interface",
+      "name": "HTMLInputElement",
+      "inheritance": "HTMLElement",
+      "members": [
+        {
+          "type": "constructor",
+          "arguments": [],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "HTMLConstructor",
+              "rhs": null,
+              "arguments": []
+            }
+          ]
+        },
+        {
+          "type": "attribute",
+          "name": "accept",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "alpha",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "alt",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "autocomplete",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "ReflectSetter",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "defaultChecked",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"checked\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "checked",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "colorSpace",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "dirName",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "disabled",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "form",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "HTMLFormElement"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "files",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "FileList"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "formAction",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "USVString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "ReflectSetter",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "formEnctype",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "formMethod",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "formNoValidate",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "formTarget",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "height",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "unsigned long"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "ReflectSetter",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "indeterminate",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "list",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "HTMLDataListElement"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "max",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "maxLength",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "long"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "ReflectNonNegative",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "min",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "minLength",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "long"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "ReflectNonNegative",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "multiple",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "name",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "pattern",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "placeholder",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "readOnly",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "required",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "size",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "unsigned long"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "src",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "USVString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "ReflectURL",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "step",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "type",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "defaultValue",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"value\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "value",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [
+              {
+                "type": "extended-attribute",
+                "name": "LegacyNullToEmptyString",
+                "rhs": null,
+                "arguments": []
+              }
+            ],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "valueAsDate",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "object"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "valueAsNumber",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "unrestricted double"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "width",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "unsigned long"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "ReflectSetter",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "operation",
+          "name": "stepUp",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "n",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "long"
+              },
+              "default": {
+                "type": "number",
+                "value": "1"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "stepDown",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "n",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "long"
+              },
+              "default": {
+                "type": "number",
+                "value": "1"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "attribute",
+          "name": "willValidate",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "validity",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "ValidityState"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "validationMessage",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "operation",
+          "name": "checkValidity",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "arguments": [],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "reportValidity",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "arguments": [],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "setCustomValidity",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "error",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "attribute",
+          "name": "labels",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "NodeList"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "operation",
+          "name": "select",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "attribute",
+          "name": "selectionStart",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "unsigned long"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "selectionEnd",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "unsigned long"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "selectionDirection",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "operation",
+          "name": "setRangeText",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "replacement",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "setRangeText",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "replacement",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "start",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "unsigned long"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "end",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "unsigned long"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "selectionMode",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "SelectionMode"
+              },
+              "default": {
+                "type": "string",
+                "value": "preserve"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "setSelectionRange",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "start",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "unsigned long"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "end",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "unsigned long"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "direction",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "showPicker",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [],
+          "extAttrs": [],
+          "special": ""
+        }
+      ],
+      "extAttrs": [
+        {
+          "type": "extended-attribute",
+          "name": "Exposed",
+          "rhs": {
+            "type": "identifier",
+            "value": "Window"
+          },
+          "arguments": []
+        }
+      ],
+      "partial": false
+    },
+    {
+      "spec": "html",
+      "type": "interface",
+      "name": "Window",
+      "inheritance": "EventTarget",
+      "members": [
+        {
+          "type": "attribute",
+          "name": "window",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "WindowProxy"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "LegacyUnforgeable",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "self",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "WindowProxy"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "Replaceable",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "document",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "Document"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "LegacyUnforgeable",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "name",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "location",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "Location"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "PutForwards",
+              "rhs": {
+                "type": "identifier",
+                "value": "href"
+              },
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "LegacyUnforgeable",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "history",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "History"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "navigation",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "Navigation"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "Replaceable",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "customElements",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "CustomElementRegistry"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "locationbar",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "BarProp"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "Replaceable",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "menubar",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "BarProp"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "Replaceable",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "personalbar",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "BarProp"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "Replaceable",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "scrollbars",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "BarProp"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "Replaceable",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "statusbar",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "BarProp"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "Replaceable",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "toolbar",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "BarProp"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "Replaceable",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "status",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "operation",
+          "name": "close",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "attribute",
+          "name": "closed",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "operation",
+          "name": "stop",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "focus",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "blur",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "attribute",
+          "name": "frames",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "WindowProxy"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "Replaceable",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "length",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "unsigned long"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "Replaceable",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "top",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "WindowProxy"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "LegacyUnforgeable",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "opener",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "any"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "parent",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "WindowProxy"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "Replaceable",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "frameElement",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "Element"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "operation",
+          "name": "open",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "WindowProxy"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "url",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "USVString"
+              },
+              "default": {
+                "type": "string",
+                "value": ""
+              },
+              "optional": true,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "target",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": {
+                "type": "string",
+                "value": "_blank"
+              },
+              "optional": true,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "features",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [
+                  {
+                    "type": "extended-attribute",
+                    "name": "LegacyNullToEmptyString",
+                    "rhs": null,
+                    "arguments": []
+                  }
+                ],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": {
+                "type": "string",
+                "value": ""
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "object"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "name",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": "getter"
+        },
+        {
+          "type": "attribute",
+          "name": "navigator",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "Navigator"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "clientInformation",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "Navigator"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "Replaceable",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "originAgentCluster",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "operation",
+          "name": "alert",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "alert",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "message",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "confirm",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "message",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": {
+                "type": "string",
+                "value": ""
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "prompt",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "message",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": {
+                "type": "string",
+                "value": ""
+              },
+              "optional": true,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "default",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": {
+                "type": "string",
+                "value": ""
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "print",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "postMessage",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "message",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "any"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "targetOrigin",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "USVString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "transfer",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "sequence",
+                "nullable": false,
+                "union": false,
+                "idlType": [
+                  {
+                    "type": "argument-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "object"
+                  }
+                ]
+              },
+              "default": {
+                "type": "sequence",
+                "value": []
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "postMessage",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "message",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "any"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "options",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "WindowPostMessageOptions"
+              },
+              "default": {
+                "type": "dictionary"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        }
+      ],
+      "extAttrs": [
+        {
+          "type": "extended-attribute",
+          "name": "Global",
+          "rhs": {
+            "type": "identifier",
+            "value": "Window"
+          },
+          "arguments": []
+        },
+        {
+          "type": "extended-attribute",
+          "name": "Exposed",
+          "rhs": {
+            "type": "identifier",
+            "value": "Window"
+          },
+          "arguments": []
+        },
+        {
+          "type": "extended-attribute",
+          "name": "LegacyUnenumerableNamedProperties",
+          "rhs": null,
+          "arguments": []
+        }
+      ],
+      "partial": false
+    },
+    {
+      "spec": "html",
+      "type": "interface",
+      "name": "Element",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "operation",
+          "name": "setHTML",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "html",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "options",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "SetHTMLOptions"
+              },
+              "default": {
+                "type": "dictionary"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "setHTMLUnsafe",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "html",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": true,
+                "idlType": [
+                  {
+                    "type": "argument-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "TrustedHTML"
+                  },
+                  {
+                    "type": "argument-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "DOMString"
+                  }
+                ]
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "options",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "SetHTMLUnsafeOptions"
+              },
+              "default": {
+                "type": "dictionary"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "getHTML",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "options",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "GetHTMLOptions"
+              },
+              "default": {
+                "type": "dictionary"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "attribute",
+          "name": "innerHTML",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": true,
+            "idlType": [
+              {
+                "type": "attribute-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "TrustedHTML"
+              },
+              {
+                "type": "attribute-type",
+                "extAttrs": [
+                  {
+                    "type": "extended-attribute",
+                    "name": "LegacyNullToEmptyString",
+                    "rhs": null,
+                    "arguments": []
+                  }
+                ],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              }
+            ]
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "outerHTML",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": true,
+            "idlType": [
+              {
+                "type": "attribute-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "TrustedHTML"
+              },
+              {
+                "type": "attribute-type",
+                "extAttrs": [
+                  {
+                    "type": "extended-attribute",
+                    "name": "LegacyNullToEmptyString",
+                    "rhs": null,
+                    "arguments": []
+                  }
+                ],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              }
+            ]
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "operation",
+          "name": "insertAdjacentHTML",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "position",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "string",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": true,
+                "idlType": [
+                  {
+                    "type": "argument-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "TrustedHTML"
+                  },
+                  {
+                    "type": "argument-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "DOMString"
+                  }
+                ]
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "spec": "html",
+      "type": "interface",
+      "name": "HTMLInputElement",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "align",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "useMap",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "spec": "html",
+      "type": "interface",
+      "name": "Document",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "fgColor",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [
+              {
+                "type": "extended-attribute",
+                "name": "LegacyNullToEmptyString",
+                "rhs": null,
+                "arguments": []
+              }
+            ],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "linkColor",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [
+              {
+                "type": "extended-attribute",
+                "name": "LegacyNullToEmptyString",
+                "rhs": null,
+                "arguments": []
+              }
+            ],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "vlinkColor",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [
+              {
+                "type": "extended-attribute",
+                "name": "LegacyNullToEmptyString",
+                "rhs": null,
+                "arguments": []
+              }
+            ],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "alinkColor",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [
+              {
+                "type": "extended-attribute",
+                "name": "LegacyNullToEmptyString",
+                "rhs": null,
+                "arguments": []
+              }
+            ],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "bgColor",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [
+              {
+                "type": "extended-attribute",
+                "name": "LegacyNullToEmptyString",
+                "rhs": null,
+                "arguments": []
+              }
+            ],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "anchors",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "HTMLCollection"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "SameObject",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "applets",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "HTMLCollection"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "SameObject",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "operation",
+          "name": "clear",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "captureEvents",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "releaseEvents",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "attribute",
+          "name": "all",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "HTMLAllCollection"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "SameObject",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "spec": "html",
+      "type": "interface",
+      "name": "Window",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "operation",
+          "name": "captureEvents",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "releaseEvents",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "attribute",
+          "name": "external",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "External"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "Replaceable",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "SameObject",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    }
+  ],
+  "mixins": [
+    {
+      "spec": "dom",
+      "type": "interface mixin",
+      "name": "NonElementParentNode",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "operation",
+          "name": "getElementById",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "Element"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "elementId",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        }
+      ],
+      "extAttrs": [],
+      "partial": false
+    },
+    {
+      "spec": "dom",
+      "type": "interface mixin",
+      "name": "DocumentOrShadowRoot",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "customElementRegistry",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "CustomElementRegistry"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        }
+      ],
+      "extAttrs": [],
+      "partial": false
+    },
+    {
+      "spec": "dom",
+      "type": "interface mixin",
+      "name": "ParentNode",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "children",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "HTMLCollection"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "SameObject",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "firstElementChild",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "Element"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "lastElementChild",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "Element"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "childElementCount",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "unsigned long"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "operation",
+          "name": "prepend",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "nodes",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": true,
+                "idlType": [
+                  {
+                    "type": "argument-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "Node"
+                  },
+                  {
+                    "type": "argument-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "DOMString"
+                  }
+                ]
+              },
+              "default": null,
+              "optional": false,
+              "variadic": true
+            }
+          ],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Unscopable",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "append",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "nodes",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": true,
+                "idlType": [
+                  {
+                    "type": "argument-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "Node"
+                  },
+                  {
+                    "type": "argument-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "DOMString"
+                  }
+                ]
+              },
+              "default": null,
+              "optional": false,
+              "variadic": true
+            }
+          ],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Unscopable",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "replaceChildren",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "nodes",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": true,
+                "idlType": [
+                  {
+                    "type": "argument-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "Node"
+                  },
+                  {
+                    "type": "argument-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "DOMString"
+                  }
+                ]
+              },
+              "default": null,
+              "optional": false,
+              "variadic": true
+            }
+          ],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Unscopable",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "moveBefore",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "node",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "Node"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "child",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": true,
+                "union": false,
+                "idlType": "Node"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "querySelector",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "Element"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "selectors",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "querySelectorAll",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "NodeList"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "selectors",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "NewObject",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        }
+      ],
+      "extAttrs": [],
+      "partial": false
+    },
+    {
+      "spec": "dom",
+      "type": "interface mixin",
+      "name": "NonDocumentTypeChildNode",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "previousElementSibling",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "Element"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "nextElementSibling",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "Element"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        }
+      ],
+      "extAttrs": [],
+      "partial": false
+    },
+    {
+      "spec": "dom",
+      "type": "interface mixin",
+      "name": "ChildNode",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "operation",
+          "name": "before",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "nodes",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": true,
+                "idlType": [
+                  {
+                    "type": "argument-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "Node"
+                  },
+                  {
+                    "type": "argument-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "DOMString"
+                  }
+                ]
+              },
+              "default": null,
+              "optional": false,
+              "variadic": true
+            }
+          ],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Unscopable",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "after",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "nodes",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": true,
+                "idlType": [
+                  {
+                    "type": "argument-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "Node"
+                  },
+                  {
+                    "type": "argument-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "DOMString"
+                  }
+                ]
+              },
+              "default": null,
+              "optional": false,
+              "variadic": true
+            }
+          ],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Unscopable",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "replaceWith",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "nodes",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": true,
+                "idlType": [
+                  {
+                    "type": "argument-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "Node"
+                  },
+                  {
+                    "type": "argument-type",
+                    "extAttrs": [],
+                    "generic": "",
+                    "nullable": false,
+                    "union": false,
+                    "idlType": "DOMString"
+                  }
+                ]
+              },
+              "default": null,
+              "optional": false,
+              "variadic": true
+            }
+          ],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Unscopable",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "remove",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Unscopable",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        }
+      ],
+      "extAttrs": [],
+      "partial": false
+    },
+    {
+      "spec": "dom",
+      "type": "interface mixin",
+      "name": "Slottable",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "assignedSlot",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "HTMLSlotElement"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        }
+      ],
+      "extAttrs": [],
+      "partial": false
+    },
+    {
+      "spec": "dom",
+      "type": "interface mixin",
+      "name": "XPathEvaluatorBase",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "operation",
+          "name": "createExpression",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "XPathExpression"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "expression",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "resolver",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": true,
+                "union": false,
+                "idlType": "XPathNSResolver"
+              },
+              "default": {
+                "type": "null"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "NewObject",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "createNSResolver",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "Node"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "nodeResolver",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "Node"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "evaluate",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "XPathResult"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "expression",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "contextNode",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "Node"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "resolver",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": true,
+                "union": false,
+                "idlType": "XPathNSResolver"
+              },
+              "default": {
+                "type": "null"
+              },
+              "optional": true,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "type",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "unsigned short"
+              },
+              "default": {
+                "type": "number",
+                "value": "0"
+              },
+              "optional": true,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "result",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": true,
+                "union": false,
+                "idlType": "XPathResult"
+              },
+              "default": {
+                "type": "null"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        }
+      ],
+      "extAttrs": [],
+      "partial": false
+    },
+    {
+      "spec": "html",
+      "type": "interface mixin",
+      "name": "DocumentOrShadowRoot",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "activeElement",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "Element"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        }
+      ],
+      "extAttrs": [],
+      "partial": true
+    },
+    {
+      "spec": "html",
+      "type": "interface mixin",
+      "name": "HTMLOrSVGOrMathMLElement",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "dataset",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMStringMap"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "SameObject",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "nonce",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "autofocus",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "tabIndex",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "long"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "ReflectSetter",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "operation",
+          "name": "focus",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "options",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "FocusOptions"
+              },
+              "default": {
+                "type": "dictionary"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "blur",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [],
+          "extAttrs": [],
+          "special": ""
+        }
+      ],
+      "extAttrs": [],
+      "partial": false
+    },
+    {
+      "spec": "html",
+      "type": "interface mixin",
+      "name": "ElementContentEditable",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "contentEditable",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "enterKeyHint",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "isContentEditable",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "inputMode",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        }
+      ],
+      "extAttrs": [],
+      "partial": false
+    },
+    {
+      "spec": "html",
+      "type": "interface mixin",
+      "name": "PopoverTargetAttributes",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "popoverTargetElement",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": true,
+            "union": false,
+            "idlType": "Element"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            },
+            {
+              "type": "extended-attribute",
+              "name": "Reflect",
+              "rhs": {
+                "type": "string",
+                "value": "\"popovertarget\""
+              },
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "popoverTargetAction",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "CEReactions",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        }
+      ],
+      "extAttrs": [],
+      "partial": false
+    },
+    {
+      "spec": "html",
+      "type": "interface mixin",
+      "name": "GlobalEventHandlers",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "onabort",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onauxclick",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onbeforeinput",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onbeforematch",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onbeforetoggle",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onblur",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "oncancel",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "oncanplay",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "oncanplaythrough",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onchange",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onclick",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onclose",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "oncommand",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "oncontextlost",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "oncontextmenu",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "oncontextrestored",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "oncopy",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "oncuechange",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "oncut",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ondblclick",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ondrag",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ondragend",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ondragenter",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ondragleave",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ondragover",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ondragstart",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ondrop",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ondurationchange",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onemptied",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onended",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onerror",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "OnErrorEventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onfocus",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onformdata",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "oninput",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "oninvalid",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onkeydown",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onkeypress",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onkeyup",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onload",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onloadeddata",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onloadedmetadata",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onloadstart",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onmousedown",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onmouseenter",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "LegacyLenientThis",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onmouseleave",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "LegacyLenientThis",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onmousemove",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onmouseout",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onmouseover",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onmouseup",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onpaste",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onpause",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onplay",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onplaying",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onprogress",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onratechange",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onreset",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onresize",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onscroll",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onscrollend",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onsecuritypolicyviolation",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onseeked",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onseeking",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onselect",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onslotchange",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onstalled",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onsubmit",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onsuspend",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ontimeupdate",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ontoggle",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onvolumechange",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onwaiting",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onwebkitanimationend",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onwebkitanimationiteration",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onwebkitanimationstart",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onwebkittransitionend",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onwheel",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        }
+      ],
+      "extAttrs": [],
+      "partial": false
+    },
+    {
+      "spec": "html",
+      "type": "interface mixin",
+      "name": "WindowEventHandlers",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "onafterprint",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onbeforeprint",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onbeforeunload",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "OnBeforeUnloadEventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onhashchange",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onlanguagechange",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onmessage",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onmessageerror",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onoffline",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "ononline",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onpagehide",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onpagereveal",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onpageshow",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onpageswap",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onpopstate",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onrejectionhandled",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onstorage",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onunhandledrejection",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        },
+        {
+          "type": "attribute",
+          "name": "onunload",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "EventHandler"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": false
+        }
+      ],
+      "extAttrs": [],
+      "partial": false
+    },
+    {
+      "spec": "html",
+      "type": "interface mixin",
+      "name": "WindowOrWorkerGlobalScope",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "origin",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "USVString"
+          },
+          "extAttrs": [
+            {
+              "type": "extended-attribute",
+              "name": "Replaceable",
+              "rhs": null,
+              "arguments": []
+            }
+          ],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "isSecureContext",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "attribute",
+          "name": "crossOriginIsolated",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "boolean"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        },
+        {
+          "type": "operation",
+          "name": "reportError",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "e",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "any"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "btoa",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "data",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "atob",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "ByteString"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "data",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "DOMString"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "setTimeout",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "long"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "handler",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "TimerHandler"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "timeout",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "long"
+              },
+              "default": {
+                "type": "number",
+                "value": "0"
+              },
+              "optional": true,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "arguments",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "any"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": true
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "clearTimeout",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "id",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "long"
+              },
+              "default": {
+                "type": "number",
+                "value": "0"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "setInterval",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "long"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "handler",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "TimerHandler"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "timeout",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "long"
+              },
+              "default": {
+                "type": "number",
+                "value": "0"
+              },
+              "optional": true,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "arguments",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "any"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": true
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "clearInterval",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "id",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "long"
+              },
+              "default": {
+                "type": "number",
+                "value": "0"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "queueMicrotask",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "callback",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "VoidFunction"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "createImageBitmap",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "Promise",
+            "nullable": false,
+            "union": false,
+            "idlType": [
+              {
+                "type": "return-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "ImageBitmap"
+              }
+            ]
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "image",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "ImageBitmapSource"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "options",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "ImageBitmapOptions"
+              },
+              "default": {
+                "type": "dictionary"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "createImageBitmap",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "Promise",
+            "nullable": false,
+            "union": false,
+            "idlType": [
+              {
+                "type": "return-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "ImageBitmap"
+              }
+            ]
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "image",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "ImageBitmapSource"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "sx",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "long"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "sy",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "long"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "sw",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "long"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "sh",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "long"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "options",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "ImageBitmapOptions"
+              },
+              "default": {
+                "type": "dictionary"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "structuredClone",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "any"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "value",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "any"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            },
+            {
+              "type": "argument",
+              "name": "options",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "StructuredSerializeOptions"
+              },
+              "default": {
+                "type": "dictionary"
+              },
+              "optional": true,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        }
+      ],
+      "extAttrs": [],
+      "partial": false
+    },
+    {
+      "spec": "html",
+      "type": "interface mixin",
+      "name": "AnimationFrameProvider",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "operation",
+          "name": "requestAnimationFrame",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "unsigned long"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "callback",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "FrameRequestCallback"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        },
+        {
+          "type": "operation",
+          "name": "cancelAnimationFrame",
+          "idlType": {
+            "type": "return-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "undefined"
+          },
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "handle",
+              "extAttrs": [],
+              "idlType": {
+                "type": "argument-type",
+                "extAttrs": [],
+                "generic": "",
+                "nullable": false,
+                "union": false,
+                "idlType": "unsigned long"
+              },
+              "default": null,
+              "optional": false,
+              "variadic": false
+            }
+          ],
+          "extAttrs": [],
+          "special": ""
+        }
+      ],
+      "extAttrs": [],
+      "partial": false
+    },
+    {
+      "spec": "html",
+      "type": "interface mixin",
+      "name": "WindowSessionStorage",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "sessionStorage",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "Storage"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        }
+      ],
+      "extAttrs": [],
+      "partial": false
+    },
+    {
+      "spec": "html",
+      "type": "interface mixin",
+      "name": "WindowLocalStorage",
+      "inheritance": null,
+      "members": [
+        {
+          "type": "attribute",
+          "name": "localStorage",
+          "idlType": {
+            "type": "attribute-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "Storage"
+          },
+          "extAttrs": [],
+          "special": "",
+          "readonly": true
+        }
+      ],
+      "extAttrs": [],
+      "partial": false
+    }
+  ],
+  "includes": [
+    {
+      "spec": "dom",
+      "type": "includes",
+      "extAttrs": [],
+      "target": "Document",
+      "includes": "NonElementParentNode"
+    },
+    {
+      "spec": "dom",
+      "type": "includes",
+      "extAttrs": [],
+      "target": "Document",
+      "includes": "DocumentOrShadowRoot"
+    },
+    {
+      "spec": "dom",
+      "type": "includes",
+      "extAttrs": [],
+      "target": "Document",
+      "includes": "ParentNode"
+    },
+    {
+      "spec": "dom",
+      "type": "includes",
+      "extAttrs": [],
+      "target": "Element",
+      "includes": "ParentNode"
+    },
+    {
+      "spec": "dom",
+      "type": "includes",
+      "extAttrs": [],
+      "target": "Element",
+      "includes": "NonDocumentTypeChildNode"
+    },
+    {
+      "spec": "dom",
+      "type": "includes",
+      "extAttrs": [],
+      "target": "Element",
+      "includes": "ChildNode"
+    },
+    {
+      "spec": "dom",
+      "type": "includes",
+      "extAttrs": [],
+      "target": "Element",
+      "includes": "Slottable"
+    },
+    {
+      "spec": "dom",
+      "type": "includes",
+      "extAttrs": [],
+      "target": "Document",
+      "includes": "XPathEvaluatorBase"
+    },
+    {
+      "spec": "html",
+      "type": "includes",
+      "extAttrs": [],
+      "target": "Document",
+      "includes": "GlobalEventHandlers"
+    },
+    {
+      "spec": "html",
+      "type": "includes",
+      "extAttrs": [],
+      "target": "HTMLElement",
+      "includes": "GlobalEventHandlers"
+    },
+    {
+      "spec": "html",
+      "type": "includes",
+      "extAttrs": [],
+      "target": "HTMLElement",
+      "includes": "ElementContentEditable"
+    },
+    {
+      "spec": "html",
+      "type": "includes",
+      "extAttrs": [],
+      "target": "HTMLElement",
+      "includes": "HTMLOrSVGOrMathMLElement"
+    },
+    {
+      "spec": "html",
+      "type": "includes",
+      "extAttrs": [],
+      "target": "HTMLInputElement",
+      "includes": "PopoverTargetAttributes"
+    },
+    {
+      "spec": "html",
+      "type": "includes",
+      "extAttrs": [],
+      "target": "Window",
+      "includes": "GlobalEventHandlers"
+    },
+    {
+      "spec": "html",
+      "type": "includes",
+      "extAttrs": [],
+      "target": "Window",
+      "includes": "WindowEventHandlers"
+    },
+    {
+      "spec": "html",
+      "type": "includes",
+      "extAttrs": [],
+      "target": "Window",
+      "includes": "WindowOrWorkerGlobalScope"
+    },
+    {
+      "spec": "html",
+      "type": "includes",
+      "extAttrs": [],
+      "target": "Window",
+      "includes": "AnimationFrameProvider"
+    },
+    {
+      "spec": "html",
+      "type": "includes",
+      "extAttrs": [],
+      "target": "Window",
+      "includes": "WindowSessionStorage"
+    },
+    {
+      "spec": "html",
+      "type": "includes",
+      "extAttrs": [],
+      "target": "Window",
+      "includes": "WindowLocalStorage"
+    }
+  ],
+  "typedefs": [
+    {
+      "spec": "html",
+      "type": "typedef",
+      "name": "CanvasImageSource",
+      "idlType": {
+        "type": "typedef-type",
+        "extAttrs": [],
+        "generic": "",
+        "nullable": false,
+        "union": true,
+        "idlType": [
+          {
+            "type": "typedef-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "HTMLOrSVGImageElement"
+          },
+          {
+            "type": "typedef-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "HTMLVideoElement"
+          },
+          {
+            "type": "typedef-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "HTMLCanvasElement"
+          },
+          {
+            "type": "typedef-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "ImageBitmap"
+          },
+          {
+            "type": "typedef-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "OffscreenCanvas"
+          },
+          {
+            "type": "typedef-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "VideoFrame"
+          }
+        ]
+      },
+      "extAttrs": []
+    },
+    {
+      "spec": "hr-time",
+      "type": "typedef",
+      "name": "DOMHighResTimeStamp",
+      "idlType": {
+        "type": "typedef-type",
+        "extAttrs": [],
+        "generic": "",
+        "nullable": false,
+        "union": false,
+        "idlType": "double"
+      },
+      "extAttrs": []
+    },
+    {
+      "spec": "html",
+      "type": "typedef",
+      "name": "EventHandler",
+      "idlType": {
+        "type": "typedef-type",
+        "extAttrs": [],
+        "generic": "",
+        "nullable": true,
+        "union": false,
+        "idlType": "EventHandlerNonNull"
+      },
+      "extAttrs": []
+    },
+    {
+      "spec": "html",
+      "type": "typedef",
+      "name": "HTMLOrSVGImageElement",
+      "idlType": {
+        "type": "typedef-type",
+        "extAttrs": [],
+        "generic": "",
+        "nullable": false,
+        "union": true,
+        "idlType": [
+          {
+            "type": "typedef-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "HTMLImageElement"
+          },
+          {
+            "type": "typedef-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "SVGImageElement"
+          }
+        ]
+      },
+      "extAttrs": []
+    },
+    {
+      "spec": "html",
+      "type": "typedef",
+      "name": "HTMLOrSVGScriptElement",
+      "idlType": {
+        "type": "typedef-type",
+        "extAttrs": [],
+        "generic": "",
+        "nullable": false,
+        "union": true,
+        "idlType": [
+          {
+            "type": "typedef-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "HTMLScriptElement"
+          },
+          {
+            "type": "typedef-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "SVGScriptElement"
+          }
+        ]
+      },
+      "extAttrs": []
+    },
+    {
+      "spec": "html",
+      "type": "typedef",
+      "name": "ImageBitmapSource",
+      "idlType": {
+        "type": "typedef-type",
+        "extAttrs": [],
+        "generic": "",
+        "nullable": false,
+        "union": true,
+        "idlType": [
+          {
+            "type": "typedef-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "CanvasImageSource"
+          },
+          {
+            "type": "typedef-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "Blob"
+          },
+          {
+            "type": "typedef-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "ImageData"
+          }
+        ]
+      },
+      "extAttrs": []
+    },
+    {
+      "spec": "html",
+      "type": "typedef",
+      "name": "OnBeforeUnloadEventHandler",
+      "idlType": {
+        "type": "typedef-type",
+        "extAttrs": [],
+        "generic": "",
+        "nullable": true,
+        "union": false,
+        "idlType": "OnBeforeUnloadEventHandlerNonNull"
+      },
+      "extAttrs": []
+    },
+    {
+      "spec": "html",
+      "type": "typedef",
+      "name": "OnErrorEventHandler",
+      "idlType": {
+        "type": "typedef-type",
+        "extAttrs": [],
+        "generic": "",
+        "nullable": true,
+        "union": false,
+        "idlType": "OnErrorEventHandlerNonNull"
+      },
+      "extAttrs": []
+    },
+    {
+      "spec": "html",
+      "type": "typedef",
+      "name": "TimerHandler",
+      "idlType": {
+        "type": "typedef-type",
+        "extAttrs": [],
+        "generic": "",
+        "nullable": false,
+        "union": true,
+        "idlType": [
+          {
+            "type": "typedef-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "DOMString"
+          },
+          {
+            "type": "typedef-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "Function"
+          },
+          {
+            "type": "typedef-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "TrustedScript"
+          }
+        ]
+      },
+      "extAttrs": []
+    },
+    {
+      "spec": "trusted-types",
+      "type": "typedef",
+      "name": "TrustedType",
+      "idlType": {
+        "type": "typedef-type",
+        "extAttrs": [],
+        "generic": "",
+        "nullable": false,
+        "union": true,
+        "idlType": [
+          {
+            "type": "typedef-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "TrustedHTML"
+          },
+          {
+            "type": "typedef-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "TrustedScript"
+          },
+          {
+            "type": "typedef-type",
+            "extAttrs": [],
+            "generic": "",
+            "nullable": false,
+            "union": false,
+            "idlType": "TrustedScriptURL"
+          }
+        ]
+      },
+      "extAttrs": []
+    }
+  ]
+}

--- a/wado-compiler/src/codegen/component.rs
+++ b/wado-compiler/src/codegen/component.rs
@@ -769,6 +769,22 @@ fn collect_resources_in_type(
     }
 }
 
+/// A named type the shared generator spells as a declared CM type: a record,
+/// or a local newtype kept as its alias so the boundary matches `wado wit`.
+fn has_named_cm_form(ty: &Type, registry: &crate::component_model::CmInterfaceRegistry) -> bool {
+    let Type::Named(named) = ty else {
+        return false;
+    };
+    let source = registry.source_interface(named);
+    source.as_deref().is_some_and(|s| {
+        registry
+            .get_struct_fields_by_source(s, &named.name)
+            .is_some()
+    }) || registry
+        .local_newtype_base(source.as_deref(), &named.name)
+        .is_some()
+}
+
 fn wado_type_to_cm_val_type(
     ty: &Type,
     stream_type_idx: Option<u32>,
@@ -2666,26 +2682,12 @@ fn generate_cm_imports(
                         let resolved_ty = project
                             .cm_interface_registry
                             .resolve_type_preserving_local_newtypes(ty);
-                        let is_struct = matches!(&resolved_ty, Type::Named(named)
-                        if project.cm_interface_registry.source_interface(named).is_some_and(|s| {
-                            project
-                                .cm_interface_registry
-                                .get_struct_fields_by_source(&s, &named.name)
-                                .is_some()
-                        }));
-                        // A local newtype routes through `ast_type_to_cm` like a
-                        // struct so its named alias reaches the boundary.
-                        let is_local_newtype = matches!(&resolved_ty, Type::Named(named)
-                        if project
-                            .cm_interface_registry
-                            .local_newtype_base(
-                                project.cm_interface_registry.source_interface(named).as_deref(),
-                                &named.name,
-                            )
-                            .is_some());
-                        // So does a composite (`Option<T>`, `List<T>`, a tuple):
-                        // `wado_type_to_cm_val_type` spells only the flat shapes
-                        // and the pre-defined `Stream` / `Result` params.
+                        let is_named =
+                            has_named_cm_form(&resolved_ty, &project.cm_interface_registry);
+                        // A composite (`Option<T>`, `List<T>`, a tuple) needs the
+                        // shared generator too: `wado_type_to_cm_val_type` spells
+                        // only the flat shapes and the pre-defined `Stream` /
+                        // `Result` params.
                         let is_composite = match &resolved_ty {
                             Type::Generic(g) => g.name != "Stream" && g.name != "Result",
                             Type::Tuple(_) => true,
@@ -2698,29 +2700,27 @@ fn generate_cm_imports(
                             | Type::Infer(_)
                             | Type::Error(_) => false,
                         };
-                        let val_type =
-                            if is_component_import || is_struct || is_local_newtype || is_composite
-                            {
-                                let mut sink = crate::component_model::InstanceSink {
-                                    it: &mut instance_type,
-                                    next_idx: &mut local_type_idx,
-                                };
-                                shared_type_gen.ast_type_to_cm(
-                                    &mut sink,
-                                    &resolved_ty,
-                                    &project.cm_interface_registry,
-                                    &resource_exports,
-                                )
-                            } else {
-                                wado_type_to_cm_val_type(
-                                    &resolved_ty,
-                                    stream_type_idx,
-                                    result_param_type_idx,
-                                    &enum_export_indices,
-                                    &flags_export_indices,
-                                    &borrow_resource_type_indices,
-                                )
+                        let val_type = if is_component_import || is_named || is_composite {
+                            let mut sink = crate::component_model::InstanceSink {
+                                it: &mut instance_type,
+                                next_idx: &mut local_type_idx,
                             };
+                            shared_type_gen.ast_type_to_cm(
+                                &mut sink,
+                                &resolved_ty,
+                                &project.cm_interface_registry,
+                                &resource_exports,
+                            )
+                        } else {
+                            wado_type_to_cm_val_type(
+                                &resolved_ty,
+                                stream_type_idx,
+                                result_param_type_idx,
+                                &enum_export_indices,
+                                &flags_export_indices,
+                                &borrow_resource_type_indices,
+                            )
+                        };
                         (cm_name.clone(), val_type)
                     })
                     .collect();
@@ -2735,22 +2735,9 @@ fn generate_cm_imports(
                     let resolved_ty = project
                         .cm_interface_registry
                         .resolve_type_preserving_local_newtypes(ty);
-                    let is_struct = matches!(&resolved_ty, Type::Named(named)
-                    if project.cm_interface_registry.source_interface(named).is_some_and(|s| {
-                        project
-                            .cm_interface_registry
-                            .get_struct_fields_by_source(&s, &named.name)
-                            .is_some()
-                    }));
-                    let is_local_newtype = matches!(&resolved_ty, Type::Named(named)
-                    if project
-                        .cm_interface_registry
-                        .local_newtype_base(
-                                project.cm_interface_registry.source_interface(named).as_deref(),
-                                &named.name,
-                            )
-                        .is_some());
-                    if is_component_import || is_struct || is_local_newtype {
+                    if is_component_import
+                        || has_named_cm_form(&resolved_ty, &project.cm_interface_registry)
+                    {
                         let mut sink = crate::component_model::InstanceSink {
                             it: &mut instance_type,
                             next_idx: &mut local_type_idx,

--- a/wado-compiler/src/codegen/component.rs
+++ b/wado-compiler/src/codegen/component.rs
@@ -2616,6 +2616,13 @@ fn generate_cm_imports(
                 }
             }
 
+            // Every own-resource index is registered by here, so the borrowed
+            // view each signature hands `ast_type_to_cm` is built once.
+            let resource_exports: IndexMap<&str, u32> = own_resource_type_indices
+                .iter()
+                .map(|(k, &v)| (k.as_str(), v))
+                .collect();
+
             for func in &supported_functions {
                 // Pre-define param-only types (stream for params, result for params)
                 let needs_stream_u8 = func
@@ -2682,16 +2689,18 @@ fn generate_cm_imports(
                         let is_composite = match &resolved_ty {
                             Type::Generic(g) => g.name != "Stream" && g.name != "Result",
                             Type::Tuple(_) => true,
-                            _ => false,
+                            Type::Named(_)
+                            | Type::NamespacedGeneric(_)
+                            | Type::Function(_)
+                            | Type::Reference(_)
+                            | Type::MutReference(_)
+                            | Type::TypePackSpread(..)
+                            | Type::Infer(_)
+                            | Type::Error(_) => false,
                         };
                         let val_type =
                             if is_component_import || is_struct || is_local_newtype || is_composite
                             {
-                                let resource_exports: IndexMap<&str, u32> =
-                                    own_resource_type_indices
-                                        .iter()
-                                        .map(|(k, &v)| (k.as_str(), v))
-                                        .collect();
                                 let mut sink = crate::component_model::InstanceSink {
                                     it: &mut instance_type,
                                     next_idx: &mut local_type_idx,
@@ -2704,7 +2713,7 @@ fn generate_cm_imports(
                                 )
                             } else {
                                 wado_type_to_cm_val_type(
-                                    ty,
+                                    &resolved_ty,
                                     stream_type_idx,
                                     result_param_type_idx,
                                     &enum_export_indices,
@@ -2742,10 +2751,6 @@ fn generate_cm_imports(
                             )
                         .is_some());
                     if is_component_import || is_struct || is_local_newtype {
-                        let resource_exports: IndexMap<&str, u32> = own_resource_type_indices
-                            .iter()
-                            .map(|(k, &v)| (k.as_str(), v))
-                            .collect();
                         let mut sink = crate::component_model::InstanceSink {
                             it: &mut instance_type,
                             next_idx: &mut local_type_idx,

--- a/wado-compiler/src/codegen/component.rs
+++ b/wado-compiler/src/codegen/component.rs
@@ -2676,31 +2676,42 @@ fn generate_cm_imports(
                                 &named.name,
                             )
                             .is_some());
-                        let val_type = if is_component_import || is_struct || is_local_newtype {
-                            let resource_exports: IndexMap<&str, u32> = own_resource_type_indices
-                                .iter()
-                                .map(|(k, &v)| (k.as_str(), v))
-                                .collect();
-                            let mut sink = crate::component_model::InstanceSink {
-                                it: &mut instance_type,
-                                next_idx: &mut local_type_idx,
-                            };
-                            shared_type_gen.ast_type_to_cm(
-                                &mut sink,
-                                &resolved_ty,
-                                &project.cm_interface_registry,
-                                &resource_exports,
-                            )
-                        } else {
-                            wado_type_to_cm_val_type(
-                                ty,
-                                stream_type_idx,
-                                result_param_type_idx,
-                                &enum_export_indices,
-                                &flags_export_indices,
-                                &borrow_resource_type_indices,
-                            )
+                        // So does a composite (`Option<T>`, `List<T>`, a tuple):
+                        // `wado_type_to_cm_val_type` spells only the flat shapes
+                        // and the pre-defined `Stream` / `Result` params.
+                        let is_composite = match &resolved_ty {
+                            Type::Generic(g) => g.name != "Stream" && g.name != "Result",
+                            Type::Tuple(_) => true,
+                            _ => false,
                         };
+                        let val_type =
+                            if is_component_import || is_struct || is_local_newtype || is_composite
+                            {
+                                let resource_exports: IndexMap<&str, u32> =
+                                    own_resource_type_indices
+                                        .iter()
+                                        .map(|(k, &v)| (k.as_str(), v))
+                                        .collect();
+                                let mut sink = crate::component_model::InstanceSink {
+                                    it: &mut instance_type,
+                                    next_idx: &mut local_type_idx,
+                                };
+                                shared_type_gen.ast_type_to_cm(
+                                    &mut sink,
+                                    &resolved_ty,
+                                    &project.cm_interface_registry,
+                                    &resource_exports,
+                                )
+                            } else {
+                                wado_type_to_cm_val_type(
+                                    ty,
+                                    stream_type_idx,
+                                    result_param_type_idx,
+                                    &enum_export_indices,
+                                    &flags_export_indices,
+                                    &borrow_resource_type_indices,
+                                )
+                            };
                         (cm_name.clone(), val_type)
                     })
                     .collect();

--- a/wado-compiler/src/component_model.rs
+++ b/wado-compiler/src/component_model.rs
@@ -693,11 +693,17 @@ impl CmFunctionInfo {
         false
     }
 
-    /// Check if a parameter type requires Memory + Realloc in canon lower.
+    /// Check if a parameter type requires Memory + Realloc in canon lower: a
+    /// string, a list or a stream anywhere in it — `option<string>` lowers its
+    /// payload into linear memory as a bare string does.
     fn type_requires_memory(ty: &Type) -> bool {
         match ty {
-            Type::Generic(g) => matches!(g.name.as_str(), "Stream" | "List"),
+            Type::Generic(g) => {
+                matches!(g.name.as_str(), "Stream" | "List")
+                    || g.args.iter().any(Self::type_requires_memory)
+            }
             Type::Named(named) => named.name == "String",
+            Type::Tuple(elems) => elems.iter().any(Self::type_requires_memory),
             _ => false,
         }
     }

--- a/wado-compiler/src/component_model.rs
+++ b/wado-compiler/src/component_model.rs
@@ -693,9 +693,8 @@ impl CmFunctionInfo {
         false
     }
 
-    /// Check if a parameter type requires Memory + Realloc in canon lower: a
-    /// string, a list or a stream anywhere in it — `option<string>` lowers its
-    /// payload into linear memory as a bare string does.
+    /// Whether a parameter type requires Memory + Realloc in canon lower: a
+    /// string, a list or a stream anywhere in it, `option<string>` included.
     fn type_requires_memory(ty: &Type) -> bool {
         match ty {
             Type::Generic(g) => {

--- a/wado-compiler/src/component_model.rs
+++ b/wado-compiler/src/component_model.rs
@@ -703,7 +703,12 @@ impl CmFunctionInfo {
             }
             Type::Named(named) => named.name == "String",
             Type::Tuple(elems) => elems.iter().any(Self::type_requires_memory),
-            _ => false,
+            Type::Reference(inner) | Type::MutReference(inner) => Self::type_requires_memory(inner),
+            Type::NamespacedGeneric(_)
+            | Type::Function(_)
+            | Type::TypePackSpread(..)
+            | Type::Infer(_)
+            | Type::Error(_) => false,
         }
     }
 
@@ -3050,9 +3055,10 @@ impl CmInterfaceRegistry {
         let resources: IndexSet<&str> = self.resources.keys().map(|(_, n)| n.as_str()).collect();
         let structs: IndexSet<&str> = self.structs.keys().map(|(_, n)| n.as_str()).collect();
 
-        // Check all parameter types
+        // Check all parameter types, at the boundary's view: an extern handle is a `u32`.
         for (_, _, ty) in &func.params {
-            if !is_param_type_supported_with_types(ty, &enums, &resources, &structs) {
+            let resolved = self.resolve_type(ty);
+            if !is_param_type_supported_with_types(&resolved, &enums, &resources, &structs) {
                 return false;
             }
         }
@@ -3094,11 +3100,11 @@ impl CmInterfaceRegistry {
             .clone()
             .unwrap_or_else(|| method_name.replace('_', "-"));
 
-        // Resolve newtypes in params upfront
-        // This ensures codegen doesn't need any type resolution logic
+        // Params carry their value types: newtypes peeled, extern handles kept,
+        // so a binding's GC-level types match the caller's.
         let resolved_params: Vec<(String, String, Type)> = params
             .into_iter()
-            .map(|(name, cm_name, ty)| (name, cm_name, self.resolve_type(&ty)))
+            .map(|(name, cm_name, ty)| (name, cm_name, self.value_type(&ty)))
             .collect();
         let func_info = CmFunctionInfo {
             namespace: wasi.namespace.clone(),
@@ -3147,7 +3153,7 @@ impl CmInterfaceRegistry {
     ) {
         let resolved_params: Vec<(String, String, Type)> = params
             .into_iter()
-            .map(|(name, cm_name, ty)| (name, cm_name, self.resolve_type(&ty)))
+            .map(|(name, cm_name, ty)| (name, cm_name, self.value_type(&ty)))
             .collect();
         let func_info = CmFunctionInfo {
             // A world import sits above any interface, so it has no namespace,
@@ -3448,7 +3454,15 @@ impl CmInterfaceRegistry {
     /// This resolves newtypes like `Instant` -> `u64` throughout the type tree,
     /// including within generic type arguments.
     pub fn resolve_type(&self, ty: &Type) -> Type {
-        self.resolve_type_impl(ty, false)
+        self.resolve_type_impl(ty, false, false)
+    }
+
+    /// The type a value of `ty` has in the guest: newtypes peel to their base,
+    /// but an extern-handle resource stays itself. Its handle is the resource's
+    /// own representation, and `Option<Node>` is a GC type of its own, not
+    /// `Option<u32>`; [`Self::resolve_type`] is the boundary's view.
+    pub fn value_type(&self, ty: &Type) -> Type {
+        self.resolve_type_impl(ty, false, true)
     }
 
     /// Like [`Self::resolve_type`], but a *local* newtype (no `#[cm(...)]`
@@ -3457,21 +3471,26 @@ impl CmInterfaceRegistry {
     /// so the compiled component's structural type matches `wado wit`
     /// (issue #1456). WASI/CM-imported newtypes still resolve through.
     pub fn resolve_type_preserving_local_newtypes(&self, ty: &Type) -> Type {
-        self.resolve_type_impl(ty, true)
+        self.resolve_type_impl(ty, true, false)
     }
 
-    fn resolve_type_impl(&self, ty: &Type, preserve_local: bool) -> Type {
+    fn resolve_type_impl(&self, ty: &Type, preserve_local: bool, keep_handles: bool) -> Type {
         match ty {
             Type::Named(named) => {
-                if preserve_local
+                let source = self.source_interface(named);
+                let kept = (preserve_local
                     && self
-                        .local_newtype_base(self.source_interface(named).as_deref(), &named.name)
-                        .is_some()
-                {
+                        .local_newtype_base(source.as_deref(), &named.name)
+                        .is_some())
+                    || (keep_handles
+                        && source
+                            .as_deref()
+                            .is_some_and(|s| self.is_extern_handle_resource(s, &named.name)));
+                if kept {
                     ty.clone()
                 } else if let Some(aliased_ty) = self.resolve_newtype_ref(named) {
                     // Recursively resolve the aliased type
-                    self.resolve_type_impl(aliased_ty, preserve_local)
+                    self.resolve_type_impl(aliased_ty, preserve_local, keep_handles)
                 } else {
                     ty.clone()
                 }
@@ -3481,7 +3500,7 @@ impl CmInterfaceRegistry {
                 let resolved_args: Vec<Type> = generic
                     .args
                     .iter()
-                    .map(|arg| self.resolve_type_impl(arg, preserve_local))
+                    .map(|arg| self.resolve_type_impl(arg, preserve_local, keep_handles))
                     .collect();
                 Type::Generic(GenericType {
                     id: generic.id,
@@ -3493,24 +3512,29 @@ impl CmInterfaceRegistry {
             Type::Tuple(types) => {
                 let resolved: Vec<Type> = types
                     .iter()
-                    .map(|t| self.resolve_type_impl(t, preserve_local))
+                    .map(|t| self.resolve_type_impl(t, preserve_local, keep_handles))
                     .collect();
                 Type::Tuple(resolved)
             }
-            Type::Reference(inner) => {
-                Type::Reference(Box::new(self.resolve_type_impl(inner, preserve_local)))
-            }
-            Type::MutReference(inner) => {
-                Type::MutReference(Box::new(self.resolve_type_impl(inner, preserve_local)))
-            }
+            Type::Reference(inner) => Type::Reference(Box::new(self.resolve_type_impl(
+                inner,
+                preserve_local,
+                keep_handles,
+            ))),
+            Type::MutReference(inner) => Type::MutReference(Box::new(self.resolve_type_impl(
+                inner,
+                preserve_local,
+                keep_handles,
+            ))),
             Type::Function(func_ty) => {
                 // For function types, resolve params and return type
                 let resolved_params: Vec<Type> = func_ty
                     .params
                     .iter()
-                    .map(|t| self.resolve_type_impl(t, preserve_local))
+                    .map(|t| self.resolve_type_impl(t, preserve_local, keep_handles))
                     .collect();
-                let resolved_return = self.resolve_type_impl(&func_ty.return_type, preserve_local);
+                let resolved_return =
+                    self.resolve_type_impl(&func_ty.return_type, preserve_local, keep_handles);
                 Type::Function(Box::new(crate::ast::FunctionType {
                     is_mut: func_ty.is_mut,
                     params: resolved_params,
@@ -3525,7 +3549,7 @@ impl CmInterfaceRegistry {
                 let resolved_args: Vec<Type> = ng
                     .args
                     .iter()
-                    .map(|arg| self.resolve_type_impl(arg, preserve_local))
+                    .map(|arg| self.resolve_type_impl(arg, preserve_local, keep_handles))
                     .collect();
                 Type::NamespacedGeneric(Box::new(crate::ast::NamespacedGenericType {
                     id: ng.id,

--- a/wado-compiler/src/stdlib.rs
+++ b/wado-compiler/src/stdlib.rs
@@ -143,7 +143,7 @@ stdlib_table! {
     "wasi:tls/types.wado" => "wasi/tls/types.wado",
     "wasi:tls/client.wado" => "wasi/tls/client.wado",
     "wasi:tls/worlds.wado" => "wasi/tls/worlds.wado",
-    // Web platform bindings — the extern-handle slice Tide's WebIDL frontend replaces.
+    // Web platform bindings, generated from the WebIDL snapshot beside them.
     "web:dom" => "web/dom.wado",
 }
 

--- a/wado-compiler/src/synthesis/cm_binding/import_adapter.rs
+++ b/wado-compiler/src/synthesis/cm_binding/import_adapter.rs
@@ -295,7 +295,7 @@ fn synthesize_async_lift_function(
     }];
 
     let lifted = if let Some(return_type) = &func_info.return_type {
-        let resolved = cm_interface_registry.resolve_type(return_type);
+        let resolved = cm_interface_registry.value_type(return_type);
         let lift_ctx = LiftContext {
             cm_interface_registry,
             type_table,
@@ -1452,7 +1452,7 @@ impl<'a> AdapterBuilder<'a> {
         // The type argument T for AsyncCall<T> is the CM-level result type
         // (`func_info.return_type` stores the inner T); `()` for void async.
         let inner_type_id = if let Some(return_type) = &func_info.return_type {
-            let resolved = self.registry().resolve_type(return_type);
+            let resolved = self.registry().value_type(return_type);
             self.cm_type_id(&resolved)
         } else {
             TypeTable::UNIT
@@ -1529,7 +1529,7 @@ impl<'a> AdapterBuilder<'a> {
             .return_type
             .as_ref()
             .expect("outptr result implies a return type");
-        let resolved = self.registry().resolve_type(return_type);
+        let resolved = self.registry().value_type(return_type);
 
         // Inline lifting for all types, including list<T> which uses
         // List::<T>::with_capacity() and .push() with proper monomorphization info.
@@ -1580,7 +1580,7 @@ impl<'a> AdapterBuilder<'a> {
         return_type: &Type,
     ) -> TypeId {
         let registry = self.registry();
-        let resolved = registry.resolve_type(return_type);
+        let resolved = registry.value_type(return_type);
         let return_flat = registry.cm_flatten(&resolved);
         // Enums/newtypes flatten to a scalar and pass through; only a struct
         // that flattens to one core value must be rebuilt into its GC form.

--- a/wado-compiler/src/synthesis/cm_binding/lift.rs
+++ b/wado-compiler/src/synthesis/cm_binding/lift.rs
@@ -96,7 +96,7 @@ fn synthesize_lift_inner(
     // before dispatching, so the CM-lift logic sees the underlying shape
     // rather than treating an unknown name as an i32 handle. Other type
     // shapes pass through `resolve_type` unchanged.
-    let resolved = ctx.cm_interface_registry.resolve_type(ty);
+    let resolved = ctx.cm_interface_registry.value_type(ty);
     let ty = &resolved;
     // Resolve stdlib struct names through the compiler-item registry so
     // a rename of `String` / `List` / `Option` / `Result` flows through
@@ -317,7 +317,7 @@ fn try_lift_wasi_struct(
     // Resolve field types through newtypes and compute the record layout
     let resolved_fields: Vec<(String, Type)> = fields
         .iter()
-        .map(|(fname, fty)| (fname.clone(), ctx.cm_interface_registry.resolve_type(fty)))
+        .map(|(fname, fty)| (fname.clone(), ctx.cm_interface_registry.value_type(fty)))
         .collect();
     let offsets = cm_abi::layout_fields_with_registry_scoped(
         resolved_fields.iter().map(|(_, ty)| ty),

--- a/wado-compiler/src/synthesis/cm_binding/lower.rs
+++ b/wado-compiler/src/synthesis/cm_binding/lower.rs
@@ -628,7 +628,7 @@ pub(super) fn synthesize_lower_list_to_buffer(
 ) -> (Vec<TirStmt>, u32, u32) {
     let names = &ctx.names;
     let list_type_id = value.type_id;
-    let elem_resolved = ctx.cm_interface_registry.resolve_type(elem_type);
+    let elem_resolved = ctx.cm_interface_registry.value_type(elem_type);
 
     let elem_size = crate::component_model::cm_size_with_registry_scoped(
         &elem_resolved,
@@ -852,7 +852,7 @@ pub(super) fn synthesize_flatten_value_to_flat_args(
     ctx: &LowerContext<'_>,
 ) {
     let names = &ctx.names;
-    let resolved = ctx.cm_interface_registry.resolve_type(ty);
+    let resolved = ctx.cm_interface_registry.value_type(ty);
     match &resolved {
         // String → cm_lower_string → packed i64 → (ptr, len)
         Type::Named(n) if n.name == names.string => {
@@ -1204,7 +1204,7 @@ pub(super) fn flatten_cm_record_fields(
     ctx: &LowerContext<'_>,
 ) {
     for (field_idx, (wado_name, _, field_ty)) in fields.iter().enumerate() {
-        let resolved_field = ctx.cm_interface_registry.resolve_type(field_ty);
+        let resolved_field = ctx.cm_interface_registry.value_type(field_ty);
         let field_type_id = {
             let mut tt = ctx.type_table.borrow_mut();
             cm_type_to_type_id(
@@ -1574,7 +1574,7 @@ pub(super) fn synthesize_lower_wasi_type_to_memory(
     ctx: &LowerContext<'_>,
 ) -> Vec<TirStmt> {
     let names = &ctx.names;
-    let resolved = ctx.cm_interface_registry.resolve_type(ty);
+    let resolved = ctx.cm_interface_registry.value_type(ty);
     match &resolved {
         Type::Named(n) => {
             // CM record lowering: store each field at its offset, keyed on the
@@ -1591,7 +1591,7 @@ pub(super) fn synthesize_lower_wasi_type_to_memory(
             }) {
                 let resolved_fields: Vec<(String, Type)> = fields
                     .iter()
-                    .map(|(wn, _, ft)| (wn.clone(), ctx.cm_interface_registry.resolve_type(ft)))
+                    .map(|(wn, _, ft)| (wn.clone(), ctx.cm_interface_registry.value_type(ft)))
                     .collect();
                 let offsets = cm_abi::layout_fields_with_registry_scoped(
                     resolved_fields.iter().map(|(_, ty)| ty),
@@ -1658,7 +1658,7 @@ pub(super) fn synthesize_lower_wasi_type_to_memory(
             synthesize_lower_tuple(elems, value, addr, next_local, locals, ctx)
         }
         Type::Generic(g) if g.name == names.option && g.args.len() == 1 => {
-            let inner = ctx.cm_interface_registry.resolve_type(&g.args[0]);
+            let inner = ctx.cm_interface_registry.value_type(&g.args[0]);
             let mut stmts = Vec::new();
             synthesize_lower_option_to_memory(
                 &inner, value, addr, next_local, &mut stmts, locals, ctx,
@@ -1669,8 +1669,8 @@ pub(super) fn synthesize_lower_wasi_type_to_memory(
             synthesize_lower_list_to_memory(&g.args[0], value, addr, next_local, locals, ctx)
         }
         Type::Generic(g) if g.name == names.result && g.args.len() == 2 => {
-            let ok = ctx.cm_interface_registry.resolve_type(&g.args[0]);
-            let err = ctx.cm_interface_registry.resolve_type(&g.args[1]);
+            let ok = ctx.cm_interface_registry.value_type(&g.args[0]);
+            let err = ctx.cm_interface_registry.value_type(&g.args[1]);
             let mut stmts = Vec::new();
             synthesize_lower_result_to_memory(
                 &ok, &err, value, addr, next_local, &mut stmts, locals, ctx,

--- a/wado-compiler/src/synthesis/cm_binding/type_fixup.rs
+++ b/wado-compiler/src/synthesis/cm_binding/type_fixup.rs
@@ -174,7 +174,7 @@ fn fixup_wasi_derived_types_in_adapter(
         }
         let new_type = call_args[i].type_id;
         // Resolve newtypes (e.g., FieldName → String) before computing WASI-derived TypeId
-        let resolved = cm_interface_registry.resolve_type(param_type);
+        let resolved = cm_interface_registry.value_type(param_type);
         replace_wasi_derived_type_recursive(
             adapter,
             &resolved,
@@ -192,7 +192,7 @@ fn fixup_wasi_derived_types_in_adapter(
     if !adapter.is_cm_binding
         && let Some(return_type) = &func_info.return_type
     {
-        let resolved = cm_interface_registry.resolve_type(return_type);
+        let resolved = cm_interface_registry.value_type(return_type);
         replace_wasi_derived_type_recursive(
             adapter,
             &resolved,
@@ -403,7 +403,7 @@ fn fixup_types_in_block(
 }
 
 /// Retype a Let holding an adapter intermediate: a method-call result, or the
-/// lifted result's initial value (`ref.null`, or the `None` of a GC-variant `Option`).
+/// `ref.null` a lifted result starts as.
 fn fixup_adapter_let(
     expr: &mut TirExpr,
     local_index: u32,
@@ -415,18 +415,15 @@ fn fixup_adapter_let(
     let should_fix = expr.type_id == TypeTable::I32 || expr.type_id == old_type;
     let holds_intermediate = match &expr.kind {
         TirExprKind::Call { func, .. } => func.method_info.is_some(),
-        TirExprKind::Null | TirExprKind::VariantConstruct { .. } => true,
+        TirExprKind::Null => true,
         _ => false,
     };
     if !(should_fix && holds_intermediate) {
         return;
     }
-    fixup_variant_construct(expr, old_type, new_type);
     expr.type_id = new_type;
     *let_type_id = new_type;
-    if (local_index as usize) < locals.len() {
-        locals[local_index as usize].type_id = new_type;
-    }
+    locals[local_index as usize].type_id = new_type;
 }
 
 /// Fix up an expression statement (e.g., Assign with `VariantConstruct`).
@@ -748,9 +745,7 @@ fn fixup_adapter_param_from_call_site(
     }
     let local_idx = param.local_index as usize;
     param.type_id = arg_type;
-    if local_idx < adapter.locals.len() {
-        adapter.locals[local_idx].type_id = arg_type;
-    }
+    adapter.locals[local_idx].type_id = arg_type;
 }
 
 /// Cast call-site args whose flat-typed adapter param is authoritative

--- a/wado-compiler/src/synthesis/cm_binding/type_fixup.rs
+++ b/wado-compiler/src/synthesis/cm_binding/type_fixup.rs
@@ -402,10 +402,8 @@ fn fixup_types_in_block(
     }
 }
 
-/// Fix up an expression in a Let statement that might hold adapter intermediate
-/// values: a method-call result, or the initial value of the lifted result — a
-/// `ref.null` for a nullable-ref `Option`, a `None` construct for a GC-variant
-/// one (`Option<Element>`, whose payload is a handle).
+/// Retype a Let holding an adapter intermediate: a method-call result, or the
+/// lifted result's initial value (`ref.null`, or the `None` of a GC-variant `Option`).
 fn fixup_adapter_let(
     expr: &mut TirExpr,
     local_index: u32,

--- a/wado-compiler/src/synthesis/cm_binding/type_fixup.rs
+++ b/wado-compiler/src/synthesis/cm_binding/type_fixup.rs
@@ -402,7 +402,10 @@ fn fixup_types_in_block(
     }
 }
 
-/// Fix up an expression in a Let statement that might hold adapter intermediate values.
+/// Fix up an expression in a Let statement that might hold adapter intermediate
+/// values: a method-call result, or the initial value of the lifted result — a
+/// `ref.null` for a nullable-ref `Option`, a `None` construct for a GC-variant
+/// one (`Option<Element>`, whose payload is a handle).
 fn fixup_adapter_let(
     expr: &mut TirExpr,
     local_index: u32,
@@ -412,26 +415,19 @@ fn fixup_adapter_let(
     locals: &mut [TirLocal],
 ) {
     let should_fix = expr.type_id == TypeTable::I32 || expr.type_id == old_type;
-    match &mut expr.kind {
-        TirExprKind::Call { func, .. } if func.method_info.is_some() => {
-            if should_fix {
-                expr.type_id = new_type;
-                *let_type_id = new_type;
-                if (local_index as usize) < locals.len() {
-                    locals[local_index as usize].type_id = new_type;
-                }
-            }
-        }
-        TirExprKind::Null => {
-            if should_fix {
-                expr.type_id = new_type;
-                *let_type_id = new_type;
-                if (local_index as usize) < locals.len() {
-                    locals[local_index as usize].type_id = new_type;
-                }
-            }
-        }
-        _ => {}
+    let holds_intermediate = match &expr.kind {
+        TirExprKind::Call { func, .. } => func.method_info.is_some(),
+        TirExprKind::Null | TirExprKind::VariantConstruct { .. } => true,
+        _ => false,
+    };
+    if !(should_fix && holds_intermediate) {
+        return;
+    }
+    fixup_variant_construct(expr, old_type, new_type);
+    expr.type_id = new_type;
+    *let_type_id = new_type;
+    if (local_index as usize) < locals.len() {
+        locals[local_index as usize].type_id = new_type;
     }
 }
 

--- a/wado-compiler/src/synthesis/cm_binding/types.rs
+++ b/wado-compiler/src/synthesis/cm_binding/types.rs
@@ -309,6 +309,17 @@ pub fn cm_type_to_type_id(
                         .lib_local_type_source(&named.name)
                         .and_then(|ms| type_table.find_named_type_by_source(&named.name, ms))
                 })
+                // An extern-handle resource keeps its own type in a guest
+                // signature, and its package is one flat module (`web:dom`),
+                // not a module per interface.
+                .or_else(|| {
+                    let source = registry.resolve_cm_source_for(named, Some(wasi_package))?;
+                    if !registry.is_extern_handle_resource(&source, &named.name) {
+                        return None;
+                    }
+                    let (namespace, package) = cm_package_from_source(&source)?;
+                    type_table.find_named_type_by_module_name(&named.name, package, Some(namespace))
+                })
                 // Resources are bare i32 handles at the CM boundary and need no
                 // registered GC type. Anything else without a TypeId would
                 // miscompile (e.g. FieldAccess on an i32), so fail loudly.

--- a/wado-compiler/tests/integration/web_dom.rs
+++ b/wado-compiler/tests/integration/web_dom.rs
@@ -74,6 +74,21 @@ fn an_optional_extern_handle_result_lifts_to_the_declared_option() {
     );
 }
 
+/// An `option<extern-handle>` parameter is the caller's `Option<Node>` on both
+/// sides of the binding, whether the argument is `null`, a `Some` literal, or a
+/// value of that type.
+#[test]
+fn an_optional_extern_handle_argument_keeps_the_declared_option() {
+    let wat = compile_to_wat(&on_an_element(
+        "let node: Node = el;\n\
+         assert !el.contains(null);\n\
+         assert el.is_same_node(Option::Some(node));\n\
+         let other: Option<Node> = Option::Some(node);\n\
+         assert el.is_equal_node(other);",
+    ));
+    assert!(wat.contains("web:dom/node"), "{wat}");
+}
+
 /// Compile `source`, holding it to what `wado check` reports as well: a program
 /// this slice accepts has to be clean, not merely compilable.
 fn compile_to_wat(source: &str) -> String {

--- a/wado-compiler/tests/integration/web_dom.rs
+++ b/wado-compiler/tests/integration/web_dom.rs
@@ -59,9 +59,8 @@ fn an_upcast_is_a_no_op() {
     );
 }
 
-/// An `option<extern-handle>` result lifts into the declared `Option<Element>`:
-/// the lift's `None` initializer is retyped along with its `Some`, so the
-/// binding's local and its two assignments agree.
+/// An `option<extern-handle>` result lifts into the declared `Option<Element>`,
+/// not the `Option<u32>` the boundary sees.
 #[test]
 fn an_optional_extern_handle_result_lifts_to_the_declared_option() {
     let wat = compile_to_wat(&on_an_element(

--- a/wado-compiler/tests/integration/web_dom.rs
+++ b/wado-compiler/tests/integration/web_dom.rs
@@ -1,5 +1,6 @@
 //! `web:` is a bundled namespace and `web:dom` the extern-handle slice Tide's
-//! generator will replace. See `docs/wep-2026-04-01-tide.md`.
+//! generator emits from the vendored `WebIDL` snapshot. See
+//! `docs/wep-2026-04-01-tide.md`.
 
 use crate::common::{check_diagnostics, compile_source};
 
@@ -9,17 +10,18 @@ fn on_an_element(body: &str) -> String {
         "use {{ Dom, Node }} from \"web:dom\";\n\
          export fn run() with Dom {{\n\
              let doc = Dom::document();\n\
-             let el = doc.create_element(\"div\");\n\
+             let el = doc.create_element(\"div\", null);\n\
              {body}\n\
          }}\n"
     )
 }
 
 /// `set_text_content` is declared on `Node`, which `Element` extends.
-const INHERITED: &str = "el.set_text_content(\"Hello, Wado!\");";
+const INHERITED: &str = "el.set_text_content(Option::Some(\"Hello, Wado!\"));";
 
 /// The same call, reached through an upcast to the declaring resource.
-const UPCAST: &str = "let parent: Node = el;\nparent.set_text_content(\"Hello, Wado!\");";
+const UPCAST: &str =
+    "let parent: Node = el;\nparent.set_text_content(Option::Some(\"Hello, Wado!\"));";
 
 /// An extern-handle-backed resource is an opaque `u32` at the CM boundary, not
 /// a CM `resource`, so the component's imports carry no handle type.
@@ -54,6 +56,21 @@ fn an_upcast_is_a_no_op() {
     assert_eq!(
         compile_to_wat(&on_an_element(UPCAST)),
         compile_to_wat(&on_an_element(INHERITED))
+    );
+}
+
+/// An `option<extern-handle>` result lifts into the declared `Option<Element>`:
+/// the lift's `None` initializer is retyped along with its `Some`, so the
+/// binding's local and its two assignments agree.
+#[test]
+fn an_optional_extern_handle_result_lifts_to_the_declared_option() {
+    let wat = compile_to_wat(&on_an_element(
+        "assert doc.get_element_by_id(\"app\") matches { None };\n\
+         assert el.parent_node() matches { None };",
+    ));
+    assert!(
+        wat.contains("web:dom/document") && wat.contains("web:dom/node"),
+        "both interfaces should be imported: {wat}"
     );
 }
 

--- a/wado-compiler/tests/integration/web_dom_e2e.rs
+++ b/wado-compiler/tests/integration/web_dom_e2e.rs
@@ -23,28 +23,36 @@ use { Dom, Event, EventTarget, Node } from "web:dom";
 
 export fn run() with (Dom, Event, EventTarget) {
     let doc = Dom::document();
-    let el = doc.create_element("div");
+    let el = doc.create_element("div", null);
     el.set_id("app");
-    el.set_text_content("hello");
+    el.set_text_content(Option::Some("hello"));
 
     assert el.tag_name() == "div";
     assert el.id() == "app";
 
     // Declared on `Node`, called on an `Element`.
-    assert el.text_content() == "hello";
+    assert el.text_content() == Option::Some("hello");
 
     // The upcast converts nothing: the same handle answers as a `Node`.
     let parent: Node = el;
-    assert parent.text_content() == "hello";
+    assert parent.text_content() == Option::Some("hello");
 
     // Declared on `EventTarget`, two links above `Element`.
     let ev = Event::new("click");
-    assert el.dispatch_event(&ev);
+    assert el.dispatch_event(ev);
 
     // A handle both taken as a non-receiver argument and handed back.
-    let child = doc.create_element("span");
-    child.set_text_content("world");
-    assert parent.append_child(&child).text_content() == "world";
+    let child = doc.create_element("span", null);
+    child.set_text_content(Option::Some("world"));
+    assert parent.append_child(child).text_content() == Option::Some("world");
+
+    // An optional handle: the host answers with the element's own handle, or none.
+    let found = doc.get_element_by_id("app");
+    assert found matches { Some(_) };
+    if let Some(same) = found {
+        assert same.id() == "app";
+    }
+    assert doc.get_element_by_id("missing") matches { None };
 }
 "#;
 
@@ -102,13 +110,24 @@ fn add_dom_to_linker(
         over_dom(dom, |dom, ()| (dom.insert(Object::default()),)),
     )?;
 
-    linker.instance("web:dom/document")?.func_wrap(
+    let mut document = linker.instance("web:dom/document")?;
+    document.func_wrap(
         "create-element",
-        over_dom(dom, |dom, (_self, local_name): (u32, String)| {
-            (dom.insert(Object {
-                tag: local_name,
-                ..Object::default()
-            }),)
+        over_dom(
+            dom,
+            |dom, (_self, local_name, _options): (u32, String, Option<String>)| {
+                (dom.insert(Object {
+                    tag: local_name,
+                    ..Object::default()
+                }),)
+            },
+        ),
+    )?;
+    document.func_wrap(
+        "get-element-by-id",
+        over_dom(dom, |dom, (_self, id): (u32, String)| {
+            let found = dom.objects.iter().position(|o| o.id == id);
+            (found.map(|index| u32::try_from(index).expect("a table index")),)
         }),
     )?;
 
@@ -131,12 +150,14 @@ fn add_dom_to_linker(
     let mut node = linker.instance("web:dom/node")?;
     node.func_wrap(
         "text-content",
-        over_dom(dom, |dom, (handle,): (u32,)| (dom.at(handle).text.clone(),)),
+        over_dom(dom, |dom, (handle,): (u32,)| {
+            (Some(dom.at(handle).text.clone()),)
+        }),
     )?;
     node.func_wrap(
         "set-text-content",
-        over_dom(dom, |dom, (handle, value): (u32, String)| {
-            dom.at(handle).text = value;
+        over_dom(dom, |dom, (handle, value): (u32, Option<String>)| {
+            dom.at(handle).text = value.unwrap_or_default();
         }),
     )?;
     node.func_wrap("append-child", |_, (_parent, child): (u32, u32)| {

--- a/wado-compiler/tests/integration/web_dom_e2e.rs
+++ b/wado-compiler/tests/integration/web_dom_e2e.rs
@@ -53,6 +53,11 @@ export fn run() with (Dom, Event, EventTarget) {
         assert same.id() == "app";
     }
     assert doc.get_element_by_id("missing") matches { None };
+
+    // An optional handle argument, absent and present.
+    assert !parent.contains(null);
+    let child_node: Node = child;
+    assert parent.contains(Option::Some(child_node));
 }
 "#;
 
@@ -162,6 +167,9 @@ fn add_dom_to_linker(
     )?;
     node.func_wrap("append-child", |_, (_parent, child): (u32, u32)| {
         Ok((child,))
+    })?;
+    node.func_wrap("contains", |_, (_parent, other): (u32, Option<u32>)| {
+        Ok((other.is_some(),))
     })?;
 
     linker.instance("web:dom/event")?.func_wrap(

--- a/wado-compiler/tests/integration/wit.rs
+++ b/wado-compiler/tests/integration/wit.rs
@@ -219,16 +219,16 @@ fn full_scope_reconstructs_an_extern_handle_interface_per_wado_type() {
     let text = emit_scope(
         "use { Dom, Node } from \"web:dom\";\n\
          export fn run() with Dom {\n\
-             let el = Dom::document().create_element(\"div\");\n\
+             let el = Dom::document().create_element(\"div\", null);\n\
              el.set_id(\"app\");\n\
              let parent: Node = el;\n\
-             parent.append_child(&el);\n\
+             parent.append_child(el);\n\
          }",
         WitScope::Full,
     );
     assert!(text.contains("package web:dom {"), "\n{text}");
     assert!(
-        text.contains("append-child: func(self: u32, child: u32) -> u32;"),
+        text.contains("append-child: func(self: u32, node: u32) -> u32;"),
         "a handle is the same opaque u32 in every position\n{text}"
     );
     assert!(

--- a/wado-from-idl/AGENTS.md
+++ b/wado-from-idl/AGENTS.md
@@ -15,7 +15,7 @@ Generates Wado stdlib modules from IDL files: WIT, and WebIDL.
   `mise run update-stdlib-web`; `tests/web_dom_is_fresh.rs` fails when the
   module is stale. The snapshot is the webidl2 AST of the slice
   `scripts/webidl/snapshot.mjs` takes from `@webref/idl`; widen the slice
-  there and run `mise run update-webidl-snapshot` (network). See
+  there and run `mise run update-webidl-snapshot`. See
   `docs/wep-2026-04-01-tide.md`.
 
 Never edit a generated `.wado` file. Change this crate and regenerate.

--- a/wado-from-idl/AGENTS.md
+++ b/wado-from-idl/AGENTS.md
@@ -1,6 +1,6 @@
 # wado-from-idl
 
-Generates Wado stdlib modules from WIT files.
+Generates Wado stdlib modules from IDL files: WIT, and WebIDL.
 
 ## Generated Modules
 
@@ -10,5 +10,12 @@ Generates Wado stdlib modules from WIT files.
 - `core:kiln` — the submodules under `wado-compiler/lib/core/kiln/`. Regenerate
   with `mise run update-stdlib-kiln`. The facade `lib/core/kiln.wado` is
   hand-written and must be preserved.
+- `web:dom` — `wado-compiler/lib/web/dom.wado`, generated from the WebIDL
+  snapshot beside it, `dom.webidl.json`. Regenerate with
+  `mise run update-stdlib-web`; `tests/web_dom_is_fresh.rs` fails when the
+  module is stale. The snapshot is the webidl2 AST of the slice
+  `scripts/webidl/snapshot.mjs` takes from `@webref/idl`; widen the slice
+  there and run `mise run update-webidl-snapshot` (network). See
+  `docs/wep-2026-04-01-tide.md`.
 
 Never edit a generated `.wado` file. Change this crate and regenerate.

--- a/wado-from-idl/Cargo.toml
+++ b/wado-from-idl/Cargo.toml
@@ -15,6 +15,8 @@ indexmap.workspace = true
 wit-parser = { workspace = true }
 lexopt = { workspace = true }
 heck = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 [lints]
 workspace = true

--- a/wado-from-idl/Cargo.toml
+++ b/wado-from-idl/Cargo.toml
@@ -15,6 +15,7 @@ indexmap.workspace = true
 wit-parser = { workspace = true }
 lexopt = { workspace = true }
 heck = { workspace = true }
+wado-compiler = { path = "../wado-compiler" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/wado-from-idl/src/codegen.rs
+++ b/wado-from-idl/src/codegen.rs
@@ -190,12 +190,22 @@ impl WadoCodeGenerator {
 
     fn write_resource(&mut self, resource: &WadoResource) {
         self.write_doc_comment(resource.doc_comment.as_ref());
-        self.writeln(&format!("#[cm(\"{}\")]", resource.cm_attr));
+        let backing = if resource.extern_handle {
+            ", type = \"extern-handle\""
+        } else {
+            ""
+        };
+        self.writeln(&format!("#[cm(\"{}\"{backing})]", resource.cm_attr));
+        let extends = resource
+            .extends
+            .as_ref()
+            .map(|parent| format!(" extends {parent}"))
+            .unwrap_or_default();
 
         if resource.methods.is_empty() {
-            self.writeln(&format!("pub resource {};", resource.name));
+            self.writeln(&format!("pub resource {}{extends};", resource.name));
         } else {
-            self.writeln(&format!("pub resource {} {{", resource.name));
+            self.writeln(&format!("pub resource {}{extends} {{", resource.name));
             self.indent += 1;
 
             for method in &resource.methods {

--- a/wado-from-idl/src/ir.rs
+++ b/wado-from-idl/src/ir.rs
@@ -168,6 +168,11 @@ pub struct WadoResource {
     pub name: String,
     pub doc_comment: Option<String>,
     pub cm_attr: String,
+    /// `type = "extern-handle"`: an opaque host-table index rather than a CM
+    /// resource handle. Required on both sides of `extends`.
+    pub extern_handle: bool,
+    /// The parent resource of a `resource X extends Y`.
+    pub extends: Option<String>,
     pub methods: Vec<WadoFunction>,
 }
 

--- a/wado-from-idl/src/lib.rs
+++ b/wado-from-idl/src/lib.rs
@@ -4,6 +4,7 @@ pub mod codegen;
 pub mod ir;
 pub mod naming;
 pub mod transform;
+pub mod webidl;
 
 pub use codegen::WadoCodeGenerator;
 pub use ir::WadoModule;

--- a/wado-from-idl/src/main.rs
+++ b/wado-from-idl/src/main.rs
@@ -44,6 +44,8 @@ fn require_path(parser: &mut lexopt::Parser) -> PathBuf {
 
 struct Cli {
     wit_dir: Option<PathBuf>,
+    /// A `WebIDL` snapshot (`scripts/webidl/snapshot.mjs`) to generate from.
+    webidl: Option<PathBuf>,
     output_dir: Option<PathBuf>,
     package: Option<String>,
     package_name: String,
@@ -59,6 +61,7 @@ fn print_usage() {
     eprintln!();
     eprintln!("Filter mode (default): Reads WIT from stdin, writes Wado to stdout.");
     eprintln!("Directory mode: Use --wit-dir and --output-dir to batch process files.");
+    eprintln!("WebIDL mode: Use --webidl and --output-dir to generate a web:* package.");
     eprintln!();
     eprintln!("Usage: wado-from-idl [options]");
     eprintln!();
@@ -67,7 +70,10 @@ fn print_usage() {
         "  --wit-dir <DIR>           Directory containing WIT files (enables directory mode)"
     );
     eprintln!(
-        "  --output-dir <DIR>        Output directory for generated Wado files (required with --wit-dir)"
+        "  --webidl <FILE>           WebIDL snapshot JSON written by scripts/webidl/snapshot.mjs"
+    );
+    eprintln!(
+        "  --output-dir <DIR>        Output directory for generated Wado files (required with --wit-dir / --webidl)"
     );
     eprintln!(
         "  --package <NAME>          Only generate for specific package (e.g., \"cli\", \"filesystem\")"
@@ -82,6 +88,7 @@ fn print_usage() {
 fn parse_args() -> Cli {
     let mut cli = Cli {
         wit_dir: None,
+        webidl: None,
         output_dir: None,
         package: None,
         package_name: "wasi".to_string(),
@@ -99,6 +106,7 @@ fn parse_args() -> Cli {
                 process::exit(0);
             }
             Long("wit-dir") => cli.wit_dir = Some(require_path(&mut parser)),
+            Long("webidl") => cli.webidl = Some(require_path(&mut parser)),
             Long("output-dir") => cli.output_dir = Some(require_path(&mut parser)),
             Long("package") => cli.package = Some(require_string(&mut parser)),
             Long("package-name") => cli.package_name = require_string(&mut parser),
@@ -118,6 +126,14 @@ fn parse_args() -> Cli {
 
 fn main() -> Result<()> {
     let cli = parse_args();
+
+    if let Some(ref webidl) = cli.webidl {
+        let output_dir = cli
+            .output_dir
+            .as_ref()
+            .context("--output-dir is required when using --webidl")?;
+        return run_webidl_mode(webidl, output_dir);
+    }
 
     if let Some(ref wit_dir) = cli.wit_dir {
         // Directory mode
@@ -301,6 +317,38 @@ fn run_directory_mode(
         }
     }
 
+    Ok(())
+}
+
+/// Generate `<output-dir>/<package>.wado` from a `WebIDL` snapshot: one module
+/// per package, since its resources reference each other in both directions.
+fn run_webidl_mode(snapshot_path: &Path, output_dir: &Path) -> Result<()> {
+    let json = fs::read_to_string(snapshot_path)
+        .with_context(|| format!("Failed to read {}", snapshot_path.display()))?;
+    let snapshot: wado_from_idl::webidl::Snapshot = serde_json::from_str(&json)
+        .with_context(|| format!("Failed to parse {}", snapshot_path.display()))?;
+    let base_dir = std::env::current_dir()?;
+    let source = snapshot_path
+        .strip_prefix(&base_dir)
+        .unwrap_or(snapshot_path)
+        .display()
+        .to_string();
+    let (code, skipped) = wado_from_idl::webidl::generate(&snapshot, &source)?;
+
+    fs::create_dir_all(output_dir)
+        .with_context(|| format!("Failed to create directory {}", output_dir.display()))?;
+    let output_path = output_dir.join(format!("{}.wado", snapshot.package));
+    fs::write(&output_path, code)
+        .with_context(|| format!("Failed to write {}", output_path.display()))?;
+
+    for line in &skipped {
+        eprintln!("Skipped: {line}");
+    }
+    eprintln!(
+        "Generated: {} ({} members skipped)",
+        output_path.display(),
+        skipped.len()
+    );
     Ok(())
 }
 

--- a/wado-from-idl/src/main.rs
+++ b/wado-from-idl/src/main.rs
@@ -327,12 +327,7 @@ fn run_webidl_mode(snapshot_path: &Path, output_dir: &Path) -> Result<()> {
         .with_context(|| format!("Failed to read {}", snapshot_path.display()))?;
     let snapshot: wado_from_idl::webidl::Snapshot = serde_json::from_str(&json)
         .with_context(|| format!("Failed to parse {}", snapshot_path.display()))?;
-    let base_dir = std::env::current_dir()?;
-    let source = snapshot_path
-        .strip_prefix(&base_dir)
-        .unwrap_or(snapshot_path)
-        .display()
-        .to_string();
+    let source = relative_to_cwd(snapshot_path)?;
     let (code, skipped) = wado_from_idl::webidl::generate(&snapshot, &source)?;
 
     fs::create_dir_all(output_dir)
@@ -420,6 +415,19 @@ fn stdlib_identity_for(namespace: &str, pkg_name: &str, file: Option<&str>) -> O
     })
 }
 
+/// `path` as the generated header names it: relative to the working directory
+/// when under it.
+fn relative_to_cwd(path: &Path) -> Result<String> {
+    Ok(relative_to(path, &std::env::current_dir()?))
+}
+
+fn relative_to(path: &Path, base_dir: &Path) -> String {
+    path.strip_prefix(base_dir)
+        .unwrap_or(path)
+        .display()
+        .to_string()
+}
+
 fn package_sources(
     source_map: &PackageSourceMap,
     pkg_id: PackageId,
@@ -428,9 +436,7 @@ fn package_sources(
     let Some(paths) = source_map.package_paths(pkg_id) else {
         return Vec::new();
     };
-    let mut out: Vec<String> = paths
-        .map(|p| p.strip_prefix(base_dir).unwrap_or(p).display().to_string())
-        .collect();
+    let mut out: Vec<String> = paths.map(|p| relative_to(p, base_dir)).collect();
     out.sort();
     out.dedup();
     out

--- a/wado-from-idl/src/naming.rs
+++ b/wado-from-idl/src/naming.rs
@@ -1,6 +1,7 @@
 //! Naming convention utilities for WIT-to-Wado conversion
 
 use heck::{ToKebabCase, ToSnakeCase, ToUpperCamelCase};
+use wado_compiler::syntax::{CONTEXTUAL_KEYWORDS, KEYWORDS, NAME_KEYWORDS};
 
 /// Convert WIT kebab-case to Wado `snake_case` for function/field names
 #[must_use]
@@ -20,62 +21,16 @@ pub fn to_kebab_case(name: &str) -> String {
     name.to_kebab_case()
 }
 
-/// The Wado keywords, plus `self`, which no parameter or method may be named.
-const RESERVED: &[&str] = &[
-    "if",
-    "else",
-    "while",
-    "for",
-    "loop",
-    "break",
-    "continue",
-    "return",
-    "match",
-    "fn",
-    "let",
-    "global",
-    "const",
-    "struct",
-    "enum",
-    "variant",
-    "flags",
-    "impl",
-    "trait",
-    "type",
-    "resource",
-    "extends",
-    "world",
-    "effect",
-    "interface",
-    "pub",
-    "internal",
-    "export",
-    "mut",
-    "async",
-    "unique",
-    "stores",
-    "reactive",
-    "use",
-    "from",
-    "import",
-    "as",
-    "with",
-    "in",
-    "of",
-    "assert",
-    "true",
-    "false",
-    "null",
-    "matches",
-    "self",
-];
-
-/// Convert a `WebIDL` identifier to a Wado `snake_case` name that is not a
-/// keyword: `type` becomes `type_`.
+/// Convert a `WebIDL` identifier to a Wado `snake_case` name the parser takes
+/// as a name: a keyword it does not (`match`, `self`) gets a trailing `_`.
 #[must_use]
 pub fn to_wado_identifier(name: &str) -> String {
     let snake = name.to_snake_case();
-    if RESERVED.contains(&snake.as_str()) {
+    let keyword = KEYWORDS
+        .iter()
+        .chain(CONTEXTUAL_KEYWORDS)
+        .any(|(keyword, _)| *keyword == snake);
+    if keyword && !NAME_KEYWORDS.contains(&snake.as_str()) {
         format!("{snake}_")
     } else {
         snake
@@ -95,8 +50,11 @@ mod tests {
 
     #[test]
     fn a_webidl_identifier_avoids_the_keywords() {
-        assert_eq!(to_wado_identifier("type"), "type_");
+        assert_eq!(to_wado_identifier("match"), "match_");
+        assert_eq!(to_wado_identifier("resume"), "resume_");
         assert_eq!(to_wado_identifier("self"), "self_");
+        // The parser takes these as names.
+        assert_eq!(to_wado_identifier("type"), "type");
         assert_eq!(to_wado_identifier("innerHTML"), "inner_html");
         assert_eq!(to_kebab_case("HTMLInputElement"), "html-input-element");
         assert_eq!(to_kebab_case("setHTMLUnsafe"), "set-html-unsafe");

--- a/wado-from-idl/src/naming.rs
+++ b/wado-from-idl/src/naming.rs
@@ -1,6 +1,6 @@
 //! Naming convention utilities for WIT-to-Wado conversion
 
-use heck::{ToSnakeCase, ToUpperCamelCase};
+use heck::{ToKebabCase, ToSnakeCase, ToUpperCamelCase};
 
 /// Convert WIT kebab-case to Wado `snake_case` for function/field names
 #[must_use]
@@ -14,6 +14,74 @@ pub fn to_upper_camel_case(name: &str) -> String {
     name.to_upper_camel_case()
 }
 
+/// Convert a `WebIDL` identifier to the kebab-case a CM member name takes
+#[must_use]
+pub fn to_kebab_case(name: &str) -> String {
+    name.to_kebab_case()
+}
+
+/// The Wado keywords, plus `self`, which no parameter or method may be named.
+const RESERVED: &[&str] = &[
+    "if",
+    "else",
+    "while",
+    "for",
+    "loop",
+    "break",
+    "continue",
+    "return",
+    "match",
+    "fn",
+    "let",
+    "global",
+    "const",
+    "struct",
+    "enum",
+    "variant",
+    "flags",
+    "impl",
+    "trait",
+    "type",
+    "resource",
+    "extends",
+    "world",
+    "effect",
+    "interface",
+    "pub",
+    "internal",
+    "export",
+    "mut",
+    "async",
+    "unique",
+    "stores",
+    "reactive",
+    "use",
+    "from",
+    "import",
+    "as",
+    "with",
+    "in",
+    "of",
+    "assert",
+    "true",
+    "false",
+    "null",
+    "matches",
+    "self",
+];
+
+/// Convert a `WebIDL` identifier to a Wado `snake_case` name that is not a
+/// keyword: `type` becomes `type_`.
+#[must_use]
+pub fn to_wado_identifier(name: &str) -> String {
+    let snake = name.to_snake_case();
+    if RESERVED.contains(&snake.as_str()) {
+        format!("{snake}_")
+    } else {
+        snake
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -23,6 +91,15 @@ mod tests {
         assert_eq!(to_snake_case("write-via-stream"), "write_via_stream");
         assert_eq!(to_snake_case("get-environment"), "get_environment");
         assert_eq!(to_snake_case("getArguments"), "get_arguments");
+    }
+
+    #[test]
+    fn a_webidl_identifier_avoids_the_keywords() {
+        assert_eq!(to_wado_identifier("type"), "type_");
+        assert_eq!(to_wado_identifier("self"), "self_");
+        assert_eq!(to_wado_identifier("innerHTML"), "inner_html");
+        assert_eq!(to_kebab_case("HTMLInputElement"), "html-input-element");
+        assert_eq!(to_kebab_case("setHTMLUnsafe"), "set-html-unsafe");
     }
 
     #[test]

--- a/wado-from-idl/src/naming.rs
+++ b/wado-from-idl/src/naming.rs
@@ -1,4 +1,4 @@
-//! Naming convention utilities for WIT-to-Wado conversion
+//! The names a WIT or `WebIDL` identifier takes in Wado and at the CM boundary.
 
 use heck::{ToKebabCase, ToSnakeCase, ToUpperCamelCase};
 use wado_compiler::syntax::{CONTEXTUAL_KEYWORDS, KEYWORDS, NAME_KEYWORDS};

--- a/wado-from-idl/src/transform.rs
+++ b/wado-from-idl/src/transform.rs
@@ -628,6 +628,8 @@ impl<'a> Transformer<'a> {
             name,
             doc_comment: ty.docs.contents.clone(),
             cm_attr,
+            extern_handle: false,
+            extends: None,
             methods,
         }))
     }

--- a/wado-from-idl/src/webidl.rs
+++ b/wado-from-idl/src/webidl.rs
@@ -117,8 +117,11 @@ pub struct WebIdlOutput {
     pub skipped: Vec<String>,
 }
 
-/// One interface with its partials and mixins folded in.
+/// One interface with its partials and mixins folded in. `defined` is false
+/// while only partials have been seen, which the slice does not admit.
+#[derive(Default)]
 struct Merged<'a> {
+    defined: bool,
     inheritance: Option<String>,
     global: bool,
     members: Vec<&'a Member>,
@@ -166,33 +169,7 @@ pub fn transform(snapshot: &Snapshot) -> Result<WebIdlOutput> {
     let mut resources: IndexMap<&str, WadoResource> = IndexMap::new();
     for (name, iface) in &merged {
         let path = lowering.interface_path(name);
-        let mut candidates: IndexMap<String, (Vec<WadoFunction>, Vec<String>)> = IndexMap::new();
-        for member in &iface.members {
-            for lowered in lowering.lower_member(name, &path, member) {
-                match lowered {
-                    Ok(function) => candidates
-                        .entry(function.name.clone())
-                        .or_default()
-                        .0
-                        .push(function),
-                    Err((wado_name, reason)) => {
-                        candidates.entry(wado_name).or_default().1.push(reason);
-                    }
-                }
-            }
-        }
-        let mut methods = Vec::new();
-        for (wado_name, (mut functions, reasons)) in candidates {
-            match functions.len() {
-                1 => methods.push(functions.pop().unwrap()),
-                0 => skipped.extend(
-                    reasons
-                        .into_iter()
-                        .map(|reason| format!("{name}.{wado_name}: {reason}")),
-                ),
-                n => skipped.push(format!("{name}.{wado_name}: {n} overloads")),
-            }
-        }
+        let methods = lowering.methods_of(name, &path, iface, &mut skipped);
         resources.insert(
             name,
             WadoResource {
@@ -220,31 +197,21 @@ fn merge(snapshot: &Snapshot) -> Result<IndexMap<&str, Merged<'_>>> {
     let mut merged: IndexMap<&str, Merged<'_>> = snapshot
         .slice
         .iter()
-        .map(|name| {
-            (
-                name.as_str(),
-                Merged {
-                    inheritance: None,
-                    global: false,
-                    members: Vec::new(),
-                },
-            )
-        })
+        .map(|name| (name.as_str(), Merged::default()))
         .collect();
-    let mut defined: IndexSet<&str> = IndexSet::new();
     for iface in &snapshot.interfaces {
         let Some(target) = merged.get_mut(iface.name.as_str()) else {
             bail!("interface `{}` is not in the slice", iface.name);
         };
         if !iface.partial {
-            defined.insert(&iface.name);
+            target.defined = true;
             target.inheritance.clone_from(&iface.inheritance);
             target.global = iface.ext_attrs.iter().any(|a| a.name == "Global");
         }
         target.members.extend(&iface.members);
     }
     for (name, iface) in &merged {
-        if !defined.contains(name) {
+        if !iface.defined {
             bail!("the slice names `{name}`, which no interface definition declares");
         }
         if let Some(parent) = &iface.inheritance
@@ -315,6 +282,45 @@ struct Lowering<'a> {
 impl Lowering<'_> {
     fn interface_path(&self, name: &str) -> String {
         format!("web:{}/{}", self.package, to_kebab_case(name))
+    }
+
+    /// Every member of `iface` that lowers, appending to `skipped` the ones
+    /// that do not and the names two overloads compete for.
+    fn methods_of(
+        &self,
+        iface: &str,
+        path: &str,
+        merged: &Merged<'_>,
+        skipped: &mut Vec<String>,
+    ) -> Vec<WadoFunction> {
+        let mut candidates: IndexMap<String, (Vec<WadoFunction>, Vec<String>)> = IndexMap::new();
+        for member in &merged.members {
+            for lowered in self.lower_member(iface, path, member) {
+                match lowered {
+                    Ok(function) => {
+                        candidates
+                            .entry(function.name.clone())
+                            .or_default()
+                            .0
+                            .push(function);
+                    }
+                    Err((name, reason)) => candidates.entry(name).or_default().1.push(reason),
+                }
+            }
+        }
+        let mut methods = Vec::new();
+        for (name, (mut functions, reasons)) in candidates {
+            match functions.len() {
+                1 => methods.push(functions.pop().unwrap()),
+                0 => skipped.extend(
+                    reasons
+                        .into_iter()
+                        .map(|reason| format!("{iface}.{name}: {reason}")),
+                ),
+                n => skipped.push(format!("{iface}.{name}: {n} overloads")),
+            }
+        }
+        methods
     }
 
     /// The functions a member yields: a getter and a setter for an attribute,

--- a/wado-from-idl/src/webidl.rs
+++ b/wado-from-idl/src/webidl.rs
@@ -1,0 +1,590 @@
+//! WebIDL-to-IR transformation, over the webidl2 AST that
+//! `scripts/webidl/snapshot.mjs` writes. See `docs/wep-2026-04-01-tide.md`.
+//!
+//! Every interface in the snapshot becomes an `extern-handle` resource with
+//! one CM interface of its own, `web:<package>/<kebab-name>`. A member whose
+//! type the slice cannot express is skipped and reported, never approximated.
+
+use anyhow::{Result, bail};
+use indexmap::{IndexMap, IndexSet};
+use serde::Deserialize;
+
+use crate::ir::{WadoFunction, WadoInterface, WadoModule, WadoParam, WadoResource, WadoType};
+use crate::naming::{to_kebab_case, to_upper_camel_case, to_wado_identifier};
+
+/// The file `snapshot.mjs` writes: the slice's definitions, in webidl2's shape.
+#[derive(Deserialize)]
+pub struct Snapshot {
+    /// The `@webref/idl` version the slice was taken from.
+    pub webref: String,
+    /// The `web:<package>` the slice generates.
+    pub package: String,
+    /// The interfaces to generate, in output order.
+    pub slice: Vec<String>,
+    /// Every `interface` and `partial interface` of a slice member.
+    pub interfaces: Vec<Interface>,
+    /// Every `interface mixin` (and partial) a slice member includes.
+    pub mixins: Vec<Interface>,
+    /// The `X includes M` statements whose target is in the slice.
+    pub includes: Vec<Includes>,
+    pub typedefs: Vec<Typedef>,
+}
+
+#[derive(Deserialize)]
+pub struct Interface {
+    pub name: String,
+    pub partial: bool,
+    pub inheritance: Option<String>,
+    #[serde(rename = "extAttrs")]
+    pub ext_attrs: Vec<ExtAttr>,
+    pub members: Vec<Member>,
+}
+
+#[derive(Deserialize)]
+pub struct ExtAttr {
+    pub name: String,
+}
+
+#[derive(Deserialize)]
+pub struct Includes {
+    pub target: String,
+    pub includes: String,
+}
+
+#[derive(Deserialize)]
+pub struct Typedef {
+    pub name: String,
+    #[serde(rename = "idlType")]
+    pub idl_type: IdlType,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "type")]
+pub enum Member {
+    #[serde(rename = "attribute")]
+    Attribute {
+        name: String,
+        #[serde(rename = "idlType")]
+        idl_type: IdlType,
+        readonly: bool,
+        special: String,
+    },
+    #[serde(rename = "operation")]
+    Operation {
+        name: String,
+        #[serde(rename = "idlType")]
+        idl_type: IdlType,
+        arguments: Vec<Argument>,
+        special: String,
+    },
+    #[serde(rename = "constructor")]
+    Constructor {
+        arguments: Vec<Argument>,
+        #[serde(rename = "extAttrs")]
+        ext_attrs: Vec<ExtAttr>,
+    },
+    /// `const`, `iterable`, `maplike`, `setlike`: nothing a resource carries.
+    #[serde(other)]
+    Other,
+}
+
+#[derive(Deserialize, Clone)]
+pub struct Argument {
+    pub name: String,
+    #[serde(rename = "idlType")]
+    pub idl_type: IdlType,
+    pub optional: bool,
+    pub variadic: bool,
+}
+
+#[derive(Deserialize, Clone)]
+pub struct IdlType {
+    pub generic: String,
+    pub nullable: bool,
+    pub union: bool,
+    #[serde(rename = "idlType")]
+    pub inner: IdlTypeInner,
+}
+
+#[derive(Deserialize, Clone)]
+#[serde(untagged)]
+pub enum IdlTypeInner {
+    Name(String),
+    Types(Vec<IdlType>),
+}
+
+/// The generated module, and every member the slice could not express.
+#[derive(Debug)]
+pub struct WebIdlOutput {
+    pub module: WadoModule,
+    /// `Interface.member: reason`, in source order.
+    pub skipped: Vec<String>,
+}
+
+/// One interface with its partials and mixins folded in.
+struct Merged<'a> {
+    inheritance: Option<String>,
+    global: bool,
+    members: Vec<&'a Member>,
+}
+
+/// A member's lowering: a function, or why there is none.
+type Lowered = std::result::Result<WadoFunction, String>;
+
+/// Generate the `web:<package>` module's source from a snapshot, naming
+/// `source` in its header: the generated code and the skipped members.
+///
+/// # Errors
+///
+/// See [`transform`].
+pub fn generate(snapshot: &Snapshot, source: &str) -> Result<(String, Vec<String>)> {
+    let WebIdlOutput {
+        mut module,
+        skipped,
+    } = transform(snapshot)?;
+    module.source_files = vec![source.to_string()];
+    module.stdlib_identity = Some(format!("web:{}", snapshot.package));
+    Ok((crate::WadoCodeGenerator::new().generate(&module), skipped))
+}
+
+/// Transform a snapshot into the `web:<package>` module.
+///
+/// # Errors
+///
+/// Fails when the slice is not closed — a parent or a mixin it names is
+/// missing — or when a child redeclares an inherited method.
+pub fn transform(snapshot: &Snapshot) -> Result<WebIdlOutput> {
+    let typedefs: IndexMap<&str, &IdlType> = snapshot
+        .typedefs
+        .iter()
+        .map(|t| (t.name.as_str(), &t.idl_type))
+        .collect();
+    let merged = merge(snapshot)?;
+    let lowering = Lowering {
+        package: &snapshot.package,
+        slice: merged.keys().copied().collect(),
+        typedefs,
+    };
+
+    let mut skipped = Vec::new();
+    let mut resources = Vec::new();
+    for (name, iface) in &merged {
+        let mut candidates: IndexMap<String, Vec<Lowered>> = IndexMap::new();
+        for member in &iface.members {
+            for (wado_name, lowered) in lowering.lower_member(name, member) {
+                candidates.entry(wado_name).or_default().push(lowered);
+            }
+        }
+        let mut methods = Vec::new();
+        for (wado_name, lowered) in candidates {
+            let (ok, reasons): (Vec<_>, Vec<_>) = lowered.into_iter().partition(Result::is_ok);
+            match ok.len() {
+                1 => methods.push(ok.into_iter().next().unwrap().unwrap()),
+                0 => skipped.extend(
+                    reasons
+                        .into_iter()
+                        .map(|r| format!("{name}.{wado_name}: {}", r.unwrap_err())),
+                ),
+                n => skipped.push(format!("{name}.{wado_name}: {n} overloads")),
+            }
+        }
+        resources.push(WadoResource {
+            name: to_upper_camel_case(name),
+            doc_comment: None,
+            cm_attr: lowering.interface_path(name),
+            extern_handle: true,
+            extends: iface.inheritance.as_deref().map(to_upper_camel_case),
+            methods,
+        });
+    }
+    reject_overrides(&merged, &resources)?;
+
+    let mut module = WadoModule::new(snapshot.package.clone(), snapshot.webref.clone());
+    module
+        .interfaces
+        .extend(lowering.global_effect(&merged, &resources));
+    module.resources = resources;
+    Ok(WebIdlOutput { module, skipped })
+}
+
+/// Fold partials and mixins into their interface, in slice order.
+fn merge(snapshot: &Snapshot) -> Result<IndexMap<&str, Merged<'_>>> {
+    let mut merged: IndexMap<&str, Merged<'_>> = snapshot
+        .slice
+        .iter()
+        .map(|name| {
+            (
+                name.as_str(),
+                Merged {
+                    inheritance: None,
+                    global: false,
+                    members: Vec::new(),
+                },
+            )
+        })
+        .collect();
+    let mut defined: IndexSet<&str> = IndexSet::new();
+    for iface in &snapshot.interfaces {
+        let Some(target) = merged.get_mut(iface.name.as_str()) else {
+            bail!("interface `{}` is not in the slice", iface.name);
+        };
+        if !iface.partial {
+            defined.insert(&iface.name);
+            target.inheritance.clone_from(&iface.inheritance);
+            target.global = iface.ext_attrs.iter().any(|a| a.name == "Global");
+        }
+        target.members.extend(&iface.members);
+    }
+    for name in merged.keys() {
+        if !defined.contains(name) {
+            bail!("the slice names `{name}`, which no interface definition declares");
+        }
+    }
+    for (name, iface) in &merged {
+        if let Some(parent) = &iface.inheritance
+            && !merged.contains_key(parent.as_str())
+        {
+            bail!("`{name}` extends `{parent}`, which is not in the slice: add it");
+        }
+    }
+    for inc in &snapshot.includes {
+        let Some(target) = merged.get_mut(inc.target.as_str()) else {
+            bail!("`{}` is not in the slice", inc.target);
+        };
+        let parts: Vec<&Interface> = snapshot
+            .mixins
+            .iter()
+            .filter(|m| m.name == inc.includes)
+            .collect();
+        if !parts.iter().any(|m| !m.partial) {
+            bail!(
+                "`{}` includes `{}`, which the snapshot does not define",
+                inc.target,
+                inc.includes
+            );
+        }
+        for mixin in parts {
+            target.members.extend(&mixin.members);
+        }
+    }
+    Ok(merged)
+}
+
+/// A child may not redeclare a method reachable through its chain. Statics
+/// (`new` above all) are not inherited, so they are not in the question.
+fn reject_overrides(merged: &IndexMap<&str, Merged<'_>>, resources: &[WadoResource]) -> Result<()> {
+    let methods: IndexMap<&str, IndexSet<&str>> = merged
+        .keys()
+        .zip(resources)
+        .map(|(name, r)| {
+            let receivers = r
+                .methods
+                .iter()
+                .filter(|m| m.params.first().is_some_and(|p| p.name == "self"))
+                .map(|m| m.name.as_str())
+                .collect();
+            (*name, receivers)
+        })
+        .collect();
+    for (name, iface) in merged {
+        let mut ancestor = iface.inheritance.as_deref();
+        while let Some(parent) = ancestor {
+            if let Some(method) = methods[name].intersection(&methods[parent]).next() {
+                bail!("`{name}.{method}` redeclares a method inherited from `{parent}`");
+            }
+            ancestor = merged[parent].inheritance.as_deref();
+        }
+    }
+    Ok(())
+}
+
+struct Lowering<'a> {
+    package: &'a str,
+    slice: IndexSet<&'a str>,
+    typedefs: IndexMap<&'a str, &'a IdlType>,
+}
+
+impl Lowering<'_> {
+    fn interface_path(&self, name: &str) -> String {
+        format!("web:{}/{}", self.package, to_kebab_case(name))
+    }
+
+    /// The functions a member yields, keyed by Wado name: a getter and a
+    /// setter for an attribute, one function otherwise.
+    fn lower_member(&self, iface: &str, member: &Member) -> Vec<(String, Lowered)> {
+        let path = self.interface_path(iface);
+        match member {
+            Member::Attribute {
+                name,
+                idl_type,
+                readonly,
+                special,
+            } => {
+                let getter_name = to_wado_identifier(name);
+                if special == "static" {
+                    return vec![(getter_name, Err("static attribute".to_string()))];
+                }
+                let ty = match self.lower_type(idl_type) {
+                    Ok(ty) => ty,
+                    Err(reason) => return vec![(getter_name, Err(reason))],
+                };
+                let kebab = to_kebab_case(name);
+                let mut out = vec![(
+                    getter_name.clone(),
+                    Ok(WadoFunction {
+                        name: getter_name,
+                        doc_comment: None,
+                        cm_attr: format!("{path}#{kebab}"),
+                        params: vec![self_param(iface)],
+                        return_type: Some(ty.clone()),
+                        is_async: false,
+                        never_returns: false,
+                    }),
+                )];
+                if !readonly {
+                    let setter_name = format!("set_{}", to_wado_identifier(name));
+                    out.push((
+                        setter_name.clone(),
+                        Ok(WadoFunction {
+                            name: setter_name,
+                            doc_comment: None,
+                            cm_attr: format!("{path}#set-{kebab}"),
+                            params: vec![
+                                self_param(iface),
+                                WadoParam {
+                                    name: "value".to_string(),
+                                    ty,
+                                    wit_name: "value".to_string(),
+                                },
+                            ],
+                            return_type: None,
+                            is_async: false,
+                            never_returns: false,
+                        }),
+                    ));
+                }
+                out
+            }
+            Member::Operation {
+                name,
+                idl_type,
+                arguments,
+                special,
+            } => {
+                let wado_name = if name.is_empty() {
+                    format!("({special})")
+                } else {
+                    to_wado_identifier(name)
+                };
+                let receiver = match special.as_str() {
+                    "" => Some(self_param(iface)),
+                    "static" => None,
+                    _ => return vec![(wado_name, Err(format!("{special} operation")))],
+                };
+                let lowered = self.lower_operation(
+                    iface,
+                    &wado_name,
+                    format!("{path}#{}", to_kebab_case(name)),
+                    receiver,
+                    arguments,
+                    Some(idl_type),
+                );
+                vec![(wado_name, lowered)]
+            }
+            Member::Constructor {
+                arguments,
+                ext_attrs,
+            } => {
+                // `[HTMLConstructor]` runs only from a custom element definition.
+                if ext_attrs.iter().any(|a| a.name == "HTMLConstructor") {
+                    return vec![("new".to_string(), Err("HTMLConstructor".to_string()))];
+                }
+                let lowered = self.lower_operation(
+                    iface,
+                    "new",
+                    format!("{path}#new"),
+                    None,
+                    arguments,
+                    None,
+                );
+                vec![("new".to_string(), lowered)]
+            }
+            Member::Other => Vec::new(),
+        }
+    }
+
+    /// `return_type` is `None` for a constructor, which yields `iface`.
+    fn lower_operation(
+        &self,
+        iface: &str,
+        wado_name: &str,
+        cm_attr: String,
+        receiver: Option<WadoParam>,
+        arguments: &[Argument],
+        return_type: Option<&IdlType>,
+    ) -> Lowered {
+        let return_type = match return_type {
+            None => Some(WadoType::Named(to_upper_camel_case(iface))),
+            Some(ty) if is_undefined(ty) => None,
+            Some(ty) => Some(self.lower_type(ty)?),
+        };
+        let mut params: Vec<WadoParam> = receiver.into_iter().collect();
+        for arg in arguments {
+            let lowered = if arg.variadic {
+                Err("variadic".to_string())
+            } else {
+                self.lower_type(&arg.idl_type)
+            };
+            let ty = match lowered {
+                Ok(ty) => ty,
+                // A trailing optional the slice cannot express is left to
+                // its WebIDL default; a required one takes the member with it.
+                Err(_) if arg.optional || arg.variadic => break,
+                Err(reason) => return Err(format!("`{}`: {reason}", arg.name)),
+            };
+            // An `optional` argument is an `Option`: `None` is the argument
+            // left out, so the WebIDL default applies in the browser. A CM
+            // operation admits no default argument, which would let a call
+            // site omit it as well.
+            let ty = match ty {
+                WadoType::Option(_) => ty,
+                other if arg.optional => WadoType::Option(Box::new(other)),
+                other => other,
+            };
+            params.push(WadoParam {
+                name: to_wado_identifier(&arg.name),
+                ty,
+                wit_name: to_kebab_case(&arg.name),
+            });
+        }
+        Ok(WadoFunction {
+            name: wado_name.to_string(),
+            doc_comment: None,
+            cm_attr,
+            params,
+            return_type,
+            is_async: false,
+            never_returns: false,
+        })
+    }
+
+    /// The Wado type of a `WebIDL` type, or why the slice has none.
+    ///
+    /// A union collapses to the one constituent the slice can express — the
+    /// `DOMString` of `(TrustedHTML or DOMString)`, the `boolean` shorthand
+    /// of `(ScrollIntoViewOptions or boolean)` — and an `undefined`
+    /// constituent makes it nullable. Two expressible constituents want a
+    /// variant, which is not built.
+    fn lower_type(&self, ty: &IdlType) -> std::result::Result<WadoType, String> {
+        if !ty.generic.is_empty() {
+            return Err(format!("`{}<…>`", ty.generic));
+        }
+        let name = match &ty.inner {
+            IdlTypeInner::Name(name) => name,
+            IdlTypeInner::Types(members) => {
+                let undefined = members.iter().any(is_undefined);
+                let mut expressible = members
+                    .iter()
+                    .filter(|m| !is_undefined(m))
+                    .filter_map(|m| self.lower_type(m).ok());
+                let (Some(one), None) = (expressible.next(), expressible.next()) else {
+                    return Err("union type".to_string());
+                };
+                return Ok(match one {
+                    WadoType::Option(_) => one,
+                    other if ty.nullable || undefined => WadoType::Option(Box::new(other)),
+                    other => other,
+                });
+            }
+        };
+        let inner = match name.as_str() {
+            "boolean" => WadoType::Bool,
+            "byte" => WadoType::I8,
+            "octet" => WadoType::U8,
+            "short" => WadoType::I16,
+            "unsigned short" => WadoType::U16,
+            "long" => WadoType::I32,
+            "unsigned long" => WadoType::U32,
+            "long long" => WadoType::I64,
+            "unsigned long long" => WadoType::U64,
+            "float" | "unrestricted float" => WadoType::F32,
+            "double" | "unrestricted double" => WadoType::F64,
+            "DOMString" | "USVString" | "ByteString" => WadoType::String,
+            "undefined" => return Err("`undefined` outside a return type".to_string()),
+            _ if self.slice.contains(name.as_str()) => WadoType::Named(to_upper_camel_case(name)),
+            _ => match self.typedefs.get(name.as_str()) {
+                Some(target) => {
+                    let mut target = (*target).clone();
+                    target.nullable |= ty.nullable;
+                    return self.lower_type(&target);
+                }
+                None => return Err(format!("`{name}` is outside the slice")),
+            },
+        };
+        Ok(if ty.nullable {
+            WadoType::Option(Box::new(inner))
+        } else {
+            inner
+        })
+    }
+
+    /// The effect handing out the first handle: the `[Global]` interface, and
+    /// each of its read-only attributes typed as another slice resource.
+    fn global_effect(
+        &self,
+        merged: &IndexMap<&str, Merged<'_>>,
+        resources: &[WadoResource],
+    ) -> Option<WadoInterface> {
+        let (name, global) = merged.iter().find(|(_, iface)| iface.global)?;
+        let path = format!("web:{}/global", self.package);
+        let accessor = |name: &str, ty: &str| WadoFunction {
+            name: to_wado_identifier(name),
+            doc_comment: None,
+            cm_attr: format!("{path}#{}", to_kebab_case(name)),
+            params: Vec::new(),
+            return_type: Some(WadoType::Named(ty.to_string())),
+            is_async: false,
+            never_returns: false,
+        };
+        let global_type = to_upper_camel_case(name);
+        let mut functions = vec![accessor(name, &global_type)];
+        let resource = &resources[merged.get_index_of(name).unwrap()];
+        for member in &global.members {
+            if let Member::Attribute {
+                name,
+                idl_type,
+                readonly: true,
+                ..
+            } = member
+                && let Ok(WadoType::Named(ty)) = self.lower_type(idl_type)
+                && ty != global_type
+                && resource
+                    .methods
+                    .iter()
+                    .any(|m| m.name == to_wado_identifier(name))
+            {
+                functions.push(accessor(name, &ty));
+            }
+        }
+        Some(WadoInterface {
+            name: "Dom".to_string(),
+            doc_comment: Some("The DOM entry points, which hand out the first handle.".to_string()),
+            cm_interface: path,
+            functions,
+        })
+    }
+}
+
+fn self_param(iface: &str) -> WadoParam {
+    WadoParam {
+        name: "self".to_string(),
+        ty: WadoType::Borrow(Box::new(WadoType::Named(to_upper_camel_case(iface)))),
+        wit_name: "self".to_string(),
+    }
+}
+
+fn is_undefined(ty: &IdlType) -> bool {
+    matches!(&ty.inner, IdlTypeInner::Name(n) if n == "undefined")
+        && ty.generic.is_empty()
+        && !ty.union
+}

--- a/wado-from-idl/src/webidl.rs
+++ b/wado-from-idl/src/webidl.rs
@@ -109,6 +109,16 @@ pub enum IdlTypeInner {
     Types(Vec<IdlType>),
 }
 
+/// Which way a value crosses the boundary. It decides whether collapsing a
+/// union to its one expressible constituent is lossless: on the way in the
+/// dropped constituents are types the slice cannot build, on the way out they
+/// are values the host may hand back.
+#[derive(Clone, Copy, PartialEq)]
+enum Flow {
+    In,
+    Out,
+}
+
 /// The generated module, and every member the slice could not express.
 #[derive(Debug)]
 pub struct WebIdlOutput {
@@ -337,18 +347,19 @@ impl Lowering<'_> {
                 if special == "static" {
                     return vec![Err((getter, "static attribute".to_string()))];
                 }
-                let ty = match self.lower_type(idl_type) {
-                    Ok(ty) => ty,
-                    Err(reason) => return vec![Err((getter, reason))],
-                };
                 let kebab = to_kebab_case(name);
-                let mut out = vec![Ok(function(
-                    getter,
-                    format!("{path}#{kebab}"),
-                    vec![self_param(iface)],
-                    Some(ty.clone()),
-                ))];
-                if !readonly {
+                let mut out = vec![match self.lower_type(idl_type, Flow::Out) {
+                    Ok(ty) => Ok(function(
+                        getter,
+                        format!("{path}#{kebab}"),
+                        vec![self_param(iface)],
+                        Some(ty),
+                    )),
+                    Err(reason) => Err((getter, reason)),
+                }];
+                // `Flow::In` admits everything `Flow::Out` does, so a setter
+                // that fails here fails for the reason the getter just gave.
+                if let Some(Ok(ty)) = (!readonly).then(|| self.lower_type(idl_type, Flow::In)) {
                     let value = WadoParam {
                         name: "value".to_string(),
                         ty,
@@ -423,7 +434,7 @@ impl Lowering<'_> {
         let return_type = match return_type {
             None => Some(WadoType::Named(to_upper_camel_case(iface))),
             Some(ty) if is_undefined(ty) => None,
-            Some(ty) => match self.lower_type(ty) {
+            Some(ty) => match self.lower_type(ty, Flow::Out) {
                 Ok(ty) => Some(ty),
                 Err(reason) => return skip(reason),
             },
@@ -433,7 +444,7 @@ impl Lowering<'_> {
             if arg.variadic {
                 return skip(format!("`{}`: variadic", arg.name));
             }
-            let ty = match self.lower_type(&arg.idl_type) {
+            let ty = match self.lower_type(&arg.idl_type, Flow::In) {
                 Ok(ty) => ty,
                 // A trailing optional the slice cannot express is left to
                 // its WebIDL default; a required one takes the member with it.
@@ -453,23 +464,29 @@ impl Lowering<'_> {
 
     /// The Wado type of a `WebIDL` type, or why the slice has none. A union is
     /// the one constituent the slice can express; `undefined` in it means nullable.
-    fn lower_type(&self, ty: &IdlType) -> std::result::Result<WadoType, String> {
+    fn lower_type(&self, ty: &IdlType, flow: Flow) -> std::result::Result<WadoType, String> {
         if !ty.generic.is_empty() {
             return Err(format!("`{}<…>`", ty.generic));
         }
         let (inner, nullable) = match &ty.inner {
-            IdlTypeInner::Name(name) => (self.lower_name(name)?, ty.nullable),
+            IdlTypeInner::Name(name) => (self.lower_name(name, flow)?, ty.nullable),
             IdlTypeInner::Types(constituents) => {
                 let mut expressible = Vec::new();
                 let mut reasons = Vec::new();
                 for constituent in constituents.iter().filter(|c| !is_undefined(c)) {
-                    match self.lower_type(constituent) {
+                    match self.lower_type(constituent, flow) {
                         Ok(ty) => expressible.push(ty),
                         Err(reason) => reasons.push(reason),
                     }
                 }
                 match expressible.len() {
-                    1 => (),
+                    1 if reasons.is_empty() || flow == Flow::In => (),
+                    1 => {
+                        return Err(format!(
+                            "union narrowed in a result: {}",
+                            reasons.join("; ")
+                        ));
+                    }
                     0 => return Err(format!("union: {}", reasons.join("; "))),
                     n => return Err(format!("union of {n} expressible types")),
                 }
@@ -480,7 +497,7 @@ impl Lowering<'_> {
         Ok(optional(inner, nullable))
     }
 
-    fn lower_name(&self, name: &str) -> std::result::Result<WadoType, String> {
+    fn lower_name(&self, name: &str, flow: Flow) -> std::result::Result<WadoType, String> {
         Ok(match name {
             "boolean" => WadoType::Bool,
             "byte" => WadoType::I8,
@@ -497,7 +514,7 @@ impl Lowering<'_> {
             "undefined" => return Err("`undefined` outside a return type".to_string()),
             _ if self.slice.contains(name) => WadoType::Named(to_upper_camel_case(name)),
             _ => match self.typedefs.get(name) {
-                Some(target) => return self.lower_type(target),
+                Some(target) => return self.lower_type(target, flow),
                 None => return Err(format!("`{name}` is outside the slice")),
             },
         })
@@ -544,7 +561,7 @@ impl Lowering<'_> {
                 readonly: true,
                 ..
             } = member
-                && let Ok(WadoType::Named(ty)) = self.lower_type(idl_type)
+                && let Ok(WadoType::Named(ty)) = self.lower_type(idl_type, Flow::Out)
                 && ty != global_type
             {
                 let wado_name = to_wado_identifier(name);

--- a/wado-from-idl/src/webidl.rs
+++ b/wado-from-idl/src/webidl.rs
@@ -124,8 +124,9 @@ struct Merged<'a> {
     members: Vec<&'a Member>,
 }
 
-/// A member's lowering: a function, or why there is none.
-type Lowered = std::result::Result<WadoFunction, String>;
+/// A member's lowering: a function, or the Wado name it would have had and
+/// why there is none.
+type Lowered = std::result::Result<WadoFunction, (String, String)>;
 
 /// The `web:<package>` module's source, naming `source` in its header, and
 /// the skipped members.
@@ -147,8 +148,8 @@ pub fn generate(snapshot: &Snapshot, source: &str) -> Result<(String, Vec<String
 ///
 /// # Errors
 ///
-/// The slice is not closed (a parent or a mixin it names is missing), or a
-/// child redeclares an inherited method.
+/// The slice is not closed (a parent or a mixin it names is missing), a child
+/// redeclares an inherited method, or the slice holds two `[Global]` interfaces.
 pub fn transform(snapshot: &Snapshot) -> Result<WebIdlOutput> {
     let merged = merge(snapshot)?;
     let lowering = Lowering {
@@ -162,43 +163,55 @@ pub fn transform(snapshot: &Snapshot) -> Result<WebIdlOutput> {
     };
 
     let mut skipped = Vec::new();
-    let mut resources = Vec::new();
+    let mut resources: IndexMap<&str, WadoResource> = IndexMap::new();
     for (name, iface) in &merged {
-        let mut candidates: IndexMap<String, Vec<Lowered>> = IndexMap::new();
+        let path = lowering.interface_path(name);
+        let mut candidates: IndexMap<String, (Vec<WadoFunction>, Vec<String>)> = IndexMap::new();
         for member in &iface.members {
-            for (wado_name, lowered) in lowering.lower_member(name, member) {
-                candidates.entry(wado_name).or_default().push(lowered);
+            for lowered in lowering.lower_member(name, &path, member) {
+                match lowered {
+                    Ok(function) => candidates
+                        .entry(function.name.clone())
+                        .or_default()
+                        .0
+                        .push(function),
+                    Err((wado_name, reason)) => {
+                        candidates.entry(wado_name).or_default().1.push(reason);
+                    }
+                }
             }
         }
         let mut methods = Vec::new();
-        for (wado_name, lowered) in candidates {
-            let (ok, reasons): (Vec<_>, Vec<_>) = lowered.into_iter().partition(Result::is_ok);
-            match ok.len() {
-                1 => methods.push(ok.into_iter().next().unwrap().unwrap()),
+        for (wado_name, (mut functions, reasons)) in candidates {
+            match functions.len() {
+                1 => methods.push(functions.pop().unwrap()),
                 0 => skipped.extend(
                     reasons
                         .into_iter()
-                        .map(|r| format!("{name}.{wado_name}: {}", r.unwrap_err())),
+                        .map(|reason| format!("{name}.{wado_name}: {reason}")),
                 ),
                 n => skipped.push(format!("{name}.{wado_name}: {n} overloads")),
             }
         }
-        resources.push(WadoResource {
-            name: to_upper_camel_case(name),
-            doc_comment: None,
-            cm_attr: lowering.interface_path(name),
-            extern_handle: true,
-            extends: iface.inheritance.as_deref().map(to_upper_camel_case),
-            methods,
-        });
+        resources.insert(
+            name,
+            WadoResource {
+                name: to_upper_camel_case(name),
+                doc_comment: None,
+                cm_attr: path,
+                extern_handle: true,
+                extends: iface.inheritance.as_deref().map(to_upper_camel_case),
+                methods,
+            },
+        );
     }
     reject_overrides(&merged, &resources)?;
 
     let mut module = WadoModule::new(snapshot.package.clone(), snapshot.webref.clone());
     module
         .interfaces
-        .extend(lowering.global_effect(&merged, &resources));
-    module.resources = resources;
+        .extend(lowering.global_effect(&merged, &resources)?);
+    module.resources = resources.into_values().collect();
     Ok(WebIdlOutput { module, skipped })
 }
 
@@ -230,12 +243,10 @@ fn merge(snapshot: &Snapshot) -> Result<IndexMap<&str, Merged<'_>>> {
         }
         target.members.extend(&iface.members);
     }
-    for name in merged.keys() {
+    for (name, iface) in &merged {
         if !defined.contains(name) {
             bail!("the slice names `{name}`, which no interface definition declares");
         }
-    }
-    for (name, iface) in &merged {
         if let Some(parent) = &iface.inheritance
             && !merged.contains_key(parent.as_str())
         {
@@ -267,10 +278,12 @@ fn merge(snapshot: &Snapshot) -> Result<IndexMap<&str, Merged<'_>>> {
 
 /// A child may not redeclare a method reachable through its chain. Statics
 /// (`new` above all) are not inherited.
-fn reject_overrides(merged: &IndexMap<&str, Merged<'_>>, resources: &[WadoResource]) -> Result<()> {
-    let methods: IndexMap<&str, IndexSet<&str>> = merged
-        .keys()
-        .zip(resources)
+fn reject_overrides(
+    merged: &IndexMap<&str, Merged<'_>>,
+    resources: &IndexMap<&str, WadoResource>,
+) -> Result<()> {
+    let methods: IndexMap<&str, IndexSet<&str>> = resources
+        .iter()
         .map(|(name, r)| {
             let receivers = r
                 .methods
@@ -304,10 +317,9 @@ impl Lowering<'_> {
         format!("web:{}/{}", self.package, to_kebab_case(name))
     }
 
-    /// The functions a member yields, keyed by Wado name: a getter and a
-    /// setter for an attribute, one function otherwise.
-    fn lower_member(&self, iface: &str, member: &Member) -> Vec<(String, Lowered)> {
-        let path = self.interface_path(iface);
+    /// The functions a member yields: a getter and a setter for an attribute,
+    /// one function otherwise. `path` is `iface`'s CM interface.
+    fn lower_member(&self, iface: &str, path: &str, member: &Member) -> Vec<Lowered> {
         match member {
             Member::Attribute {
                 name,
@@ -317,38 +329,31 @@ impl Lowering<'_> {
             } => {
                 let getter = to_wado_identifier(name);
                 if special == "static" {
-                    return vec![(getter, Err("static attribute".to_string()))];
+                    return vec![Err((getter, "static attribute".to_string()))];
                 }
                 let ty = match self.lower_type(idl_type) {
                     Ok(ty) => ty,
-                    Err(reason) => return vec![(getter, Err(reason))],
+                    Err(reason) => return vec![Err((getter, reason))],
                 };
                 let kebab = to_kebab_case(name);
-                let mut out = vec![(
-                    getter.clone(),
-                    Ok(function(
-                        &getter,
-                        format!("{path}#{kebab}"),
-                        vec![self_param(iface)],
-                        Some(ty.clone()),
-                    )),
-                )];
+                let mut out = vec![Ok(function(
+                    getter,
+                    format!("{path}#{kebab}"),
+                    vec![self_param(iface)],
+                    Some(ty.clone()),
+                ))];
                 if !readonly {
-                    let setter = format!("set_{}", to_snake_case(name));
                     let value = WadoParam {
                         name: "value".to_string(),
                         ty,
                         wit_name: "value".to_string(),
                     };
-                    out.push((
-                        setter.clone(),
-                        Ok(function(
-                            &setter,
-                            format!("{path}#set-{kebab}"),
-                            vec![self_param(iface), value],
-                            None,
-                        )),
-                    ));
+                    out.push(Ok(function(
+                        format!("set_{}", to_snake_case(name)),
+                        format!("{path}#set-{kebab}"),
+                        vec![self_param(iface), value],
+                        None,
+                    )));
                 }
                 out
             }
@@ -366,17 +371,16 @@ impl Lowering<'_> {
                 let receiver = match special.as_str() {
                     "" => Some(self_param(iface)),
                     "static" => None,
-                    _ => return vec![(wado_name, Err(format!("{special} operation")))],
+                    _ => return vec![Err((wado_name, format!("{special} operation")))],
                 };
-                let lowered = self.lower_operation(
+                vec![self.lower_operation(
                     iface,
-                    &wado_name,
+                    wado_name,
                     format!("{path}#{}", to_kebab_case(name)),
                     receiver,
                     arguments,
                     Some(idl_type),
-                );
-                vec![(wado_name, lowered)]
+                )]
             }
             Member::Constructor {
                 arguments,
@@ -384,17 +388,16 @@ impl Lowering<'_> {
             } => {
                 // `[HTMLConstructor]` runs only from a custom element definition.
                 if ext_attrs.iter().any(|a| a.name == "HTMLConstructor") {
-                    return vec![("new".to_string(), Err("HTMLConstructor".to_string()))];
+                    return vec![Err(("new".to_string(), "HTMLConstructor".to_string()))];
                 }
-                let lowered = self.lower_operation(
+                vec![self.lower_operation(
                     iface,
-                    "new",
+                    "new".to_string(),
                     format!("{path}#new"),
                     None,
                     arguments,
                     None,
-                );
-                vec![("new".to_string(), lowered)]
+                )]
             }
             Member::Other => Vec::new(),
         }
@@ -404,30 +407,32 @@ impl Lowering<'_> {
     fn lower_operation(
         &self,
         iface: &str,
-        wado_name: &str,
+        wado_name: String,
         cm_attr: String,
         receiver: Option<WadoParam>,
         arguments: &[Argument],
         return_type: Option<&IdlType>,
     ) -> Lowered {
+        let skip = |reason: String| Err((wado_name.clone(), reason));
         let return_type = match return_type {
             None => Some(WadoType::Named(to_upper_camel_case(iface))),
             Some(ty) if is_undefined(ty) => None,
-            Some(ty) => Some(self.lower_type(ty)?),
+            Some(ty) => match self.lower_type(ty) {
+                Ok(ty) => Some(ty),
+                Err(reason) => return skip(reason),
+            },
         };
         let mut params: Vec<WadoParam> = receiver.into_iter().collect();
         for arg in arguments {
-            let lowered = if arg.variadic {
-                Err("variadic".to_string())
-            } else {
-                self.lower_type(&arg.idl_type)
-            };
-            let ty = match lowered {
+            if arg.variadic {
+                return skip(format!("`{}`: variadic", arg.name));
+            }
+            let ty = match self.lower_type(&arg.idl_type) {
                 Ok(ty) => ty,
                 // A trailing optional the slice cannot express is left to
                 // its WebIDL default; a required one takes the member with it.
-                Err(_) if arg.optional || arg.variadic => break,
-                Err(reason) => return Err(format!("`{}`: {reason}", arg.name)),
+                Err(_) if arg.optional => break,
+                Err(reason) => return skip(format!("`{}`: {reason}", arg.name)),
             };
             // `None` is the argument left out, so the WebIDL default applies in
             // the browser. A CM operation admits no default argument.
@@ -449,14 +454,21 @@ impl Lowering<'_> {
         let (inner, nullable) = match &ty.inner {
             IdlTypeInner::Name(name) => (self.lower_name(name)?, ty.nullable),
             IdlTypeInner::Types(constituents) => {
-                let mut expressible = constituents
-                    .iter()
-                    .filter(|c| !is_undefined(c))
-                    .filter_map(|c| self.lower_type(c).ok());
-                let (Some(one), None) = (expressible.next(), expressible.next()) else {
-                    return Err("union type".to_string());
-                };
-                (one, ty.nullable || constituents.iter().any(is_undefined))
+                let mut expressible = Vec::new();
+                let mut reasons = Vec::new();
+                for constituent in constituents.iter().filter(|c| !is_undefined(c)) {
+                    match self.lower_type(constituent) {
+                        Ok(ty) => expressible.push(ty),
+                        Err(reason) => reasons.push(reason),
+                    }
+                }
+                match expressible.len() {
+                    1 => (),
+                    0 => return Err(format!("union: {}", reasons.join("; "))),
+                    n => return Err(format!("union of {n} expressible types")),
+                }
+                let nullable = ty.nullable || constituents.iter().any(is_undefined);
+                (expressible.pop().unwrap(), nullable)
             }
         };
         Ok(optional(inner, nullable))
@@ -490,21 +502,35 @@ impl Lowering<'_> {
     fn global_effect(
         &self,
         merged: &IndexMap<&str, Merged<'_>>,
-        resources: &[WadoResource],
-    ) -> Option<WadoInterface> {
-        let (name, global) = merged.iter().find(|(_, iface)| iface.global)?;
+        resources: &IndexMap<&str, WadoResource>,
+    ) -> Result<Option<WadoInterface>> {
+        let mut globals = merged.iter().filter(|(_, iface)| iface.global);
+        let Some((name, global)) = globals.next() else {
+            return Ok(None);
+        };
+        if let Some((second, _)) = globals.next() {
+            bail!("a package has one `[Global]` interface; the slice has `{name}` and `{second}`");
+        }
         let path = self.interface_path("global");
-        let accessor = |name: &str, ty: &str| {
+        let accessor = |wado_name: String, kebab: &str, ty: &str| {
             function(
-                &to_wado_identifier(name),
-                format!("{path}#{}", to_kebab_case(name)),
+                wado_name,
+                format!("{path}#{kebab}"),
                 Vec::new(),
                 Some(WadoType::Named(ty.to_string())),
             )
         };
         let global_type = to_upper_camel_case(name);
-        let mut functions = vec![accessor(name, &global_type)];
-        let resource = &resources[merged.get_index_of(name).unwrap()];
+        let mut functions = vec![accessor(
+            to_wado_identifier(name),
+            &to_kebab_case(name),
+            &global_type,
+        )];
+        let methods: IndexSet<&str> = resources[name]
+            .methods
+            .iter()
+            .map(|m| m.name.as_str())
+            .collect();
         for member in &global.members {
             if let Member::Attribute {
                 name,
@@ -514,31 +540,33 @@ impl Lowering<'_> {
             } = member
                 && let Ok(WadoType::Named(ty)) = self.lower_type(idl_type)
                 && ty != global_type
-                && resource
-                    .methods
-                    .iter()
-                    .any(|m| m.name == to_wado_identifier(name))
             {
-                functions.push(accessor(name, &ty));
+                let wado_name = to_wado_identifier(name);
+                if methods.contains(wado_name.as_str()) {
+                    functions.push(accessor(wado_name, &to_kebab_case(name), &ty));
+                }
             }
         }
-        Some(WadoInterface {
-            name: "Dom".to_string(),
-            doc_comment: Some("The DOM entry points, which hand out the first handle.".to_string()),
+        Ok(Some(WadoInterface {
+            name: to_upper_camel_case(self.package),
+            doc_comment: Some(format!(
+                "The `web:{}` entry points, which hand out the first handle.",
+                self.package
+            )),
             cm_interface: path,
             functions,
-        })
+        }))
     }
 }
 
 fn function(
-    name: &str,
+    name: String,
     cm_attr: String,
     params: Vec<WadoParam>,
     return_type: Option<WadoType>,
 ) -> WadoFunction {
     WadoFunction {
-        name: name.to_string(),
+        name,
         doc_comment: None,
         cm_attr,
         params,

--- a/wado-from-idl/src/webidl.rs
+++ b/wado-from-idl/src/webidl.rs
@@ -1,16 +1,12 @@
-//! WebIDL-to-IR transformation, over the webidl2 AST that
-//! `scripts/webidl/snapshot.mjs` writes. See `docs/wep-2026-04-01-tide.md`.
-//!
-//! Every interface in the snapshot becomes an `extern-handle` resource with
-//! one CM interface of its own, `web:<package>/<kebab-name>`. A member whose
-//! type the slice cannot express is skipped and reported, never approximated.
+//! WebIDL-to-IR transformation, over the webidl2 AST `scripts/webidl/snapshot.mjs`
+//! writes: one extern-handle resource per interface. See `docs/wep-2026-04-01-tide.md`.
 
 use anyhow::{Result, bail};
 use indexmap::{IndexMap, IndexSet};
 use serde::Deserialize;
 
 use crate::ir::{WadoFunction, WadoInterface, WadoModule, WadoParam, WadoResource, WadoType};
-use crate::naming::{to_kebab_case, to_upper_camel_case, to_wado_identifier};
+use crate::naming::{to_kebab_case, to_snake_case, to_upper_camel_case, to_wado_identifier};
 
 /// The file `snapshot.mjs` writes: the slice's definitions, in webidl2's shape.
 #[derive(Deserialize)]
@@ -88,7 +84,7 @@ pub enum Member {
     Other,
 }
 
-#[derive(Deserialize, Clone)]
+#[derive(Deserialize)]
 pub struct Argument {
     pub name: String,
     #[serde(rename = "idlType")]
@@ -97,16 +93,16 @@ pub struct Argument {
     pub variadic: bool,
 }
 
-#[derive(Deserialize, Clone)]
+#[derive(Deserialize)]
 pub struct IdlType {
     pub generic: String,
     pub nullable: bool,
-    pub union: bool,
     #[serde(rename = "idlType")]
     pub inner: IdlTypeInner,
 }
 
-#[derive(Deserialize, Clone)]
+/// A name, or the constituents of a union or of a generic's arguments.
+#[derive(Deserialize)]
 #[serde(untagged)]
 pub enum IdlTypeInner {
     Name(String),
@@ -131,8 +127,8 @@ struct Merged<'a> {
 /// A member's lowering: a function, or why there is none.
 type Lowered = std::result::Result<WadoFunction, String>;
 
-/// Generate the `web:<package>` module's source from a snapshot, naming
-/// `source` in its header: the generated code and the skipped members.
+/// The `web:<package>` module's source, naming `source` in its header, and
+/// the skipped members.
 ///
 /// # Errors
 ///
@@ -151,19 +147,18 @@ pub fn generate(snapshot: &Snapshot, source: &str) -> Result<(String, Vec<String
 ///
 /// # Errors
 ///
-/// Fails when the slice is not closed — a parent or a mixin it names is
-/// missing — or when a child redeclares an inherited method.
+/// The slice is not closed (a parent or a mixin it names is missing), or a
+/// child redeclares an inherited method.
 pub fn transform(snapshot: &Snapshot) -> Result<WebIdlOutput> {
-    let typedefs: IndexMap<&str, &IdlType> = snapshot
-        .typedefs
-        .iter()
-        .map(|t| (t.name.as_str(), &t.idl_type))
-        .collect();
     let merged = merge(snapshot)?;
     let lowering = Lowering {
         package: &snapshot.package,
         slice: merged.keys().copied().collect(),
-        typedefs,
+        typedefs: snapshot
+            .typedefs
+            .iter()
+            .map(|t| (t.name.as_str(), &t.idl_type))
+            .collect(),
     };
 
     let mut skipped = Vec::new();
@@ -271,7 +266,7 @@ fn merge(snapshot: &Snapshot) -> Result<IndexMap<&str, Merged<'_>>> {
 }
 
 /// A child may not redeclare a method reachable through its chain. Statics
-/// (`new` above all) are not inherited, so they are not in the question.
+/// (`new` above all) are not inherited.
 fn reject_overrides(merged: &IndexMap<&str, Merged<'_>>, resources: &[WadoResource]) -> Result<()> {
     let methods: IndexMap<&str, IndexSet<&str>> = merged
         .keys()
@@ -320,47 +315,39 @@ impl Lowering<'_> {
                 readonly,
                 special,
             } => {
-                let getter_name = to_wado_identifier(name);
+                let getter = to_wado_identifier(name);
                 if special == "static" {
-                    return vec![(getter_name, Err("static attribute".to_string()))];
+                    return vec![(getter, Err("static attribute".to_string()))];
                 }
                 let ty = match self.lower_type(idl_type) {
                     Ok(ty) => ty,
-                    Err(reason) => return vec![(getter_name, Err(reason))],
+                    Err(reason) => return vec![(getter, Err(reason))],
                 };
                 let kebab = to_kebab_case(name);
                 let mut out = vec![(
-                    getter_name.clone(),
-                    Ok(WadoFunction {
-                        name: getter_name,
-                        doc_comment: None,
-                        cm_attr: format!("{path}#{kebab}"),
-                        params: vec![self_param(iface)],
-                        return_type: Some(ty.clone()),
-                        is_async: false,
-                        never_returns: false,
-                    }),
+                    getter.clone(),
+                    Ok(function(
+                        &getter,
+                        format!("{path}#{kebab}"),
+                        vec![self_param(iface)],
+                        Some(ty.clone()),
+                    )),
                 )];
                 if !readonly {
-                    let setter_name = format!("set_{}", to_wado_identifier(name));
+                    let setter = format!("set_{}", to_snake_case(name));
+                    let value = WadoParam {
+                        name: "value".to_string(),
+                        ty,
+                        wit_name: "value".to_string(),
+                    };
                     out.push((
-                        setter_name.clone(),
-                        Ok(WadoFunction {
-                            name: setter_name,
-                            doc_comment: None,
-                            cm_attr: format!("{path}#set-{kebab}"),
-                            params: vec![
-                                self_param(iface),
-                                WadoParam {
-                                    name: "value".to_string(),
-                                    ty,
-                                    wit_name: "value".to_string(),
-                                },
-                            ],
-                            return_type: None,
-                            is_async: false,
-                            never_returns: false,
-                        }),
+                        setter.clone(),
+                        Ok(function(
+                            &setter,
+                            format!("{path}#set-{kebab}"),
+                            vec![self_param(iface), value],
+                            None,
+                        )),
                     ));
                 }
                 out
@@ -442,62 +429,41 @@ impl Lowering<'_> {
                 Err(_) if arg.optional || arg.variadic => break,
                 Err(reason) => return Err(format!("`{}`: {reason}", arg.name)),
             };
-            // An `optional` argument is an `Option`: `None` is the argument
-            // left out, so the WebIDL default applies in the browser. A CM
-            // operation admits no default argument, which would let a call
-            // site omit it as well.
-            let ty = match ty {
-                WadoType::Option(_) => ty,
-                other if arg.optional => WadoType::Option(Box::new(other)),
-                other => other,
-            };
+            // `None` is the argument left out, so the WebIDL default applies in
+            // the browser. A CM operation admits no default argument.
             params.push(WadoParam {
                 name: to_wado_identifier(&arg.name),
-                ty,
+                ty: optional(ty, arg.optional),
                 wit_name: to_kebab_case(&arg.name),
             });
         }
-        Ok(WadoFunction {
-            name: wado_name.to_string(),
-            doc_comment: None,
-            cm_attr,
-            params,
-            return_type,
-            is_async: false,
-            never_returns: false,
-        })
+        Ok(function(wado_name, cm_attr, params, return_type))
     }
 
-    /// The Wado type of a `WebIDL` type, or why the slice has none.
-    ///
-    /// A union collapses to the one constituent the slice can express — the
-    /// `DOMString` of `(TrustedHTML or DOMString)`, the `boolean` shorthand
-    /// of `(ScrollIntoViewOptions or boolean)` — and an `undefined`
-    /// constituent makes it nullable. Two expressible constituents want a
-    /// variant, which is not built.
+    /// The Wado type of a `WebIDL` type, or why the slice has none. A union is
+    /// the one constituent the slice can express; `undefined` in it means nullable.
     fn lower_type(&self, ty: &IdlType) -> std::result::Result<WadoType, String> {
         if !ty.generic.is_empty() {
             return Err(format!("`{}<…>`", ty.generic));
         }
-        let name = match &ty.inner {
-            IdlTypeInner::Name(name) => name,
-            IdlTypeInner::Types(members) => {
-                let undefined = members.iter().any(is_undefined);
-                let mut expressible = members
+        let (inner, nullable) = match &ty.inner {
+            IdlTypeInner::Name(name) => (self.lower_name(name)?, ty.nullable),
+            IdlTypeInner::Types(constituents) => {
+                let mut expressible = constituents
                     .iter()
-                    .filter(|m| !is_undefined(m))
-                    .filter_map(|m| self.lower_type(m).ok());
+                    .filter(|c| !is_undefined(c))
+                    .filter_map(|c| self.lower_type(c).ok());
                 let (Some(one), None) = (expressible.next(), expressible.next()) else {
                     return Err("union type".to_string());
                 };
-                return Ok(match one {
-                    WadoType::Option(_) => one,
-                    other if ty.nullable || undefined => WadoType::Option(Box::new(other)),
-                    other => other,
-                });
+                (one, ty.nullable || constituents.iter().any(is_undefined))
             }
         };
-        let inner = match name.as_str() {
+        Ok(optional(inner, nullable))
+    }
+
+    fn lower_name(&self, name: &str) -> std::result::Result<WadoType, String> {
+        Ok(match name {
             "boolean" => WadoType::Bool,
             "byte" => WadoType::I8,
             "octet" => WadoType::U8,
@@ -511,20 +477,11 @@ impl Lowering<'_> {
             "double" | "unrestricted double" => WadoType::F64,
             "DOMString" | "USVString" | "ByteString" => WadoType::String,
             "undefined" => return Err("`undefined` outside a return type".to_string()),
-            _ if self.slice.contains(name.as_str()) => WadoType::Named(to_upper_camel_case(name)),
-            _ => match self.typedefs.get(name.as_str()) {
-                Some(target) => {
-                    let mut target = (*target).clone();
-                    target.nullable |= ty.nullable;
-                    return self.lower_type(&target);
-                }
+            _ if self.slice.contains(name) => WadoType::Named(to_upper_camel_case(name)),
+            _ => match self.typedefs.get(name) {
+                Some(target) => return self.lower_type(target),
                 None => return Err(format!("`{name}` is outside the slice")),
             },
-        };
-        Ok(if ty.nullable {
-            WadoType::Option(Box::new(inner))
-        } else {
-            inner
         })
     }
 
@@ -536,15 +493,14 @@ impl Lowering<'_> {
         resources: &[WadoResource],
     ) -> Option<WadoInterface> {
         let (name, global) = merged.iter().find(|(_, iface)| iface.global)?;
-        let path = format!("web:{}/global", self.package);
-        let accessor = |name: &str, ty: &str| WadoFunction {
-            name: to_wado_identifier(name),
-            doc_comment: None,
-            cm_attr: format!("{path}#{}", to_kebab_case(name)),
-            params: Vec::new(),
-            return_type: Some(WadoType::Named(ty.to_string())),
-            is_async: false,
-            never_returns: false,
+        let path = self.interface_path("global");
+        let accessor = |name: &str, ty: &str| {
+            function(
+                &to_wado_identifier(name),
+                format!("{path}#{}", to_kebab_case(name)),
+                Vec::new(),
+                Some(WadoType::Named(ty.to_string())),
+            )
         };
         let global_type = to_upper_camel_case(name);
         let mut functions = vec![accessor(name, &global_type)];
@@ -575,6 +531,23 @@ impl Lowering<'_> {
     }
 }
 
+fn function(
+    name: &str,
+    cm_attr: String,
+    params: Vec<WadoParam>,
+    return_type: Option<WadoType>,
+) -> WadoFunction {
+    WadoFunction {
+        name: name.to_string(),
+        doc_comment: None,
+        cm_attr,
+        params,
+        return_type,
+        is_async: false,
+        never_returns: false,
+    }
+}
+
 fn self_param(iface: &str) -> WadoParam {
     WadoParam {
         name: "self".to_string(),
@@ -583,8 +556,15 @@ fn self_param(iface: &str) -> WadoParam {
     }
 }
 
+/// `ty` as an `Option` when `wrap`, without doubling one it already is.
+fn optional(ty: WadoType, wrap: bool) -> WadoType {
+    match ty {
+        WadoType::Option(_) => ty,
+        ty if wrap => WadoType::Option(Box::new(ty)),
+        ty => ty,
+    }
+}
+
 fn is_undefined(ty: &IdlType) -> bool {
-    matches!(&ty.inner, IdlTypeInner::Name(n) if n == "undefined")
-        && ty.generic.is_empty()
-        && !ty.union
+    ty.generic.is_empty() && matches!(&ty.inner, IdlTypeInner::Name(n) if n == "undefined")
 }

--- a/wado-from-idl/tests/web_dom_is_fresh.rs
+++ b/wado-from-idl/tests/web_dom_is_fresh.rs
@@ -1,0 +1,21 @@
+//! `wado-compiler/lib/web/dom.wado` is what the vendored snapshot generates.
+//! Regenerate with `mise run update-stdlib-web`.
+
+use std::path::Path;
+
+#[test]
+fn the_bundled_web_dom_module_is_generated_from_the_vendored_snapshot() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("..");
+    let source = "wado-compiler/lib/web/dom.webidl.json";
+    let json = std::fs::read_to_string(root.join(source)).expect("the snapshot is vendored");
+    let snapshot: wado_from_idl::webidl::Snapshot =
+        serde_json::from_str(&json).expect("the snapshot parses");
+    let (generated, _skipped) =
+        wado_from_idl::webidl::generate(&snapshot, source).expect("the slice transforms");
+    let bundled = std::fs::read_to_string(root.join("wado-compiler/lib/web/dom.wado"))
+        .expect("the module is bundled");
+    assert!(
+        generated == bundled,
+        "wado-compiler/lib/web/dom.wado is stale: run `mise run update-stdlib-web`"
+    );
+}

--- a/wado-from-idl/tests/webidl.rs
+++ b/wado-from-idl/tests/webidl.rs
@@ -38,20 +38,22 @@ impl Definitions {
     }
 }
 
-fn plain(name: &str) -> String {
+fn named(name: &str, nullable: bool) -> String {
     format!(
-        r#"{{"type": "attribute-type", "extAttrs": [], "generic": "", "nullable": false, "union": false, "idlType": "{name}"}}"#
+        r#"{{"type": "attribute-type", "extAttrs": [], "generic": "", "nullable": {nullable}, "union": false, "idlType": "{name}"}}"#
     )
+}
+
+fn plain(name: &str) -> String {
+    named(name, false)
 }
 
 fn nullable(name: &str) -> String {
-    plain(name).replace(r#""nullable": false"#, r#""nullable": true"#)
+    named(name, true)
 }
 
 fn typedef(name: &str, ty: &str) -> String {
-    format!(
-        r#"{{"spec": "hr-time", "type": "typedef", "name": "{name}", "idlType": {ty}, "extAttrs": []}}"#
-    )
+    format!(r#"{{"type": "typedef", "name": "{name}", "idlType": {ty}, "extAttrs": []}}"#)
 }
 
 fn attribute(name: &str, ty: &str, readonly: bool) -> String {
@@ -66,6 +68,10 @@ fn argument(name: &str, ty: &str, optional: bool, default: &str) -> String {
     )
 }
 
+fn variadic(name: &str, ty: &str) -> String {
+    argument(name, ty, true, "null").replace(r#""variadic": false"#, r#""variadic": true"#)
+}
+
 fn operation(name: &str, ret: &str, args: &[String], special: &str) -> String {
     format!(
         r#"{{"type": "operation", "name": "{name}", "idlType": {ret}, "arguments": [{}], "extAttrs": [], "special": "{special}"}}"#,
@@ -78,20 +84,21 @@ fn definition(
     name: &str,
     inheritance: &str,
     ext_attrs: &str,
+    partial: bool,
     members: &[String],
 ) -> String {
     format!(
-        r#"{{"spec": "dom", "type": "{kind}", "name": "{name}", "inheritance": {inheritance}, "partial": false, "extAttrs": [{ext_attrs}], "members": [{}]}}"#,
+        r#"{{"type": "{kind}", "name": "{name}", "inheritance": {inheritance}, "partial": {partial}, "extAttrs": [{ext_attrs}], "members": [{}]}}"#,
         members.join(", ")
     )
 }
 
 fn interface(name: &str, inheritance: &str, ext_attrs: &str, members: &[String]) -> String {
-    definition("interface", name, inheritance, ext_attrs, members)
+    definition("interface", name, inheritance, ext_attrs, false, members)
 }
 
 fn partial(name: &str, members: &[String]) -> String {
-    interface(name, "null", "", members).replace(r#""partial": false"#, r#""partial": true"#)
+    definition("interface", name, "null", "", true, members)
 }
 
 const GLOBAL: &str =
@@ -254,7 +261,8 @@ fn an_optional_argument_is_an_option() {
 fn a_keyword_is_escaped_a_typedef_resolves_and_a_const_is_not_a_member() {
     let (code, _) = chain().generate();
     assert!(code.contains("fn self_(&self) -> Window;"), "{code}");
-    assert!(code.contains("fn type_(&self) -> String;"), "{code}");
+    // `type` is a keyword the parser takes as a name.
+    assert!(code.contains("fn type(&self) -> String;"), "{code}");
     assert!(
         code.contains("fn set_type(&self, value: String);"),
         "{code}"
@@ -297,6 +305,13 @@ fn a_member_the_slice_cannot_express_is_skipped_and_reported() {
             ],
             "",
         ),
+        // A variadic has no default to fall back on, so the member goes.
+        operation(
+            "prepend",
+            &plain("undefined"),
+            &[variadic("nodes", &plain("Node"))],
+            "",
+        ),
         // Two overloads that both lower are ambiguous, so neither is emitted.
         operation("alert", &plain("undefined"), &[], ""),
         operation(
@@ -327,7 +342,8 @@ fn a_member_the_slice_cannot_express_is_skipped_and_reported() {
         [
             "Element.attributes: `NamedNodeMap` is outside the slice",
             "Element.request_fullscreen: `Promise<…>`",
-            "Element.append: `nodes`: union type",
+            "Element.append: `nodes`: union of 2 expressible types",
+            "Element.prepend: `nodes`: variadic",
             "Element.alert: 2 overloads",
             "Element.(getter): getter operation",
         ]
@@ -362,6 +378,14 @@ fn a_union_collapses_to_its_one_expressible_constituent() {
                 &union(&[plain("boolean"), plain("DOMString")], false),
                 false,
             ),
+            attribute(
+                "script",
+                &union(
+                    &[plain("HTMLScriptElement"), plain("SVGScriptElement")],
+                    false,
+                ),
+                true,
+            ),
         ],
     ));
     let (code, skipped) = defs.generate();
@@ -371,7 +395,13 @@ fn a_union_collapses_to_its_one_expressible_constituent() {
         "{code}"
     );
     assert!(code.contains("fn event(&self) -> Option<Node>;"), "{code}");
-    assert_eq!(skipped, ["Element.hidden: union type"]);
+    assert_eq!(
+        skipped,
+        [
+            "Element.hidden: union of 2 expressible types",
+            "Element.script: union: `HTMLScriptElement` is outside the slice; `SVGScriptElement` is outside the slice",
+        ]
+    );
 }
 
 #[test]
@@ -394,6 +424,7 @@ fn a_mixin_folds_into_each_including_interface() {
         "ParentNode",
         "null",
         "",
+        false,
         &[operation(
             "querySelector",
             &nullable("Element"),
@@ -402,7 +433,7 @@ fn a_mixin_folds_into_each_including_interface() {
         )],
     ));
     defs.includes.push(
-        r#"{"spec": "dom", "type": "includes", "extAttrs": [], "target": "Element", "includes": "ParentNode"}"#
+        r#"{"type": "includes", "extAttrs": [], "target": "Element", "includes": "ParentNode"}"#
             .to_string(),
     );
     let (code, skipped) = defs.generate();
@@ -413,6 +444,17 @@ fn a_mixin_folds_into_each_including_interface() {
         "{code}"
     );
     assert_eq!(skipped, Vec::<String>::new());
+}
+
+#[test]
+fn a_second_global_is_rejected() {
+    let mut defs = chain();
+    defs.interfaces[1] = interface("Node", r#""EventTarget""#, GLOBAL, &[]);
+    let err = transform(&defs.build()).expect_err("two globals are an error");
+    assert!(
+        err.to_string().contains("one `[Global]` interface"),
+        "{err}"
+    );
 }
 
 #[test]

--- a/wado-from-idl/tests/webidl.rs
+++ b/wado-from-idl/tests/webidl.rs
@@ -1,0 +1,441 @@
+//! The `WebIDL` frontend, over a hand-written webidl2 snapshot.
+
+use wado_from_idl::WadoCodeGenerator;
+use wado_from_idl::webidl::{Snapshot, WebIdlOutput, transform};
+
+/// The definitions of a snapshot, as the JSON text `snapshot.mjs` writes.
+#[derive(Default)]
+struct Definitions {
+    interfaces: Vec<String>,
+    mixins: Vec<String>,
+    includes: Vec<String>,
+}
+
+impl Definitions {
+    fn build(&self) -> Snapshot {
+        let json = format!(
+            r#"{{
+  "webref": "3.83.1",
+  "package": "dom",
+  "slice": ["EventTarget", "Node", "Element", "Window"],
+  "interfaces": [{}],
+  "mixins": [{}],
+  "includes": [{}],
+  "typedefs": [{}]
+}}"#,
+            self.interfaces.join(", "),
+            self.mixins.join(", "),
+            self.includes.join(", "),
+            typedef("Timestamp", &plain("double")),
+        );
+        serde_json::from_str(&json).expect("the test snapshot should parse")
+    }
+
+    fn generate(&self) -> (String, Vec<String>) {
+        let WebIdlOutput { module, skipped } =
+            transform(&self.build()).expect("the slice should transform");
+        (WadoCodeGenerator::new().generate(&module), skipped)
+    }
+}
+
+fn plain(name: &str) -> String {
+    format!(
+        r#"{{"type": "attribute-type", "extAttrs": [], "generic": "", "nullable": false, "union": false, "idlType": "{name}"}}"#
+    )
+}
+
+fn nullable(name: &str) -> String {
+    plain(name).replace(r#""nullable": false"#, r#""nullable": true"#)
+}
+
+fn typedef(name: &str, ty: &str) -> String {
+    format!(
+        r#"{{"spec": "hr-time", "type": "typedef", "name": "{name}", "idlType": {ty}, "extAttrs": []}}"#
+    )
+}
+
+fn attribute(name: &str, ty: &str, readonly: bool) -> String {
+    format!(
+        r#"{{"type": "attribute", "name": "{name}", "idlType": {ty}, "extAttrs": [], "special": "", "readonly": {readonly}}}"#
+    )
+}
+
+fn argument(name: &str, ty: &str, optional: bool, default: &str) -> String {
+    format!(
+        r#"{{"type": "argument", "name": "{name}", "extAttrs": [], "idlType": {ty}, "default": {default}, "optional": {optional}, "variadic": false}}"#
+    )
+}
+
+fn operation(name: &str, ret: &str, args: &[String], special: &str) -> String {
+    format!(
+        r#"{{"type": "operation", "name": "{name}", "idlType": {ret}, "arguments": [{}], "extAttrs": [], "special": "{special}"}}"#,
+        args.join(", ")
+    )
+}
+
+fn definition(
+    kind: &str,
+    name: &str,
+    inheritance: &str,
+    ext_attrs: &str,
+    members: &[String],
+) -> String {
+    format!(
+        r#"{{"spec": "dom", "type": "{kind}", "name": "{name}", "inheritance": {inheritance}, "partial": false, "extAttrs": [{ext_attrs}], "members": [{}]}}"#,
+        members.join(", ")
+    )
+}
+
+fn interface(name: &str, inheritance: &str, ext_attrs: &str, members: &[String]) -> String {
+    definition("interface", name, inheritance, ext_attrs, members)
+}
+
+fn partial(name: &str, members: &[String]) -> String {
+    interface(name, "null", "", members).replace(r#""partial": false"#, r#""partial": true"#)
+}
+
+const GLOBAL: &str =
+    r#"{"type": "extended-attribute", "name": "Global", "rhs": null, "arguments": []}"#;
+
+/// `EventTarget ← Node ← Element`, and `Window`, the global.
+fn chain() -> Definitions {
+    let event_target = interface(
+        "EventTarget",
+        "null",
+        "",
+        &[
+            r#"{"type": "constructor", "arguments": [], "extAttrs": []}"#.to_string(),
+            operation(
+                "dispatchEvent",
+                &plain("boolean"),
+                &[argument("event", &plain("Node"), false, "null")],
+                "",
+            ),
+        ],
+    );
+    let node = interface(
+        "Node",
+        r#""EventTarget""#,
+        "",
+        &[
+            attribute("nodeType", &plain("unsigned short"), true),
+            attribute("textContent", &nullable("DOMString"), false),
+            operation(
+                "cloneNode",
+                &plain("Node"),
+                &[argument(
+                    "subtree",
+                    &plain("boolean"),
+                    true,
+                    r#"{"type": "boolean", "value": false}"#,
+                )],
+                "",
+            ),
+            r#"{"type": "const", "name": "ELEMENT_NODE", "idlType": {"type": "const-type", "extAttrs": [], "generic": "", "nullable": false, "union": false, "idlType": "unsigned short"}, "extAttrs": [], "value": {"type": "number", "value": "1"}}"#.to_string(),
+        ],
+    );
+    let element = interface(
+        "Element",
+        r#""Node""#,
+        "",
+        &[
+            attribute("id", &plain("DOMString"), false),
+            operation(
+                "setAttribute",
+                &plain("undefined"),
+                &[
+                    argument("qualifiedName", &plain("DOMString"), false, "null"),
+                    argument("value", &plain("DOMString"), false, "null"),
+                ],
+                "",
+            ),
+            operation(
+                "setSelectionRange",
+                &plain("undefined"),
+                &[
+                    argument("start", &plain("unsigned long"), false, "null"),
+                    argument("direction", &plain("DOMString"), true, "null"),
+                ],
+                "",
+            ),
+        ],
+    );
+    let window = interface(
+        "Window",
+        r#""EventTarget""#,
+        GLOBAL,
+        &[
+            attribute("document", &plain("Node"), true),
+            attribute("self", &plain("Window"), true),
+            attribute("name", &plain("DOMString"), false),
+            attribute("started", &plain("Timestamp"), true),
+        ],
+    );
+    Definitions {
+        interfaces: vec![event_target, node, element, window],
+        ..Definitions::default()
+    }
+}
+
+#[test]
+fn an_interface_is_an_extern_handle_resource_with_its_own_cm_interface() {
+    let (code, _) = chain().generate();
+    assert!(
+        code.contains(
+            "#[cm(\"web:dom/event-target\", type = \"extern-handle\")]\npub resource EventTarget {"
+        ),
+        "{code}"
+    );
+    assert!(
+        code.contains(
+            "#[cm(\"web:dom/node\", type = \"extern-handle\")]\npub resource Node extends EventTarget {"
+        ),
+        "{code}"
+    );
+    assert!(
+        code.contains("pub resource Element extends Node {"),
+        "{code}"
+    );
+}
+
+#[test]
+fn an_attribute_is_a_getter_and_a_setter_and_readonly_drops_the_setter() {
+    let (code, _) = chain().generate();
+    assert!(
+        code.contains(
+            "    #[cm(\"web:dom/node#text-content\")]\n    #[cm_params(\"self\")]\n    fn text_content(&self) -> Option<String>;"
+        ),
+        "{code}"
+    );
+    assert!(
+        code.contains(
+            "    #[cm(\"web:dom/node#set-text-content\")]\n    #[cm_params(\"self\", \"value\")]\n    fn set_text_content(&self, value: Option<String>);"
+        ),
+        "{code}"
+    );
+    assert!(code.contains("fn node_type(&self) -> u16;"), "{code}");
+    assert!(!code.contains("set_node_type"), "{code}");
+}
+
+#[test]
+fn a_constructor_is_new_and_a_method_names_its_arguments_in_kebab_case() {
+    let (code, _) = chain().generate();
+    assert!(
+        code.contains("    #[cm(\"web:dom/event-target#new\")]\n    fn new() -> EventTarget;"),
+        "{code}"
+    );
+    assert!(
+        code.contains(
+            "    #[cm(\"web:dom/element#set-attribute\")]\n    #[cm_params(\"self\", \"qualified-name\", \"value\")]\n    fn set_attribute(&self, qualified_name: String, value: String);"
+        ),
+        "{code}"
+    );
+    assert!(
+        code.contains("fn dispatch_event(&self, event: Node) -> bool;"),
+        "{code}"
+    );
+}
+
+#[test]
+fn an_optional_argument_is_an_option() {
+    let (code, _) = chain().generate();
+    assert!(
+        code.contains("fn clone_node(&self, subtree: Option<bool>) -> Node;"),
+        "{code}"
+    );
+    assert!(
+        code.contains("fn set_selection_range(&self, start: u32, direction: Option<String>);"),
+        "{code}"
+    );
+}
+
+#[test]
+fn a_keyword_is_escaped_a_typedef_resolves_and_a_const_is_not_a_member() {
+    let (code, _) = chain().generate();
+    assert!(code.contains("fn self_(&self) -> Window;"), "{code}");
+    assert!(code.contains("fn started(&self) -> f64;"), "{code}");
+    assert!(!code.contains("ELEMENT_NODE"), "{code}");
+}
+
+#[test]
+fn the_global_yields_the_dom_effect_with_its_resource_typed_attributes() {
+    let (code, _) = chain().generate();
+    assert!(
+        code.contains(
+            "#[cm(\"web:dom/global\")]\npub interface Dom {\n    #[cm(\"web:dom/global#window\")]\n    fn window() -> Window;\n    #[cm(\"web:dom/global#document\")]\n    fn document() -> Node;\n}"
+        ),
+        "{code}"
+    );
+}
+
+#[test]
+fn a_member_the_slice_cannot_express_is_skipped_and_reported() {
+    let promise = r#"{"type": "return-type", "extAttrs": [], "generic": "Promise", "nullable": false, "union": false, "idlType": [{"type": "return-type", "extAttrs": [], "generic": "", "nullable": false, "union": false, "idlType": "undefined"}]}"#;
+    let union = r#"{"type": "argument-type", "extAttrs": [], "generic": "", "nullable": false, "union": true, "idlType": [{"type": "argument-type", "extAttrs": [], "generic": "", "nullable": false, "union": false, "idlType": "DOMString"}, {"type": "argument-type", "extAttrs": [], "generic": "", "nullable": false, "union": false, "idlType": "Node"}]}"#;
+    let members = [
+        attribute("attributes", &plain("NamedNodeMap"), true),
+        operation("requestFullscreen", promise, &[], ""),
+        operation(
+            "append",
+            &plain("undefined"),
+            &[argument("nodes", union, false, "null")],
+            "",
+        ),
+        // A trailing optional the slice cannot express leaves the rest intact.
+        operation(
+            "createElement",
+            &plain("Element"),
+            &[
+                argument("localName", &plain("DOMString"), false, "null"),
+                argument("options", union, true, r#"{"type": "dictionary"}"#),
+            ],
+            "",
+        ),
+        // Two overloads that both lower are ambiguous, so neither is emitted.
+        operation("alert", &plain("undefined"), &[], ""),
+        operation(
+            "alert",
+            &plain("undefined"),
+            &[argument("message", &plain("DOMString"), false, "null")],
+            "",
+        ),
+        // A special operation names no method.
+        operation(
+            "",
+            &plain("Window"),
+            &[argument("name", &plain("DOMString"), false, "null")],
+            "getter",
+        ),
+    ];
+    let mut defs = chain();
+    defs.interfaces.push(partial("Element", &members));
+    let (code, skipped) = defs.generate();
+    assert!(
+        code.contains("fn create_element(&self, local_name: String) -> Element;"),
+        "{code}"
+    );
+    assert!(!code.contains("attributes"), "{code}");
+    assert!(!code.contains("alert"), "{code}");
+    assert_eq!(
+        skipped,
+        [
+            "Element.attributes: `NamedNodeMap` is outside the slice",
+            "Element.request_fullscreen: `Promise<…>`",
+            "Element.append: `nodes`: union type",
+            "Element.alert: 2 overloads",
+            "Element.(getter): getter operation",
+        ]
+    );
+}
+
+fn union(members: &[String], nullable: bool) -> String {
+    format!(
+        r#"{{"type": "attribute-type", "extAttrs": [], "generic": "", "nullable": {nullable}, "union": true, "idlType": [{}]}}"#,
+        members.join(", ")
+    )
+}
+
+#[test]
+fn a_union_collapses_to_its_one_expressible_constituent() {
+    let mut defs = chain();
+    defs.interfaces.push(partial(
+        "Element",
+        &[
+            attribute(
+                "innerHTML",
+                &union(&[plain("TrustedHTML"), plain("DOMString")], false),
+                false,
+            ),
+            attribute(
+                "event",
+                &union(&[plain("Node"), plain("undefined")], false),
+                true,
+            ),
+            attribute(
+                "hidden",
+                &union(&[plain("boolean"), plain("DOMString")], false),
+                false,
+            ),
+        ],
+    ));
+    let (code, skipped) = defs.generate();
+    assert!(code.contains("fn inner_html(&self) -> String;"), "{code}");
+    assert!(
+        code.contains("fn set_inner_html(&self, value: String);"),
+        "{code}"
+    );
+    assert!(code.contains("fn event(&self) -> Option<Node>;"), "{code}");
+    assert_eq!(skipped, ["Element.hidden: union type"]);
+}
+
+#[test]
+fn an_html_constructor_is_not_new() {
+    let mut defs = chain();
+    defs.interfaces.push(partial(
+        "Element",
+        &[r#"{"type": "constructor", "arguments": [], "extAttrs": [{"type": "extended-attribute", "name": "HTMLConstructor", "rhs": null, "arguments": []}]}"#.to_string()],
+    ));
+    let (code, skipped) = defs.generate();
+    assert!(!code.contains("fn new() -> Element"), "{code}");
+    assert_eq!(skipped, ["Element.new: HTMLConstructor"]);
+}
+
+#[test]
+fn a_mixin_folds_into_each_including_interface() {
+    let mut defs = chain();
+    defs.mixins.push(definition(
+        "interface mixin",
+        "ParentNode",
+        "null",
+        "",
+        &[operation(
+            "querySelector",
+            &nullable("Element"),
+            &[argument("selectors", &plain("DOMString"), false, "null")],
+            "",
+        )],
+    ));
+    defs.includes.push(
+        r#"{"spec": "dom", "type": "includes", "extAttrs": [], "target": "Element", "includes": "ParentNode"}"#
+            .to_string(),
+    );
+    let (code, skipped) = defs.generate();
+    assert!(
+        code.contains(
+            "    #[cm(\"web:dom/element#query-selector\")]\n    #[cm_params(\"self\", \"selectors\")]\n    fn query_selector(&self, selectors: String) -> Option<Element>;"
+        ),
+        "{code}"
+    );
+    assert_eq!(skipped, Vec::<String>::new());
+}
+
+#[test]
+fn a_child_redeclaring_an_inherited_method_is_rejected() {
+    let mut defs = chain();
+    defs.interfaces.push(partial(
+        "Element",
+        &[attribute("nodeType", &plain("unsigned short"), true)],
+    ));
+    let err = transform(&defs.build()).expect_err("an override is an error");
+    assert!(
+        err.to_string()
+            .contains("`Element.node_type` redeclares a method inherited from `Node`"),
+        "{err}"
+    );
+}
+
+#[test]
+fn a_parent_outside_the_slice_is_rejected() {
+    let mut defs = Definitions::default();
+    defs.interfaces
+        .push(interface("Element", r#""CharacterData""#, "", &[]));
+    for name in ["EventTarget", "Node", "Window"] {
+        defs.interfaces.push(interface(name, "null", "", &[]));
+    }
+    let err = transform(&defs.build()).expect_err("an open chain is an error");
+    assert!(
+        err.to_string()
+            .contains("`Element` extends `CharacterData`, which is not in the slice"),
+        "{err}"
+    );
+}

--- a/wado-from-idl/tests/webidl.rs
+++ b/wado-from-idl/tests/webidl.rs
@@ -168,6 +168,7 @@ fn chain() -> Definitions {
             attribute("document", &plain("Node"), true),
             attribute("self", &plain("Window"), true),
             attribute("name", &plain("DOMString"), false),
+            attribute("type", &plain("DOMString"), false),
             attribute("started", &plain("Timestamp"), true),
         ],
     );
@@ -253,6 +254,11 @@ fn an_optional_argument_is_an_option() {
 fn a_keyword_is_escaped_a_typedef_resolves_and_a_const_is_not_a_member() {
     let (code, _) = chain().generate();
     assert!(code.contains("fn self_(&self) -> Window;"), "{code}");
+    assert!(code.contains("fn type_(&self) -> String;"), "{code}");
+    assert!(
+        code.contains("fn set_type(&self, value: String);"),
+        "{code}"
+    );
     assert!(code.contains("fn started(&self) -> f64;"), "{code}");
     assert!(!code.contains("ELEMENT_NODE"), "{code}");
 }

--- a/wado-from-idl/tests/webidl.rs
+++ b/wado-from-idl/tests/webidl.rs
@@ -358,7 +358,7 @@ fn union(members: &[String], nullable: bool) -> String {
 }
 
 #[test]
-fn a_union_collapses_to_its_one_expressible_constituent() {
+fn a_union_collapses_only_where_the_guest_supplies_the_value() {
     let mut defs = chain();
     defs.interfaces.push(partial(
         "Element",
@@ -389,15 +389,17 @@ fn a_union_collapses_to_its_one_expressible_constituent() {
         ],
     ));
     let (code, skipped) = defs.generate();
-    assert!(code.contains("fn inner_html(&self) -> String;"), "{code}");
+    // A `TrustedHTML` the slice cannot build is nothing lost on the way in.
     assert!(
         code.contains("fn set_inner_html(&self, value: String);"),
         "{code}"
     );
+    // `undefined` is the nullability marker, not a dropped constituent.
     assert!(code.contains("fn event(&self) -> Option<Node>;"), "{code}");
     assert_eq!(
         skipped,
         [
+            "Element.inner_html: union narrowed in a result: `TrustedHTML` is outside the slice",
             "Element.hidden: union of 2 expressible types",
             "Element.script: union: `HTMLScriptElement` is outside the slice; `SVGScriptElement` is outside the slice",
         ]


### PR DESCRIPTION
`wado-compiler/lib/web/dom.wado` is generated. `scripts/webidl/snapshot.mjs` writes a slice of `@webref/idl` to `lib/web/dom.webidl.json` — eight interfaces, their partials, their included mixins, and the typedefs their members name — and `wado-from-idl --webidl` builds the module from that file. The snapshot is vendored, so generation needs no network. `mise run update-webidl-snapshot` retakes it, `mise run update-stdlib-web` regenerates the module, and `web_dom_is_fresh.rs` fails when the module is stale.

Each interface becomes an `extern-handle` resource with its own CM interface, `extends` following WebIDL inheritance. An attribute yields a getter, and a setter when it is writable; a constructor yields `new`. The `[Global]` interface yields the effect that hands out the first handle, named after the package: `Dom::window()`, `Dom::document()`.

A member the slice cannot type is skipped and named on stderr. Nothing is approximated. The gaps that remain — `optional` as `Option<T>` with no default, a union collapsing to its one typable constituent, unmerged overloads, mixins folded rather than made traits — are in [the Tide WEP](https://github.com/wado-lang/wado/blob/main/docs/wep-2026-04-01-tide.md).

## Two compiler fixes

The CM registry reads an extern handle two ways. `resolve_type` peels it to its `u32`, the view the boundary decides with: the flat ABI, the canonical options, the emitted WIT. `value_type` keeps the resource's own type, the view the guest holds. A binding's signature takes the second, because `Option<Element>` and `Option<u32>` are distinct GC types. That settles an `option<extern-handle>` result, and an `option<extern-handle>` parameter whether the argument is `null`, a `Some` literal, or a value of that type.

Two smaller ones ride along. `canon lower` asks for the Memory option whenever a string, list or stream appears anywhere in a parameter. A composite parameter routes through the shared type generator, which spells shapes the flat lowering cannot.

## Disk GC

`.claude/hooks/incremental-gc.sh` evicts a stale test binary only while no cargo is alive. Cargo drops the build lock once everything is compiled and then spawns its test binaries one at a time, so evicting one it has already judged fresh makes that spawn fail rather than rebuild. Incremental state and debris still go under the lock alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dds1Bt5Nic1h7qwXGFd1t6