### PR TITLE
docs(wep): Total Reflection — `TypeInfo` and `match type`

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -168,3 +168,4 @@ missing and what closing it takes. A deliberate omission goes in Decision.
 - [`wado lint` — Corpus Checks](./wep-2026-08-31-wado-lint.md)
 - [Trait Resolution — One Order, Written Down](./wep-2026-09-01-trait-resolution.md)
 - [JSON Web Tokens (`core:jwt`)](./wep-2026-09-02-core-jwt.md)
+- [Reflection over an Unknown Type — `TypeKind` and `match type`](./wep-2026-09-05-reflect-unknown-types.md)

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -168,4 +168,4 @@ missing and what closing it takes. A deliberate omission goes in Decision.
 - [`wado lint` — Corpus Checks](./wep-2026-08-31-wado-lint.md)
 - [Trait Resolution — One Order, Written Down](./wep-2026-09-01-trait-resolution.md)
 - [JSON Web Tokens (`core:jwt`)](./wep-2026-09-02-core-jwt.md)
-- [Reflection over an Unknown Type — `TypeInfo` and `match type`](./wep-2026-09-05-reflect-unknown-types.md)
+- [Total Reflection — `TypeInfo` and `match type`](./wep-2026-09-05-total-reflection.md)

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -168,4 +168,4 @@ missing and what closing it takes. A deliberate omission goes in Decision.
 - [`wado lint` — Corpus Checks](./wep-2026-08-31-wado-lint.md)
 - [Trait Resolution — One Order, Written Down](./wep-2026-09-01-trait-resolution.md)
 - [JSON Web Tokens (`core:jwt`)](./wep-2026-09-02-core-jwt.md)
-- [Reflection over an Unknown Type — `TypeKind` and `match type`](./wep-2026-09-05-reflect-unknown-types.md)
+- [Reflection over an Unknown Type — `TypeInfo` and `match type`](./wep-2026-09-05-reflect-unknown-types.md)

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -4064,7 +4064,7 @@ A symbol is named `MODULE#SYMBOL` — the written form used by docs, `wado query
 core:json#parse                      # free function / global
 core:math#f64::PI                    # associated const / static fn
 core:collections#TreeMap.get         # instance method
-core:collections#List<String>::len   # generics use Wado angle brackets
+core:prelude#List<String>::len       # generics use Wado angle brackets
 core:fmt#Point^Display::fmt          # trait-impl member
 "./utils.wado"#Helper::new           # relative path — must be quoted
 ```

--- a/docs/wep-2026-06-13-reflect-derivation.md
+++ b/docs/wep-2026-06-13-reflect-derivation.md
@@ -212,18 +212,12 @@ distinct fact rather than a different spelling. `TypeInfo` carries it: the
 declaration's name and module, plus the instantiation's type arguments, each
 itself a `TypeInfo`.
 
-```wado
-/// Sealed: fields private, minted only by `type_info()`, and not itself
-/// reflectable.
-pub struct TypeInfo { … }
-
-impl TypeInfo {
-    pub fn name(&self) -> String;              // "Pair"
-    pub fn module(&self) -> String;            // "core:collections" / "./pair.wado"
-    pub fn type_args(&self) -> List<TypeInfo>; // [String, i32] for Pair<String,i32>
-    pub fn canonical_name(&self) -> String;    // "\"./pair.wado\"#Pair<String,i32>"
-}
-```
+`TypeInfo` is a sealed variant, one case per kind, and
+[Total Reflection](./wep-2026-09-05-total-reflection.md) owns its shape: the
+name, module and type arguments this section describes are what a declaration's
+case carries, and a type with no declaration to name — a reference, a function
+type — carries its components instead. Sealed as everything here is: a program
+reads a case and mints none, and `TypeInfo` is not itself reflectable.
 
 Identity sits on the root rather than on each kind. A kind bound gates a name
 behind [Visibility](#visibility), so a type whose fields are private
@@ -234,7 +228,8 @@ T` cannot do — a constrained type may be a newtype or a struct wrapper, and
 `Reflect` admits both.
 
 `type_name()` sits beside `type_info()` on the root: the allocation-free
-shorthand serde's `begin_struct` calls, answering `type_info().name()`.
+shorthand serde's `begin_struct` calls, answering the declaration name
+`type_info()` carries.
 
 The parts are the identity; `canonical_name()` renders them in the canonical
 register of [Symbol Notation](./wep-2026-06-14-symbol-notation.md) (`MODULE`
@@ -247,24 +242,13 @@ compiler renders internally; a type with none is written bare.
 
 ### What can be named
 
-The types `Reflect` is synthesized for: the five kinds, and the tuple family,
-which is the one still to come (Known gaps).
-Naming an unnameable type is therefore an unsatisfied `T: Reflect`, reason-chained
-like any other bound, rather than a special case buried in an intrinsic.
-
-A tuple is anonymous, but the prelude's `pub type [...T];` owns the family
-([Variadic Type Parameters](./wep-2026-03-14-variadic-type-parameters.md) §3)
-and that anchor is its identity: module `core:prelude`, name `[..]`, elements as
-type arguments — a generic struct's family-plus-arguments split. Only the
-rendering differs, the arguments sitting between the brackets:
-`core:prelude#[i32,String]`, and `core:prelude#()` for the family at arity zero.
-
-A resource, a function type, and a reference carry no `Reflect` impl, rather
-than a name the design invents. A resource's identity is a Component Model
-coordinate (`wasi:io/streams.input-stream`), not a module symbol, so it waits on
-the CM naming rules; the structural types have no owning declaration at all. No
-consumer needs them — a schema library inlines a tuple's schema and never keys a
-handle.
+Every type. `Reflect` is total, and which case answers for each is
+[Total Reflection](./wep-2026-09-05-total-reflection.md)'s table. A tuple is
+anonymous but its family is not — the prelude's `internal type [..T];` owns it
+([Variadic Type Parameters](./wep-2026-03-14-variadic-type-parameters.md) §3),
+so its identity is the family plus the elements as type arguments, rendered
+`core:prelude#[i32,String]`. `()` is the unit type rather than that family at
+arity zero, and answers for itself.
 
 ### Cost and shape
 
@@ -430,18 +414,20 @@ nothing else yet does.
   comment lives in the `TriviaMap` that `wado doc` reads — so closing this is
   plumbing that string through `TirField` into the synthesized member, beside
   the wire-name override that already travels that path.
-- `TypeInfo` is designed above and unimplemented: the root answers `type_name()`
-  but not yet `type_info()`, so an instantiation cannot be told from its
-  declaration. Nothing in the tree needs a new mechanism — it is a sealed handle
-  minted like a member, and it rides the root's resolution path — but the body is
+- `TypeInfo` is unimplemented: the root answers `type_name()` but not yet
+  `type_info()`, so an instantiation cannot be told from its declaration.
+  Nothing in the tree needs a new mechanism — it is a sealed value minted like a
+  member, and it rides the root's resolution path — but the body is
   per-instantiation, so it follows `type_name()`'s synthesis, where the resolved
-  subject already carries the three facts it needs (its base name, module, and
-  type arguments). The tuple family and `()` join the nameable set with it;
-  today only the five synthesized kinds carry the root.
+  subject already carries the facts a declaration's case needs (its base name,
+  module, and type arguments). Making the root total lands with it: today only
+  the five synthesized kinds carry it. Both are
+  [Total Reflection](./wep-2026-09-05-total-reflection.md)'s to close.
 
 ## Related WEPs
 
 - [Variadic Type Parameters](./wep-2026-03-14-variadic-type-parameters.md)
+- [Total Reflection — `TypeInfo` and `match type`](./wep-2026-09-05-total-reflection.md)
 - [Struct Walkability — Field Walks over `ReflectStruct` and `#[secret]` Fields](./wep-2026-07-10-struct-walkability.md)
 - [Jade — JSON Schema for Wado](./wep-2026-06-13-jade.md)
 - [Serialization and Deserialization (Serde)](./wep-2026-02-28-serde.md)

--- a/docs/wep-2026-06-14-symbol-notation.md
+++ b/docs/wep-2026-06-14-symbol-notation.md
@@ -24,7 +24,7 @@ core:json#parse                          # free function (unquoted scheme)
 core:math#f64::PI                        # associated constant
 core:collections#TreeMap::new            # associated/static function
 core:collections#TreeMap.insert          # instance method
-core:collections#List<String>::len       # generics, Wado angle brackets
+core:prelude#List<String>::len           # generics, Wado angle brackets
 core:fmt#Point^Display::fmt              # trait-impl member (^ as internally)
 "./utils.wado"#Helper::new               # relative path, quoted
 "https://x/lib.wado"#foo                  # URL, quoted
@@ -86,16 +86,18 @@ target module's import graph.
       fails the query re-imports only the files that analyze on their own,
       dropping any that can't load (e.g. a compile-time-codegen module without a
       build cache).
-- [ ] Name a structural type. A primitive, a reference and a function type have
-      no module of their own, so `MODULE` is `core:prelude` and `SYMBOL` is the
-      surface spelling — `core:prelude#i32`, `core:prelude#&Point`,
-      `core:prelude#fn(i32) -> i32`, `core:prelude#[i32,String]`,
-      `core:prelude#!`. This is what a type argument already does one level
-      down (`core:collections#List<String>`), with the operator outermost.
+- [ ] Name a reference and a function type. Alone among types they have no
+      declaration to name them — a primitive, `()`, `!`, `Array<T>` and the
+      tuple family are all prelude declarations — so `MODULE` is `core:prelude`
+      and `SYMBOL` is the surface spelling: `core:prelude#&Point`,
+      `core:prelude#&mut Point`, `core:prelude#fn(i32) -> i32`. This is what a
+      type argument already does one level down
+      (`core:prelude#List<String>`), with the operator outermost.
       `TypeInfo::canonical_name` is the first consumer
-      ([Reflection over an Unknown Type](./wep-2026-09-05-reflect-unknown-types.md)),
-      and it needs rendering alone; resolving one back has no `AstId` to land
-      on and is the open half.
+      ([Total Reflection](./wep-2026-09-05-total-reflection.md)), and it needs
+      rendering alone; resolving one back has no `AstId` to land on and is the
+      open half. The rendering is not a key either — `&Point` renders its
+      pointee bare, so two `Point` declarations collide in one string.
 - [ ] Include doc-comment summaries in `hover` output.
 - [ ] `wado doc` anchors / type cross-links keyed by the notation.
 - [ ] Convert internal `name.rs` names back into this notation (so optimizer

--- a/docs/wep-2026-06-14-symbol-notation.md
+++ b/docs/wep-2026-06-14-symbol-notation.md
@@ -87,17 +87,16 @@ target module's import graph.
       dropping any that can't load (e.g. a compile-time-codegen module without a
       build cache).
 - [ ] Name a reference and a function type. Alone among types they have no
-      declaration to name them — a primitive, `()`, `!`, `Array<T>` and the
-      tuple family are all prelude declarations — so `MODULE` is `core:prelude`
-      and `SYMBOL` is the surface spelling: `core:prelude#&Point`,
-      `core:prelude#&mut Point`, `core:prelude#fn(i32) -> i32`. This is what a
-      type argument already does one level down
-      (`core:prelude#List<String>`), with the operator outermost.
-      `TypeInfo::canonical_name` is the first consumer
-      ([Total Reflection](./wep-2026-09-05-total-reflection.md)), and it needs
-      rendering alone; resolving one back has no `AstId` to land on and is the
-      open half. The rendering is not a key either — `&Point` renders its
-      pointee bare, so two `Point` declarations collide in one string.
+      declaration to name them: a primitive, `()`, `!`, `Array<T>` and the tuple
+      family are all prelude declarations. So `MODULE` is `core:prelude` and
+      `SYMBOL` is the surface spelling — `core:prelude#&Point`,
+      `core:prelude#&mut Point`, `core:prelude#fn(i32) -> i32` — which is what
+      a type argument already does one level down (`core:prelude#List<String>`),
+      with the operator outermost. `TypeInfo::canonical_name` is the first
+      consumer ([Total Reflection](./wep-2026-09-05-total-reflection.md)) and
+      needs rendering alone; resolving one back has no `AstId` to land on and is
+      the open half. Nor is the rendering a key: `&Point` renders its pointee
+      bare, so two `Point` declarations collide in one string.
 - [ ] Include doc-comment summaries in `hover` output.
 - [ ] `wado doc` anchors / type cross-links keyed by the notation.
 - [ ] Convert internal `name.rs` names back into this notation (so optimizer

--- a/docs/wep-2026-06-14-symbol-notation.md
+++ b/docs/wep-2026-06-14-symbol-notation.md
@@ -86,6 +86,16 @@ target module's import graph.
       fails the query re-imports only the files that analyze on their own,
       dropping any that can't load (e.g. a compile-time-codegen module without a
       build cache).
+- [ ] Name a structural type. A primitive, a reference and a function type have
+      no module of their own, so `MODULE` is `core:prelude` and `SYMBOL` is the
+      surface spelling — `core:prelude#i32`, `core:prelude#&Point`,
+      `core:prelude#fn(i32) -> i32`, `core:prelude#[i32,String]`,
+      `core:prelude#!`. This is what a type argument already does one level
+      down (`core:collections#List<String>`), with the operator outermost.
+      `TypeInfo::canonical_name` is the first consumer
+      ([Reflection over an Unknown Type](./wep-2026-09-05-reflect-unknown-types.md)),
+      and it needs rendering alone; resolving one back has no `AstId` to land
+      on and is the open half.
 - [ ] Include doc-comment summaries in `hover` output.
 - [ ] `wado doc` anchors / type cross-links keyed by the notation.
 - [ ] Convert internal `name.rs` names back into this notation (so optimizer

--- a/docs/wep-2026-09-01-trait-resolution.md
+++ b/docs/wep-2026-09-01-trait-resolution.md
@@ -573,6 +573,32 @@ impl written for it, and no `Reflect*` fact or derived impl
       struct at its literal, a body-local struct at its statement — or lower
       them as the declaration `derive` reads.
 
+### Specificity is refused, and now has a named cost
+
+Rank 3 declines to rank a blanket whose bounds imply another's, and the reason
+stands: a narrower impl binding an associated type differently is the
+specialization soundness question, which a rank would decide by accident.
+
+Reflection is the first pattern to pay for it. A derivation written over the
+kind traits has no last-resort arm — `impl<T: ReflectStruct>` beside an
+`impl<T: Reflect>` meant to catch everything else reports at every struct. So a
+receiver the kinds do not admit (members not visible here, or a kind the set
+does not cover) produces no candidate rather than falling through, and rank 2's
+escape — an impl written for the receiver — cannot serve a derivation whose
+subject is unknown by construction.
+
+The reflection side is served without a rank, by a kind-narrowing construct
+proposed separately: one `impl<T: Reflect>` branching on the kind inside its
+body leaves no overlapping pair to break. This gap is therefore independent of
+reflection. Reopening it takes both of:
+
+- [ ] Answer what a caller sees when the narrower impl binds an associated type
+      differently — the question rank 3 declines.
+- [ ] Answer incomparable bound sets. Supertrait closure is a partial order:
+      `{Constrained, Reflect}` beside `{ReflectStruct, Reflect}` is neither
+      narrower nor wider, so a specificity rank leaves that pair at rank 3 and
+      the ambiguity report has to keep naming it.
+
 ## Related WEPs
 
 What each contributes to the order above.

--- a/docs/wep-2026-09-01-trait-resolution.md
+++ b/docs/wep-2026-09-01-trait-resolution.md
@@ -580,16 +580,16 @@ stands: a narrower impl binding an associated type differently is the
 specialization soundness question, which a rank would decide by accident.
 
 Reflection is the first pattern to pay for it. A derivation written over the
-kind traits has no last-resort arm — `impl<T: ReflectStruct>` beside an
-`impl<T: Reflect>` meant to catch everything else reports at every struct. So a
-receiver the kinds do not admit (members not visible here, or a kind the set
-does not cover) produces no candidate rather than falling through, and rank 2's
-escape — an impl written for the receiver — cannot serve a derivation whose
+kind traits has no last-resort arm: an `impl<T: Reflect>` meant to catch
+everything else reports at every struct, beside the `impl<T: ReflectStruct>`.
+So a receiver the kinds do not admit (members not visible here, or a kind the
+set does not cover) produces no candidate rather than falling through, and rank
+2's escape, an impl written for the receiver, cannot serve a derivation whose
 subject is unknown by construction.
 
-The reflection side is served without a rank, by a kind-narrowing construct
-proposed separately: one `impl<T: Reflect>` branching on the kind inside its
-body leaves no overlapping pair to break. This gap is therefore independent of
+[Total Reflection](./wep-2026-09-05-total-reflection.md) serves that side
+without a rank: one `impl<T: Reflect>` branching on the kind inside its body
+leaves no overlapping pair to break. This gap is therefore independent of
 reflection. Reopening it takes both of:
 
 - [ ] Answer what a caller sees when the narrower impl binds an associated type

--- a/docs/wep-2026-09-05-reflect-unknown-types.md
+++ b/docs/wep-2026-09-05-reflect-unknown-types.md
@@ -90,8 +90,15 @@ pub variant TypeInfo {
     Resource(DeclInfo),
     Tuple(DeclInfo),
     Scalar(DeclInfo),
+    Array(TypeInfo),
     Reference { mutable: bool, target: TypeInfo },
-    Function { params: List<TypeInfo>, result: TypeInfo },
+    Function {
+        mutable: bool,                 // `fn mut(…)`
+        params: List<TypeInfo>,
+        result: TypeInfo,
+        effects: List<DeclInfo>,       // the `with E…` row: one interface each
+        stores: List<i32>,             // `stores[…]`, by parameter position
+    },
     Never,
 }
 
@@ -100,6 +107,12 @@ impl TypeInfo {
 }
 ```
 
+A function type is the whole signature or it is not the type: `fn mut(…)`
+differs from `fn(…)`, and `with (Stdout, Stderr)` and `stores[data]` are row
+members of the type the same way the parameters are. The effect row is where an
+`interface` enters the model — it is a declaration Wado names, so it reads as a
+`DeclInfo` like any other, and no separate identity is invented for it.
+
 Every case is positive: no arm means "something the design has no answer for".
 `TypeTable::reflect_kind` already computes the first five and answers `None`
 for the rest, which is the classification this WEP completes:
@@ -107,24 +120,38 @@ for the rest, which is the classification this WEP completes:
 | Type                                                      | Case        |
 | --------------------------------------------------------- | ----------- |
 | `struct` (anonymous included), `variant`, `enum`, `flags` | that case   |
+| `String`, `i128`, `u128` — prelude structs                | `Struct`    |
 | `type N = B`                                              | `Newtype`   |
 | the four sealed member handles                            | `Struct`    |
-| a resource                                                | `Resource`  |
+| a resource, `Future<T>` / `Stream<T>`                     | `Resource`  |
 | the tuple family, `()`                                    | `Tuple`     |
-| `i8`…`u128`, `f32`, `f64`, `bool`, `char`, `v128`         | `Scalar`    |
+| `i8`…`u64`, `f32`, `f64`, `bool`, `char`, `v128`          | `Scalar`    |
+| `Array<T>`                                                | `Array`     |
 | `&T` / `&mut T`                                           | `Reference` |
-| `fn(…) -> R`                                              | `Function`  |
+| `fn(…) -> R with E…`                                      | `Function`  |
 | `!`                                                       | `Never`     |
 
 The four member handles are `Struct` because the seal is on structure, not on
 identity: nothing may enumerate their fields, and `match type` is where that
 shows — they reach no `struct` arm. Naming them was never withheld.
 
-`Scalar` is deliberately coarse. Nothing yet reads a primitive's width or
-signedness through reflection, and a consumer that needs one today writes the
-per-type impl it already writes. Splitting it later is additive: an arm that
-matched `Scalar` keeps matching whatever replaces it only if the split is a
-sub-classification, which is the constraint any later refinement inherits.
+A type parameter, an inference variable, a pack and an associated-type
+projection carry no case: none survives monomorphization, which is where a
+`Reflect` subject is concrete. `Reactive<T>` is the same — a reactive binding is
+typed with its underlying value type, so the wrapper never reaches
+monomorphize.
+
+`Scalar` names the Wasm primitives, which is a fact about representation rather
+than about being a leaf. `String`, `i128` and `u128` read as scalars to a
+programmer and are prelude structs with private fields, so they land in
+`Struct` and, having no visible members downstream, cannot be opened there
+either. That gap between what `Scalar` covers and what a consumer means by
+"leaf" is recorded below.
+
+Within what it does cover, `Scalar` is deliberately coarse: nothing yet reads a
+primitive's width or signedness through reflection, and a consumer that needs
+one writes the per-type impl it already writes. Splitting it later is additive
+only as a sub-classification, which is the constraint any refinement inherits.
 
 A structural case keeps its components rather than rendering them away, which
 is why the flat "name + module + args" shape the earlier WEP sketched does not
@@ -169,11 +196,12 @@ A bound states a kind before the subject is known. The body states it after:
 ```wado
 fn describe<T: Reflect>(v: &T) -> String {
     match type T {
-        struct => return fields_of(v),
-        variant => return live_case_of(v),
+        struct([..F]) => return fields_of(v),
+        variant([..P]) => return live_case_of(v),
         enum | flags => return Reflect::<T>::type_name(),
         newtype => return describe(&B::from(*v)),
-        _ => return Reflect::<T>::type_name(),
+        tuple | scalar | array | reference | function | resource | never | opaque
+            => return Reflect::<T>::type_name(),
     }
 }
 ```
@@ -181,6 +209,21 @@ fn describe<T: Reflect>(v: &T) -> String {
 Each arm proves its kind's bound for its own body. `struct =>` elaborates under
 the hypothesis `T: ReflectStruct`, so `ReflectStruct::<T>::members()` resolves
 inside it and nowhere else.
+
+A `match type` is exhaustive and carries no `_`. Every case of `TypeInfo` is a
+kind of the type system itself, so a set that closes over them closes over
+everything a subject can be, and a wildcard would mostly hide the one thing
+worth reporting: a body that forgot a kind. The cost is that adding a kind to
+the language breaks every `match type` in the ecosystem — which is what adding
+a kind is.
+
+`opaque` is the arm exhaustiveness forces into existence, and it is not `_`
+renamed. The other arms carry a hypothesis their body relies on, so a subject
+that is a struct the site may not open — private members, or one of the sealed
+member handles — cannot enter `struct` without making that hypothesis false. It
+enters `opaque` instead: a named condition ("declared, not openable here"),
+where `type_info()` still reports what the type is. A future kind does not land
+there; it fails exhaustiveness, as intended.
 
 Three rules make it more than sugar over the five blankets:
 
@@ -288,29 +331,27 @@ boundary so the split is not rediscovered.
 
 ### The arm's pack binder has no spelling
 
-`struct([..F])` above is a sketch. Each kind binds a different association
-(`FieldTypes` / `CasePayloads` / `Members`), and an arm that needs no pack
-should not be made to write one.
+What the binder does is settled: the arm pushes `T: ReflectStruct<FieldTypes =
+[..F]>` with `..F` in scope for that arm's body, which is what
+`reflect_pack_bound_ty` reads and what every projection below it already
+serves. What it looks like is not. Three shapes, each with a cost:
 
-- [ ] Choose the spelling, and decide whether an arm may bind a pack bound
-      (`struct([..F: Serialize])`) or only the pack itself.
+- Positional, as above — `struct([..F])`. Shortest, and the association is
+  implied by the arm's kind, so `FieldTypes` / `CasePayloads` / `Members` never
+  appear. A reader cannot tell from the arm which association was bound.
+- Named — `struct(FieldTypes = [..F])`. Matches an impl header exactly, so a
+  derivation moved from a blanket into an arm reads the same. Verbose on the
+  arm that binds nothing.
+- Inferred — no binder, the pack implicit under a reserved name. Rejected on
+  sight: an implicitly-named type parameter is nothing else in the language.
 
-### Exhaustiveness
+Two questions ride on the choice. Whether an arm may bound the pack
+(`struct([..F: Serialize])`) or only bind it, leaving bounds to the callee it
+delegates to; and whether an arm that binds nothing may still be written
+`struct` bare — which it must, or every kind-only branch pays for a pack it
+never reads.
 
-Listing every kind makes adding one a breaking change across every derivation
-in the ecosystem, and the tuple family is already queued. Requiring `_` costs a
-line in the exhaustive case.
-
-- [ ] Decide whether `_` is mandatory.
-
-### Which arm an unopenable struct takes
-
-A struct whose members are not visible here cannot satisfy `ReflectStruct`, so
-it cannot reach a `struct` arm. Falling to `_` is consistent with the
-visibility gate and leaves `kind()` to report what it is; the alternative is a
-distinct arm naming the case.
-
-- [ ] Decide `_` versus a named arm.
+- [ ] Choose the spelling and answer both.
 
 ### The structural notation is unwritten and one-way
 
@@ -334,16 +375,21 @@ type, and the two do not render alike.
 - [ ] Decide whether `DeclInfo` on a resource reports the CM coordinate, the
       Wado symbol, or both.
 
-### `String` is a struct, not a `Scalar`
+### `Scalar` is representation, and a consumer means "leaf"
 
-`String` is a `pub struct` in the prelude, so it classifies as `Struct` and its
-private fields keep it out of the `struct` arm elsewhere — landing it in `_`
-while `i32` lands in `Scalar`. Every derivation writes `impl … for String`
-today, so nothing breaks, but a consumer reading the taxonomy will expect the
-two to agree.
+`String`, `i128` and `u128` are prelude structs, so they classify as `Struct`
+and reach `opaque` downstream, while `i32` reaches `scalar`. Nothing breaks —
+every derivation writes `impl … for String` — but the split a consumer wants is
+leaf versus aggregate, and `Scalar` is the Wasm primitives, which is a
+different line. The two arms it can land in already say "do not walk this", so
+the gap is in what the taxonomy communicates rather than in what it permits.
 
-- [ ] Decide whether `Scalar` is "primitive" or "primitive or so marked", and
-      if the latter, what marks it.
+Marking the three (`#[scalar]` on the declaration, folding them into `Scalar`)
+closes it, at the price of an attribute any type may claim, which moves a
+third-party type between arms.
+
+- [ ] Decide whether `Scalar` stays "a Wasm primitive" or becomes "primitive or
+      so marked", and if the latter, what marks it and who may.
 
 ### `Scalar` granularity
 

--- a/docs/wep-2026-09-05-reflect-unknown-types.md
+++ b/docs/wep-2026-09-05-reflect-unknown-types.md
@@ -395,25 +395,6 @@ one back is the harder half, since a structural type has no `AstId` for
 - [ ] Decide what `wado query "core:prelude#&Point"` answers — the target's
       declaration, a synthesized view, or a diagnostic naming the limit.
 
-### `i128` has two spellings, and reflection would make that observable
-
-The user-facing `i128` / `u128` are prelude `#[compiler_item]` structs of two
-64-bit limbs, and `PrimitiveType::I128` / `U128` exist beside them, interned at
-table init as `TypeTable::I128` / `U128` and matched in 17 files. Both lower to
-the same code today, so which one a phase holds has never been observable. A
-classification over `ResolvedType` makes it observable: the primitive spelling
-would answer `Primitive` for a type this WEP puts in `Struct`, so the same
-source type could be classified two ways.
-
-Removing the duplicate is an independent refactor rather than this WEP's to
-carry — the two spellings predate it — and closing this gap is what that
-refactor does.
-
-- [ ] Retire `PrimitiveType::I128` / `U128`, leaving the prelude structs as the
-      only spelling.
-- [ ] Until then, key the classification on the surface type the program names,
-      and assert the primitive spelling never reaches it.
-
 ## Related WEPs
 
 - [Library-Defined Derivation over `Reflect*`](./wep-2026-06-13-reflect-derivation.md) — the three planes and the traits this WEP reaches

--- a/docs/wep-2026-09-05-reflect-unknown-types.md
+++ b/docs/wep-2026-09-05-reflect-unknown-types.md
@@ -1,4 +1,4 @@
-# WEP: Reflection over an Unknown Type — `TypeKind` and `match type`
+# WEP: Reflection over an Unknown Type — `TypeInfo` and `match type`
 
 ## Context
 
@@ -44,7 +44,7 @@ a name the author does not have.
   enum. Kind-agnostic and recursive, but metadata-only; it reaches values
   through raw pointers, which Wado has no counterpart for.
 - **bevy_reflect** (Rust) — `reflect_kind()` and a `ReflectRef` enum over
-  `dyn` handles. The kind query is this WEP's `TypeKind`; the `dyn` half needs
+  `dyn` handles. The kind query is this WEP's `TypeInfo`; the `dyn` half needs
   dynamic dispatch.
 - **Rust specialization** (RFC 1210) and its stable-Rust stand-in, dispatching
   on an associated "kind" type. That stand-in is the alternative rejected
@@ -59,42 +59,66 @@ the second such trait: `Inspect` already holds for all
 (`solver_bridge.rs`, `TraitDef::holds_for_all`), so a total root introduces no
 resolution shape the language does not have.
 
-`TypeKind` is what the root answers with:
+`TypeInfo` is what the root answers with, and it carries the classification
+rather than sitting beside one. There is no separate kind enum: a type is
+exactly one case, so the variant's own tag is the kind, and a second scalar
+spelling of it would be the parallel classification
+[Reflect Derivation](./wep-2026-06-13-reflect-derivation.md) refuses elsewhere.
 
 ```wado
-pub enum TypeKind {
-    Struct,
-    Variant,
-    Enum,
-    Flags,
-    Newtype,
-    Tuple,
-    Scalar,
-    Opaque,
-}
-
 internal trait Reflect {
-    fn kind() -> TypeKind;
+    fn type_info() -> TypeInfo;
     fn type_name() -> String;
     fn wire_name_policy() -> CaseStyle;
 }
+
+/// A declaration named with this instantiation's arguments.
+pub struct DeclInfo { … }
+
+impl DeclInfo {
+    pub fn name(&self) -> String;              // "Pair"
+    pub fn module(&self) -> String;            // "core:collections" / "./pair.wado"
+    pub fn type_args(&self) -> List<TypeInfo>; // [String, i32]
+}
+
+pub variant TypeInfo {
+    Struct(DeclInfo),
+    Variant(DeclInfo),
+    Enum(DeclInfo),
+    Flags(DeclInfo),
+    Newtype(DeclInfo),
+    Resource(DeclInfo),
+    Tuple(DeclInfo),
+    Scalar(DeclInfo),
+    Reference { mutable: bool, target: TypeInfo },
+    Function { params: List<TypeInfo>, result: TypeInfo },
+    Never,
+}
+
+impl TypeInfo {
+    pub fn canonical_name(&self) -> String;    // symbol notation, every case
+}
 ```
 
-`kind()` reads a compile-time fact, so it folds to a constant at each
-instantiation.
+Every case is positive: no arm means "something the design has no answer for".
+`TypeTable::reflect_kind` already computes the first five and answers `None`
+for the rest, which is the classification this WEP completes:
 
-The classification is total by construction — `TypeTable::reflect_kind` already
-computes the first five and answers `None` for everything else, which this WEP
-splits into the last three:
+| Type                                                      | Case        |
+| --------------------------------------------------------- | ----------- |
+| `struct` (anonymous included), `variant`, `enum`, `flags` | that case   |
+| `type N = B`                                              | `Newtype`   |
+| the four sealed member handles                            | `Struct`    |
+| a resource                                                | `Resource`  |
+| the tuple family, `()`                                    | `Tuple`     |
+| `i8`…`u128`, `f32`, `f64`, `bool`, `char`, `v128`         | `Scalar`    |
+| `&T` / `&mut T`                                           | `Reference` |
+| `fn(…) -> R`                                              | `Function`  |
+| `!`                                                       | `Never`     |
 
-| Type                                                      | Kind      |
-| --------------------------------------------------------- | --------- |
-| `struct` (anonymous included), `variant`, `enum`, `flags` | that kind |
-| `type N = B`                                              | `Newtype` |
-| the tuple family, `()`                                    | `Tuple`   |
-| `i8`…`u128`, `f32`, `f64`, `bool`, `char`, `v128`         | `Scalar`  |
-| a reference, a function type, a resource, `Never`         | `Opaque`  |
-| the four sealed member handles                            | `Opaque`  |
+The four member handles are `Struct` because the seal is on structure, not on
+identity: nothing may enumerate their fields, and `match type` is where that
+shows — they reach no `struct` arm. Naming them was never withheld.
 
 `Scalar` is deliberately coarse. Nothing yet reads a primitive's width or
 signedness through reflection, and a consumer that needs one today writes the
@@ -102,17 +126,41 @@ per-type impl it already writes. Splitting it later is additive: an arm that
 matched `Scalar` keeps matching whatever replaces it only if the split is a
 sub-classification, which is the constraint any later refinement inherits.
 
-`Opaque` is the honest arm, not a gap. A reference and a function type have no
-owning declaration, and a resource's identity is a Component Model coordinate
-rather than a module symbol, so the earlier WEP declined to invent names for
-them. Totality forces an answer only for `type_name()`, which renders the
-type's spelling (`&Point`, `fn(i32) -> i32`); `type_info()` is where the
-question actually bites, and it stays open below.
+A structural case keeps its components rather than rendering them away, which
+is why the flat "name + module + args" shape the earlier WEP sketched does not
+serve. `type_args()` returns `List<TypeInfo>`, so a type with no answer is not
+contained at the root — `Pair<&Point>` and `struct Handler { cb: fn(i32) -> i32 }`
+put one inside a tree a consumer is already walking. Totality is what keeps
+that tree readable end to end.
 
 The visibility gate is unchanged: it sits on the kind traits and never on the
 root ([Reflect Derivation](./wep-2026-06-13-reflect-derivation.md),
 Visibility). A total root is what that split already implied — a type's name is
 public the moment the type is.
+
+### Symbol notation names a structural type too
+
+[Symbol Notation](./wep-2026-06-14-symbol-notation.md) is `MODULE#SYMBOL`, and
+`canonical_name()` renders in its canonical register. A reference, a function
+type and a primitive have no module of their own, which is a gap in the
+notation rather than a reason for reflection to leave them unnamed: the module
+is `core:prelude`, and the symbol is the type's own surface spelling.
+
+```text
+core:prelude#i32
+core:prelude#&Point
+core:prelude#&mut Point
+core:prelude#fn(i32) -> i32
+core:prelude#[i32,String]
+core:prelude#()
+core:prelude#!
+```
+
+This is the rule the notation already follows one level down: a type argument
+renders as its surface spelling (`core:collections#List<String>`), not as a
+nested `MODULE#SYMBOL`. A structural type is the same shape with the operator
+outermost, and the tuple family's anchor — `core:prelude#[i32,String]`, the
+prelude's `pub type [...T];` — was already decided this way.
 
 ### `match type` — narrowing a subject to its kind
 
@@ -176,15 +224,15 @@ map under RAII and every existing projection path serves it unchanged.
 The two answer different questions, and the difference is load-bearing rather
 than an inconsistency to remove:
 
-- `kind()` — what the type **is**. A fact about the declaration, independent of
-  where it is asked.
-- `match type` — what the type may be **opened** as. Gated on visibility, so a
-  struct whose members are private elsewhere does not reach the `struct` arm
-  there.
+- `type_info()` — what the type is. A fact about the declaration, the same from
+  everywhere it is asked.
+- `match type` — what the type may be opened as. Gated on visibility and on the
+  member seal, so a struct whose members are private elsewhere, and a member
+  handle anywhere, reach no `struct` arm.
 
-A consumer composes the two: in the fallback arm, `kind()` still reports
+A consumer composes the two: in the fallback arm `type_info()` still answers
 `Struct`, so "a struct this module may not enumerate" is expressible. Neither
-construct can state it alone.
+construct states it alone.
 
 ### Rejected: dispatching on an associated kind type
 
@@ -222,6 +270,15 @@ reference and a function type have none, so the root's three methods are minted
 off a `TypeId` instead. The solver side already admits them —
 a primitive lowers to `DeclKey::Builtin(name)`, so the fact table can carry it.
 
+A `TypeInfo` is a tree where a kind enum would have been a scalar, and it costs
+nothing at a use site: it is a closed constant expression, so
+[Constant Object Globalization](./wep-2026-05-31-const-object-globalization.md)
+hoists it to a global and the call reads from there — the same treatment
+`members()` gets. Asking only for the case is therefore a load, not an
+allocation, which is what makes a separate scalar query unnecessary rather than
+merely redundant. `type_name()` stays beside it as the allocation-free
+shorthand serde's `begin_struct` calls.
+
 The value plane for an unknown type is unchanged and stays out of reflection: a
 uniform walk over an unknown _value_ is `core:value::Value` through
 `Serialize`, and reflection answers for the _type_. `docs/spec.md` states that
@@ -255,16 +312,27 @@ distinct arm naming the case.
 
 - [ ] Decide `_` versus a named arm.
 
-### `TypeInfo` has no answer for `Opaque`
+### The structural notation is unwritten and one-way
 
-[`TypeInfo`](./wep-2026-06-13-reflect-derivation.md) is a declaration name, a
-module and the instantiation's type arguments. A reference and a function type
-have no declaration and no module, and a resource's coordinate is not a module
-symbol. A total root asks the question the earlier WEP deferred.
+`core:prelude#&Point` and `core:prelude#fn(i32) -> i32` are decided above and
+implemented nowhere: `symbol_notation` parses and renders declaration symbols
+only. Rendering is what `canonical_name()` needs, and it comes first; resolving
+one back is the harder half, since a structural type has no `AstId` for
+`wado query` to land on and the notation "runs both ways" today.
 
-- [ ] Decide whether `TypeInfo` gains an opaque case, whether `module()`
-      becomes optional, or whether `type_info()` stays partial while
-      `type_name()` is total.
+- [ ] Render every `TypeInfo` case in `symbol_notation`.
+- [ ] Decide what `wado query "core:prelude#&Point"` answers — the target's
+      declaration, a synthesized view, or a diagnostic naming the limit.
+
+### A resource is named twice
+
+`Resource(DeclInfo)` names a resource by its Wado module symbol, which the
+compiler has (`ResolvedType::Resource` carries a `DefId`). Its Component Model
+coordinate (`wasi:io/streams.input-stream`) is a second identity for the same
+type, and the two do not render alike.
+
+- [ ] Decide whether `DeclInfo` on a resource reports the CM coordinate, the
+      Wado symbol, or both.
 
 ### `String` is a struct, not a `Scalar`
 
@@ -303,5 +371,6 @@ compiler it would be the parallel metadata list
 - [Variadic Type Parameters](./wep-2026-03-14-variadic-type-parameters.md) — the packs an arm binds, and `VariadicForOf`
 - [Trait Resolution](./wep-2026-09-01-trait-resolution.md) — why a root-bounded blanket beside the kind ones is rank 3
 - [Struct Walkability](./wep-2026-07-10-struct-walkability.md) — the visibility gate an arm inherits
+- [Symbol Notation](./wep-2026-06-14-symbol-notation.md) — the register `canonical_name()` renders, widened here to structural types
 - [Jade](./wep-2026-06-13-jade.md) — the consumer of the `Shape` gap
 - [Elaborator Architecture](./wep-2026-05-26-elaborator-rearchitecture.md) — where an arm's hypothesis and its expansion live

--- a/docs/wep-2026-09-05-reflect-unknown-types.md
+++ b/docs/wep-2026-09-05-reflect-unknown-types.md
@@ -1,0 +1,307 @@
+# WEP: Reflection over an Unknown Type — `TypeKind` and `match type`
+
+## Context
+
+[Library-Defined Derivation over `Reflect*`](./wep-2026-06-13-reflect-derivation.md)
+splits reflection into three planes, and only the first serves a subject the
+author cannot name:
+
+| Plane     | Carried by                                  | An unknown `T`                     |
+| --------- | ------------------------------------------- | ---------------------------------- |
+| Identity  | `Reflect` — `type_name`, `wire_name_policy` | answers                            |
+| Structure | the kind sub-traits (`ReflectStruct`, …)    | needs the kind named in the bound  |
+| Value     | the member bridges (`get` / `extract` / …)  | needs the payload types statically |
+
+The value plane is inherently static: a bridge's result type is the member's,
+so a walk that does not know the type cannot receive the value. The structure
+plane is not — the compiler knows every type's kind — but it is reached only by
+naming that kind in a bound, and a bound is written before the subject is known.
+
+So a derivation writes one blanket per kind, which is what `Inspect` and
+`core:serde` do. That works and has four costs:
+
+- Only a trait can dispatch. A free function cannot branch on the kind, so
+  reflection is unreachable from ordinary code.
+- The framing common to every kind is written once per kind.
+- There is no last-resort arm. A receiver the kinds do not admit — members not
+  visible here, or a type outside the five kinds — produces no candidate rather
+  than falling through, and a `T: Reflect` blanket written beside the kind ones
+  reports at every receiver ([Trait Resolution](./wep-2026-09-01-trait-resolution.md),
+  rank 3 and its Known gap).
+- Each new kind rewrites every derivation. The tuple family is already queued.
+
+`Reflect` alone therefore answers a name and nothing else, and the friction is
+not that the value plane is static — it is that the structure plane is gated on
+a name the author does not have.
+
+### Prior art
+
+- **Zig** — `switch (@typeInfo(T))` at comptime is the same shape as the
+  construct below, with one difference this WEP takes as a requirement: Zig
+  checks the selected branch per instantiation, so an error in an unexercised
+  branch surfaces at a call site far from the code that is wrong.
+- **facet** (Rust) — one `SHAPE` const per type, matched on a `Def` / `Type`
+  enum. Kind-agnostic and recursive, but metadata-only; it reaches values
+  through raw pointers, which Wado has no counterpart for.
+- **bevy_reflect** (Rust) — `reflect_kind()` and a `ReflectRef` enum over
+  `dyn` handles. The kind query is this WEP's `TypeKind`; the `dyn` half needs
+  dynamic dispatch.
+- **Rust specialization** (RFC 1210) and its stable-Rust stand-in, dispatching
+  on an associated "kind" type. That stand-in is the alternative rejected
+  below.
+
+## Decision
+
+### Every type carries `Reflect`
+
+`Reflect` holds of every type, not of the five synthesized kinds alone. It is
+the second such trait: `Inspect` already holds for all
+(`solver_bridge.rs`, `TraitDef::holds_for_all`), so a total root introduces no
+resolution shape the language does not have.
+
+`TypeKind` is what the root answers with:
+
+```wado
+pub enum TypeKind {
+    Struct,
+    Variant,
+    Enum,
+    Flags,
+    Newtype,
+    Tuple,
+    Scalar,
+    Opaque,
+}
+
+internal trait Reflect {
+    fn kind() -> TypeKind;
+    fn type_name() -> String;
+    fn wire_name_policy() -> CaseStyle;
+}
+```
+
+`kind()` reads a compile-time fact, so it folds to a constant at each
+instantiation.
+
+The classification is total by construction — `TypeTable::reflect_kind` already
+computes the first five and answers `None` for everything else, which this WEP
+splits into the last three:
+
+| Type                                                      | Kind      |
+| --------------------------------------------------------- | --------- |
+| `struct` (anonymous included), `variant`, `enum`, `flags` | that kind |
+| `type N = B`                                              | `Newtype` |
+| the tuple family, `()`                                    | `Tuple`   |
+| `i8`…`u128`, `f32`, `f64`, `bool`, `char`, `v128`         | `Scalar`  |
+| a reference, a function type, a resource, `Never`         | `Opaque`  |
+| the four sealed member handles                            | `Opaque`  |
+
+`Scalar` is deliberately coarse. Nothing yet reads a primitive's width or
+signedness through reflection, and a consumer that needs one today writes the
+per-type impl it already writes. Splitting it later is additive: an arm that
+matched `Scalar` keeps matching whatever replaces it only if the split is a
+sub-classification, which is the constraint any later refinement inherits.
+
+`Opaque` is the honest arm, not a gap. A reference and a function type have no
+owning declaration, and a resource's identity is a Component Model coordinate
+rather than a module symbol, so the earlier WEP declined to invent names for
+them. Totality forces an answer only for `type_name()`, which renders the
+type's spelling (`&Point`, `fn(i32) -> i32`); `type_info()` is where the
+question actually bites, and it stays open below.
+
+The visibility gate is unchanged: it sits on the kind traits and never on the
+root ([Reflect Derivation](./wep-2026-06-13-reflect-derivation.md),
+Visibility). A total root is what that split already implied — a type's name is
+public the moment the type is.
+
+### `match type` — narrowing a subject to its kind
+
+A bound states a kind before the subject is known. The body states it after:
+
+```wado
+fn describe<T: Reflect>(v: &T) -> String {
+    match type T {
+        struct => return fields_of(v),
+        variant => return live_case_of(v),
+        enum | flags => return Reflect::<T>::type_name(),
+        newtype => return describe(&B::from(*v)),
+        _ => return Reflect::<T>::type_name(),
+    }
+}
+```
+
+Each arm proves its kind's bound for its own body. `struct =>` elaborates under
+the hypothesis `T: ReflectStruct`, so `ReflectStruct::<T>::members()` resolves
+inside it and nowhere else.
+
+Three rules make it more than sugar over the five blankets:
+
+Arms are checked once, at the definition, under the arm's own hypothesis —
+never per instantiation. This is the requirement Zig's comptime switch does not
+meet, and it is what keeps a diagnostic on the code that is wrong rather than
+on a caller that happens to reach it.
+
+The unselected arms are dropped at monomorphization, before substitution. The
+compiler has the shape for this: `VariadicForOf` is a TIR node elaborated once
+generically and expanded against the concrete pack in `monomorphize/func_inst.rs`,
+and a `match type` node is expanded the same way against the concrete subject.
+The call it leaves behind is already a solved problem too — a
+`Reflect*` static call on a type parameter records a dispatch fact
+(`is_type_param_receiver`) that monomorphization redirects to the concrete
+type's synthesized impl, which is how `fn root_name_of<T: Reflect>()` works
+today (`reflect_root_type_name.wado`).
+
+An arm binds the payload pack its kind carries. The pack cannot be left to a
+helper function's header: a call site projects `[..F]` from the _concrete_
+subject (`variadic_free_fn_assoc_pack.wado` — the reflection impls are
+registered by a synthesis phase that runs after elaboration, so the projection
+computes rather than reads), and inside an arm the subject is still rigid. So
+the arm itself binds it, and the bound it pushes carries the association the
+projection reads:
+
+```wado
+match type T {
+    struct([..F]) => …,     // T: ReflectStruct<FieldTypes = [..F]>
+    variant([..P]) => …,    // T: ReflectVariant<CasePayloads = [..P]>
+}
+```
+
+The spelling is open (Known gaps). The mechanism it feeds is not: bounds in
+force are name-keyed in `annotate_ctx.trait_ctx.type_param_bounds`, which
+`reflect_pack_bound_ty` reads, so an arm pushes a synthesized bound onto that
+map under RAII and every existing projection path serves it unchanged.
+
+### What each construct answers
+
+The two answer different questions, and the difference is load-bearing rather
+than an inconsistency to remove:
+
+- `kind()` — what the type **is**. A fact about the declaration, independent of
+  where it is asked.
+- `match type` — what the type may be **opened** as. Gated on visibility, so a
+  struct whose members are private elsewhere does not reach the `struct` arm
+  there.
+
+A consumer composes the two: in the fallback arm, `kind()` still reports
+`Struct`, so "a struct this module may not enumerate" is expressible. Neither
+construct can state it alone.
+
+### Rejected: dispatching on an associated kind type
+
+`Reflect` could carry `type Kind` (a marker per kind) and a derivation could
+delegate to a `KindOps<T, T::Kind>` whose per-kind impls carry the kind bounds
+— the stand-in Rust reaches for while specialization is unstable. It needs no
+new syntax, and one implication rule (`Reflect<Kind = StructKind>` ⟹
+`ReflectStruct`) would carry it.
+
+It is rejected because the scaffolding is per derivation: every consumer writes
+a dispatcher trait and five impls to reach one branch, which is the cost this
+WEP exists to remove, and the entry blanket it forces (`impl<T: Reflect> Tr for T`)
+lands on the specificity gap rather than avoiding it.
+
+## Consequences
+
+A derivation collapses to one blanket over the root. `Inspect` is the
+measurement: its per-kind blankets become arms of one body, and
+`mise run report-wasm-size` must not regress — the same test proves the
+unselected arms are dropped rather than emitted.
+
+`T: Reflect` becomes a bound that admits everything, which makes it a condition
+in name only. That is `Inspect`'s existing status, so nothing new is unsound;
+what follows is that two total bounds on one trait tie at rank 3 like any other
+pair, and a derivation keyed on the root cannot also be keyed on `Inspect`.
+
+The LSP path stops after `liveness` and builds no TIR
+([Elaborator Architecture](./wep-2026-05-26-elaborator-rearchitecture.md)), so
+it never monomorphizes and every arm stays live in the editor. Hover inside an
+arm reports the hypothesis, not a selected instance.
+
+Minting `Reflect` for a type with no declaration is new work. Today the impls
+are synthesized per TIR declaration in `synthesis/traits.rs`; a primitive, a
+reference and a function type have none, so the root's three methods are minted
+off a `TypeId` instead. The solver side already admits them —
+a primitive lowers to `DeclKey::Builtin(name)`, so the fact table can carry it.
+
+The value plane for an unknown type is unchanged and stays out of reflection: a
+uniform walk over an unknown _value_ is `core:value::Value` through
+`Serialize`, and reflection answers for the _type_. `docs/spec.md` states that
+boundary so the split is not rediscovered.
+
+## Known gaps
+
+### The arm's pack binder has no spelling
+
+`struct([..F])` above is a sketch. Each kind binds a different association
+(`FieldTypes` / `CasePayloads` / `Members`), and an arm that needs no pack
+should not be made to write one.
+
+- [ ] Choose the spelling, and decide whether an arm may bind a pack bound
+      (`struct([..F: Serialize])`) or only the pack itself.
+
+### Exhaustiveness
+
+Listing every kind makes adding one a breaking change across every derivation
+in the ecosystem, and the tuple family is already queued. Requiring `_` costs a
+line in the exhaustive case.
+
+- [ ] Decide whether `_` is mandatory.
+
+### Which arm an unopenable struct takes
+
+A struct whose members are not visible here cannot satisfy `ReflectStruct`, so
+it cannot reach a `struct` arm. Falling to `_` is consistent with the
+visibility gate and leaves `kind()` to report what it is; the alternative is a
+distinct arm naming the case.
+
+- [ ] Decide `_` versus a named arm.
+
+### `TypeInfo` has no answer for `Opaque`
+
+[`TypeInfo`](./wep-2026-06-13-reflect-derivation.md) is a declaration name, a
+module and the instantiation's type arguments. A reference and a function type
+have no declaration and no module, and a resource's coordinate is not a module
+symbol. A total root asks the question the earlier WEP deferred.
+
+- [ ] Decide whether `TypeInfo` gains an opaque case, whether `module()`
+      becomes optional, or whether `type_info()` stays partial while
+      `type_name()` is total.
+
+### `String` is a struct, not a `Scalar`
+
+`String` is a `pub struct` in the prelude, so it classifies as `Struct` and its
+private fields keep it out of the `struct` arm elsewhere — landing it in `_`
+while `i32` lands in `Scalar`. Every derivation writes `impl … for String`
+today, so nothing breaks, but a consumer reading the taxonomy will expect the
+two to agree.
+
+- [ ] Decide whether `Scalar` is "primitive" or "primitive or so marked", and
+      if the latter, what marks it.
+
+### `Scalar` granularity
+
+Nothing reads a primitive's width, signedness or floating-ness through
+reflection yet. A later split has to be a sub-classification of `Scalar` for
+existing arms to keep meaning what they meant.
+
+- [ ] Revisit when a consumer needs it.
+
+### A `Shape` tree is a library, not a synthesis
+
+A facet-style metadata tree — kind-agnostic, walking an unknown type to
+arbitrary depth through lazy `fn() -> Shape` edges — is what a schema library
+(Jade, Layer B) ultimately reads. Written over `match type` it is ordinary
+library code and adds no synthesized per-type metadata; synthesized in the
+compiler it would be the parallel metadata list
+[Reflect Derivation](./wep-2026-06-13-reflect-derivation.md) refuses beside
+`members()`.
+
+- [ ] Write it in `wado:jade` over this WEP's mechanism, not in the compiler.
+
+## Related WEPs
+
+- [Library-Defined Derivation over `Reflect*`](./wep-2026-06-13-reflect-derivation.md) — the three planes and the traits this WEP reaches
+- [Variadic Type Parameters](./wep-2026-03-14-variadic-type-parameters.md) — the packs an arm binds, and `VariadicForOf`
+- [Trait Resolution](./wep-2026-09-01-trait-resolution.md) — why a root-bounded blanket beside the kind ones is rank 3
+- [Struct Walkability](./wep-2026-07-10-struct-walkability.md) — the visibility gate an arm inherits
+- [Jade](./wep-2026-06-13-jade.md) — the consumer of the `Shape` gap
+- [Elaborator Architecture](./wep-2026-05-26-elaborator-rearchitecture.md) — where an arm's hypothesis and its expansion live

--- a/docs/wep-2026-09-05-reflect-unknown-types.md
+++ b/docs/wep-2026-09-05-reflect-unknown-types.md
@@ -89,7 +89,7 @@ pub variant TypeInfo {
     Newtype(DeclInfo),
     Resource(DeclInfo),
     Tuple(DeclInfo),
-    Scalar(DeclInfo),
+    Primitive(PrimitiveKind),
     Array(TypeInfo),
     Reference { mutable: bool, target: TypeInfo },
     Function {
@@ -100,6 +100,14 @@ pub variant TypeInfo {
         stores: List<i32>,             // `stores[…]`, by parameter position
     },
     Never,
+}
+
+/// The Wasm primitives, at the granularity the type system has.
+pub enum PrimitiveKind {
+    I8, I16, I32, I64,
+    U8, U16, U32, U64,
+    F32, F64,
+    Bool, Char, V128,
 }
 
 impl TypeInfo {
@@ -125,7 +133,7 @@ for the rest, which is the classification this WEP completes:
 | the four sealed member handles                            | `Struct`    |
 | a resource, `Future<T>` / `Stream<T>`                     | `Resource`  |
 | the tuple family, `()`                                    | `Tuple`     |
-| `i8`…`u64`, `f32`, `f64`, `bool`, `char`, `v128`          | `Scalar`    |
+| `i8`…`u64`, `f32`, `f64`, `bool`, `char`, `v128`          | `Primitive` |
 | `Array<T>`                                                | `Array`     |
 | `&T` / `&mut T`                                           | `Reference` |
 | `fn(…) -> R with E…`                                      | `Function`  |
@@ -141,17 +149,24 @@ projection carry no case: none survives monomorphization, which is where a
 typed with its underlying value type, so the wrapper never reaches
 monomorphize.
 
-`Scalar` names the Wasm primitives, which is a fact about representation rather
-than about being a leaf. `String`, `i128` and `u128` read as scalars to a
-programmer and are prelude structs with private fields, so they land in
-`Struct` and, having no visible members downstream, cannot be opened there
-either. That gap between what `Scalar` covers and what a consumer means by
-"leaf" is recorded below.
+`Primitive` is named for what it holds — the Wasm primitives — and carries the
+one at the granularity the type system already has, so a consumer branches on
+`PrimitiveKind` rather than on a name string. The granularity sits in the case's
+payload, not in the case set, so `match type`'s arms are unaffected by it: one
+`primitive` arm, an ordinary `match` inside where a body cares. That placement
+is also why the kind is carried now rather than deferred — widening a case's
+payload later breaks every pattern already written against it, so "add it when
+someone needs it" is not the free option it looks like.
 
-Within what it does cover, `Scalar` is deliberately coarse: nothing yet reads a
-primitive's width or signedness through reflection, and a consumer that needs
-one writes the per-type impl it already writes. Splitting it later is additive
-only as a sub-classification, which is the constraint any refinement inherits.
+The kind is the identity here, so this case carries no `DeclInfo`: the module is
+`core:prelude` and the name is the kind's spelling, both derivable, and
+`canonical_name()` renders them.
+
+`String`, `i128` and `u128` read as primitives to a programmer and are none:
+each is a prelude struct — `i128` and `u128` are `#[compiler_item]` structs of
+two 64-bit limbs — with private fields, so they classify as `Struct` and, having
+no visible members downstream, cannot be opened there either. The gap between
+what `Primitive` covers and what a consumer means by "leaf" is recorded below.
 
 A structural case keeps its components rather than rendering them away, which
 is why the flat "name + module + args" shape the earlier WEP sketched does not
@@ -189,6 +204,25 @@ nested `MODULE#SYMBOL`. A structural type is the same shape with the operator
 outermost, and the tuple family's anchor — `core:prelude#[i32,String]`, the
 prelude's `pub type [...T];` — was already decided this way.
 
+Every type therefore has exactly one identity, and it is a module symbol. A
+resource and an interface each have a second one — the Component Model
+coordinate (`wasi:io/streams.input-stream`) — and reflection does not carry it:
+`DeclInfo` reports the Wado module symbol for every case alike, with no branch
+for the CM-backed ones. The friction is real and accepted: a consumer keying a
+registry by CM coordinate cannot get there from `TypeInfo`, and a WASI type
+reads by the name its generated Wado module gives it. One identity that is
+always the same shape is worth more than a second one that only some types
+have.
+
+### A `Shape` tree belongs to Jade
+
+A facet-style metadata tree — kind-agnostic, walking an unknown type to
+arbitrary depth through lazy `fn() -> Shape` edges — is what a schema library
+ultimately reads, and it is deliberately not here. Written over `match type` it
+is ordinary library code in `wado:jade`; synthesized in the compiler it would be
+a per-type metadata list beside `members()`, which
+[Reflect Derivation](./wep-2026-06-13-reflect-derivation.md) refuses.
+
 ### `match type` — narrowing a subject to its kind
 
 A bound states a kind before the subject is known. The body states it after:
@@ -196,11 +230,11 @@ A bound states a kind before the subject is known. The body states it after:
 ```wado
 fn describe<T: Reflect>(v: &T) -> String {
     match type T {
-        struct([..F]) => return fields_of(v),
-        variant([..P]) => return live_case_of(v),
+        struct(FieldTypes = [..F]) => return fields_of(v),
+        variant(CasePayloads = [..P]) => return live_case_of(v),
         enum | flags => return Reflect::<T>::type_name(),
         newtype => return describe(&B::from(*v)),
-        tuple | scalar | array | reference | function | resource | never | opaque
+        tuple | primitive | array | reference | function | resource | never | opaque
             => return Reflect::<T>::type_name(),
     }
 }
@@ -252,13 +286,22 @@ projection reads:
 
 ```wado
 match type T {
-    struct([..F]) => …,     // T: ReflectStruct<FieldTypes = [..F]>
-    variant([..P]) => …,    // T: ReflectVariant<CasePayloads = [..P]>
+    struct(FieldTypes = [..F]) => …,      // T: ReflectStruct<FieldTypes = [..F]>
+    variant(CasePayloads = [..P]) => …,   // T: ReflectVariant<CasePayloads = [..P]>
+    enum => …,                            // binds nothing; T: ReflectEnum
 }
 ```
 
-The spelling is open (Known gaps). The mechanism it feeds is not: bounds in
-force are name-keyed in `annotate_ctx.trait_ctx.type_param_bounds`, which
+The binder is spelled as an impl header spells it, association named, so a
+derivation moved from a blanket into an arm reads the same in both places. An
+arm that reads no pack writes none — a kind-only branch pays nothing for a pack
+it never touches — and an arm binds the pack without bounding it: `..F: Serialize`
+belongs to the header of the function the arm delegates to, which keeps the arm
+about proving the kind. Both are revisitable; a derivation that turns out to
+need the bound on the arm is the reason to revisit.
+
+The mechanism underneath is unchanged by the spelling: bounds in force are
+name-keyed in `annotate_ctx.trait_ctx.type_param_bounds`, which
 `reflect_pack_bound_ty` reads, so an arm pushes a synthesized bound onto that
 map under RAII and every existing projection path serves it unchanged.
 
@@ -329,30 +372,6 @@ boundary so the split is not rediscovered.
 
 ## Known gaps
 
-### The arm's pack binder has no spelling
-
-What the binder does is settled: the arm pushes `T: ReflectStruct<FieldTypes =
-[..F]>` with `..F` in scope for that arm's body, which is what
-`reflect_pack_bound_ty` reads and what every projection below it already
-serves. What it looks like is not. Three shapes, each with a cost:
-
-- Positional, as above — `struct([..F])`. Shortest, and the association is
-  implied by the arm's kind, so `FieldTypes` / `CasePayloads` / `Members` never
-  appear. A reader cannot tell from the arm which association was bound.
-- Named — `struct(FieldTypes = [..F])`. Matches an impl header exactly, so a
-  derivation moved from a blanket into an arm reads the same. Verbose on the
-  arm that binds nothing.
-- Inferred — no binder, the pack implicit under a reserved name. Rejected on
-  sight: an implicitly-named type parameter is nothing else in the language.
-
-Two questions ride on the choice. Whether an arm may bound the pack
-(`struct([..F: Serialize])`) or only bind it, leaving bounds to the callee it
-delegates to; and whether an arm that binds nothing may still be written
-`struct` bare — which it must, or every kind-only branch pays for a pack it
-never reads.
-
-- [ ] Choose the spelling and answer both.
-
 ### The structural notation is unwritten and one-way
 
 `core:prelude#&Point` and `core:prelude#fn(i32) -> i32` are decided above and
@@ -365,51 +384,31 @@ one back is the harder half, since a structural type has no `AstId` for
 - [ ] Decide what `wado query "core:prelude#&Point"` answers — the target's
       declaration, a synthesized view, or a diagnostic naming the limit.
 
-### A resource is named twice
+### A leaf is not a `Primitive`, and nothing says which it is
 
-`Resource(DeclInfo)` names a resource by its Wado module symbol, which the
-compiler has (`ResolvedType::Resource` carries a `DefId`). Its Component Model
-coordinate (`wasi:io/streams.input-stream`) is a second identity for the same
-type, and the two do not render alike.
+`String`, `i128` and `u128` classify as `Struct` and reach `opaque` downstream,
+while `i32` reaches `primitive`. Nothing breaks — every derivation writes
+`impl … for String`, and both arms already say "do not walk this" — but a
+consumer asking "is this an aggregate I should recurse into" reads two arms for
+one answer, and `opaque` also carries structs that genuinely are aggregates it
+may not see.
 
-- [ ] Decide whether `DeclInfo` on a resource reports the CM coordinate, the
-      Wado symbol, or both.
+Marking the three (`#[primitive]` on the declaration, folding them into
+`Primitive`) misstates them; a separate leaf predicate states the question
+directly but is a second classification over the same cases.
 
-### `Scalar` is representation, and a consumer means "leaf"
+- [ ] Decide whether the leaf/aggregate question gets an answer of its own, and
+      where it lives.
 
-`String`, `i128` and `u128` are prelude structs, so they classify as `Struct`
-and reach `opaque` downstream, while `i32` reaches `scalar`. Nothing breaks —
-every derivation writes `impl … for String` — but the split a consumer wants is
-leaf versus aggregate, and `Scalar` is the Wasm primitives, which is a
-different line. The two arms it can land in already say "do not walk this", so
-the gap is in what the taxonomy communicates rather than in what it permits.
+### The classification must not read `PrimitiveType::I128`
 
-Marking the three (`#[scalar]` on the declaration, folding them into `Scalar`)
-closes it, at the price of an attribute any type may claim, which moves a
-third-party type between arms.
+`i128` and `u128` are prelude structs, and `PrimitiveType::I128` / `U128` also
+exist in the type table, read by the CM ABI, const-eval and lowering. A
+classification that matches on `ResolvedType::Primitive` alone would answer
+`Primitive` for a type this WEP puts in `Struct`.
 
-- [ ] Decide whether `Scalar` stays "a Wasm primitive" or becomes "primitive or
-      so marked", and if the latter, what marks it and who may.
-
-### `Scalar` granularity
-
-Nothing reads a primitive's width, signedness or floating-ness through
-reflection yet. A later split has to be a sub-classification of `Scalar` for
-existing arms to keep meaning what they meant.
-
-- [ ] Revisit when a consumer needs it.
-
-### A `Shape` tree is a library, not a synthesis
-
-A facet-style metadata tree — kind-agnostic, walking an unknown type to
-arbitrary depth through lazy `fn() -> Shape` edges — is what a schema library
-(Jade, Layer B) ultimately reads. Written over `match type` it is ordinary
-library code and adds no synthesized per-type metadata; synthesized in the
-compiler it would be the parallel metadata list
-[Reflect Derivation](./wep-2026-06-13-reflect-derivation.md) refuses beside
-`members()`.
-
-- [ ] Write it in `wado:jade` over this WEP's mechanism, not in the compiler.
+- [ ] Key the classification on the surface type the program names, and assert
+      the two never disagree.
 
 ## Related WEPs
 
@@ -418,5 +417,5 @@ compiler it would be the parallel metadata list
 - [Trait Resolution](./wep-2026-09-01-trait-resolution.md) — why a root-bounded blanket beside the kind ones is rank 3
 - [Struct Walkability](./wep-2026-07-10-struct-walkability.md) — the visibility gate an arm inherits
 - [Symbol Notation](./wep-2026-06-14-symbol-notation.md) — the register `canonical_name()` renders, widened here to structural types
-- [Jade](./wep-2026-06-13-jade.md) — the consumer of the `Shape` gap
+- [Jade](./wep-2026-06-13-jade.md) — where the `Shape` tree is written
 - [Elaborator Architecture](./wep-2026-05-26-elaborator-rearchitecture.md) — where an arm's hypothesis and its expansion live

--- a/docs/wep-2026-09-05-reflect-unknown-types.md
+++ b/docs/wep-2026-09-05-reflect-unknown-types.md
@@ -395,15 +395,24 @@ one back is the harder half, since a structural type has no `AstId` for
 - [ ] Decide what `wado query "core:prelude#&Point"` answers — the target's
       declaration, a synthesized view, or a diagnostic naming the limit.
 
-### The classification must not read `PrimitiveType::I128`
+### `i128` has two spellings, and reflection would make that observable
 
-`i128` and `u128` are prelude structs, and `PrimitiveType::I128` / `U128` also
-exist in the type table, read by the CM ABI, const-eval and lowering. A
-classification that matches on `ResolvedType::Primitive` alone would answer
-`Primitive` for a type this WEP puts in `Struct`.
+The user-facing `i128` / `u128` are prelude `#[compiler_item]` structs of two
+64-bit limbs, and `PrimitiveType::I128` / `U128` exist beside them, interned at
+table init as `TypeTable::I128` / `U128` and matched in 17 files. Both lower to
+the same code today, so which one a phase holds has never been observable. A
+classification over `ResolvedType` makes it observable: the primitive spelling
+would answer `Primitive` for a type this WEP puts in `Struct`, so the same
+source type could be classified two ways.
 
-- [ ] Key the classification on the surface type the program names, and assert
-      the two never disagree.
+Removing the duplicate is an independent refactor rather than this WEP's to
+carry — the two spellings predate it — and closing this gap is what that
+refactor does.
+
+- [ ] Retire `PrimitiveType::I128` / `U128`, leaving the prelude structs as the
+      only spelling.
+- [ ] Until then, key the classification on the surface type the program names,
+      and assert the primitive spelling never reaches it.
 
 ## Related WEPs
 

--- a/docs/wep-2026-09-05-reflect-unknown-types.md
+++ b/docs/wep-2026-09-05-reflect-unknown-types.md
@@ -165,8 +165,19 @@ The kind is the identity here, so this case carries no `DeclInfo`: the module is
 `String`, `i128` and `u128` read as primitives to a programmer and are none:
 each is a prelude struct — `i128` and `u128` are `#[compiler_item]` structs of
 two 64-bit limbs — with private fields, so they classify as `Struct` and, having
-no visible members downstream, cannot be opened there either. The gap between
-what `Primitive` covers and what a consumer means by "leaf" is recorded below.
+no visible members downstream, cannot be opened there either.
+
+That they land in `opaque` rather than beside `i32` is not a question left
+unanswered. A coarser one — leaf or aggregate — is computed from these cases
+and never the reverse, so the split is the superset: merging `primitive` into a
+leaf case would lose the difference between `i32` and a struct this site may not
+open, which `type_info()` still reports as `Struct`. No consumer branches on the
+coarse question either, because reflection offers one action per side and only
+one of them: an aggregate is walked through the kind bound an arm proves, while
+reading a leaf's value needs a bound reflection never carries (`Display`,
+`Serialize`). `primitive` and `opaque` therefore admit the same body — delegate
+to a bound the signature already has, or name the type — and a predicate
+telling them apart would serve no branch.
 
 A structural case keeps its components rather than rendering them away, which
 is why the flat "name + module + args" shape the earlier WEP sketched does not
@@ -383,22 +394,6 @@ one back is the harder half, since a structural type has no `AstId` for
 - [ ] Render every `TypeInfo` case in `symbol_notation`.
 - [ ] Decide what `wado query "core:prelude#&Point"` answers — the target's
       declaration, a synthesized view, or a diagnostic naming the limit.
-
-### A leaf is not a `Primitive`, and nothing says which it is
-
-`String`, `i128` and `u128` classify as `Struct` and reach `opaque` downstream,
-while `i32` reaches `primitive`. Nothing breaks — every derivation writes
-`impl … for String`, and both arms already say "do not walk this" — but a
-consumer asking "is this an aggregate I should recurse into" reads two arms for
-one answer, and `opaque` also carries structs that genuinely are aggregates it
-may not see.
-
-Marking the three (`#[primitive]` on the declaration, folding them into
-`Primitive`) misstates them; a separate leaf predicate states the question
-directly but is a second classification over the same cases.
-
-- [ ] Decide whether the leaf/aggregate question gets an answer of its own, and
-      where it lives.
 
 ### The classification must not read `PrimitiveType::I128`
 

--- a/docs/wep-2026-09-05-total-reflection.md
+++ b/docs/wep-2026-09-05-total-reflection.md
@@ -23,23 +23,18 @@ So a derivation writes one blanket per kind, which is what `Inspect` and
 - Only a trait can dispatch. A free function cannot branch on the kind, so
   reflection is unreachable from ordinary code.
 - The framing common to every kind is written once per kind.
-- There is no last-resort arm. A receiver the kinds do not admit — members not
-  visible here, or a type outside the five kinds — produces no candidate rather
-  than falling through, and a `T: Reflect` blanket written beside the kind ones
-  reports at every receiver ([Trait Resolution](./wep-2026-09-01-trait-resolution.md),
-  rank 3 and its Known gap).
+- There is no last-resort arm. A receiver the kinds do not admit produces no
+  candidate rather than falling through, and a `T: Reflect` blanket written
+  beside the kind ones reports at every receiver
+  ([Trait Resolution](./wep-2026-09-01-trait-resolution.md), rank 3 and its
+  Known gap).
 - Each new kind rewrites every derivation. The tuple family is already queued.
-
-`Reflect` alone therefore answers a name and nothing else, and the friction is
-not that the value plane is static — it is that the structure plane is gated on
-a name the author does not have.
 
 ### Prior art
 
-- **Zig** — `switch (@typeInfo(T))` at comptime is the same shape as the
-  construct below, with one difference this WEP takes as a requirement: Zig
+- **Zig** — `switch (@typeInfo(T))` at comptime is the construct below. It
   checks the selected branch per instantiation, so an error in an unexercised
-  branch surfaces at a call site far from the code that is wrong.
+  branch surfaces at a distant call site. This WEP requires the opposite.
 - **facet** (Rust) — one `SHAPE` const per type, matched on a `Def` / `Type`
   enum. Kind-agnostic and recursive, but metadata-only; it reaches values
   through raw pointers, which Wado has no counterpart for.
@@ -129,10 +124,9 @@ pub enum PrimitiveKind {
 }
 ```
 
-`TypeInfo` keeps the seal the earlier WEP put on it: a program reads a case, and
-mints none. Every payload is a struct, since a Wado variant carries exactly one
-payload type per case — a reference and a function type each need several facts,
-so each gets a sealed struct rather than a shape the language does not have.
+`TypeInfo` keeps the seal the earlier WEP put on it: a program reads a case and
+mints none. A Wado case carries exactly one payload type, so a reference and a
+function type, each holding several facts, take a sealed struct.
 
 A function type is the whole signature or it is not the type: `fn mut(…)`
 differs from `fn(…)`, and `with (Stdout, Stderr)` and `stores[data]` are row
@@ -160,10 +154,10 @@ for the rest, which is the classification this WEP completes:
 | `fn(…) -> R with E…`                                      | `Function`  |
 
 `()` is the unit type, not the empty tuple, and the two are held apart
-everywhere else in the language — an impl for `[..T]` is never a candidate for
-it ([Trait Resolution](./wep-2026-09-01-trait-resolution.md)) — so it carries
-its own case rather than reading as a tuple of arity zero. Its declaration
-(`internal type ();`) sits beside the primitives' in the prelude, and `!`'s
+everywhere else in the language: an impl for `[..T]` is never a candidate for it
+([Trait Resolution](./wep-2026-09-01-trait-resolution.md)). So it carries its
+own case rather than reading as a tuple of arity zero, and its declaration
+`internal type ();` sits beside the primitives' in the prelude, with `!`'s
 beside it.
 
 A case carries a `DeclInfo` only where the declaration is not determined by the
@@ -195,31 +189,30 @@ each is a prelude struct — `i128` and `u128` are `#[compiler_item]` structs of
 two 64-bit limbs — with private fields, so they classify as `Struct` and, having
 no visible members downstream, cannot be opened there either.
 
-That they land in `opaque` rather than beside `i32` is not a question left
-unanswered. A coarser one — leaf or aggregate — is computed from these cases
-and never the reverse, so the split is the superset: merging `primitive` into a
-leaf case would lose the difference between `i32` and a struct this site may not
-open, which `type_info()` still reports as `Struct`. No consumer branches on the
-coarse question either, because reflection offers one action per side and only
-one of them: an aggregate is walked through the kind bound an arm proves, while
-reading a leaf's value needs a bound reflection never carries (`Display`,
-`Serialize`). `primitive` and `opaque` therefore admit the same body — delegate
-to a bound the signature already has, or name the type — and a predicate
-telling them apart would serve no branch.
+That they land in `opaque` rather than beside `i32` leaves nothing unanswered.
+The coarser question, leaf or aggregate, is computed from these cases and never
+the reverse, so this split is the superset: one leaf case would lose the
+difference between `i32` and a struct the site may not open, which `type_info()`
+still reports as `Struct`. Nor does any consumer branch on the coarse question,
+because reflection offers one action per side and carries only one. An aggregate
+is walked through the kind bound an arm proves; reading a leaf's value needs a
+bound reflection never has, like `Display` or `Serialize`. So `primitive` and
+`opaque` admit the same body, and a predicate telling them apart would serve no
+branch.
 
-A structural case keeps its components rather than rendering them away, which
-is why a flat "name + module + args" shape does not serve. `type_args()` returns
-`List<TypeInfo>`, so a type with no answer is not contained at the root —
-`Pair<&Point>` and `struct Handler { cb: fn(i32) -> i32 }` put one inside a tree
-a consumer is already walking. Totality is what keeps that tree readable end to
-end.
+A reference and a function type keep their components rather than rendering them
+away, which a flat "name + module + args" shape could not do. Totality is what
+makes that worth having: `type_args()` returns `List<TypeInfo>`, so a case with
+no answer would appear inside a tree a consumer is already walking, not at its
+root — `Pair<&Point>` and `struct Handler { cb: fn(i32) -> i32 }` each put one
+there.
 
 The visibility gate is unchanged: it sits on the kind traits and never on the
 root ([Reflect Derivation](./wep-2026-06-13-reflect-derivation.md),
 Visibility). A total root is what that split already implied — a type's name is
 public the moment the type is.
 
-### Symbol notation names a structural type too
+### Symbol notation names a reference and a function type
 
 [Symbol Notation](./wep-2026-06-14-symbol-notation.md) is `MODULE#SYMBOL`, and
 `canonical_name()` renders in its canonical register. Most cases already have a
@@ -227,13 +220,12 @@ module. A primitive, `()` and `!` are `internal type` declarations in
 `core:prelude` and resolve like any other name (`prelude/primitive.wado`,
 `trait_env.rs`'s `ImplTargetKey`); `Array<T>` is the prelude's
 `pub type Array<T>;`; and the tuple family is its `internal type [..T];`, whose
-arguments are the element types — the family-plus-arguments split a generic
+arguments are the element types, the family-plus-arguments split a generic
 struct has.
 
-Two shapes have no declaration at all — a function type and a reference — which
-is a gap in the notation rather than a reason for reflection to leave them
-unnamed. Their module is `core:prelude` and their symbol is the type's own
-surface spelling:
+A reference and a function type have no declaration at all. That is a gap in the
+notation rather than a reason for reflection to leave them unnamed: their module
+is `core:prelude` and their symbol is the type's own surface spelling.
 
 ```text
 core:prelude#i32
@@ -251,28 +243,27 @@ renders as its surface spelling (`core:prelude#List<String>`), not as a nested
 `MODULE#SYMBOL`. A structural type is the same shape with the operator
 outermost.
 
-That rendering is for a reader — a diagnostic, a dump, a doc anchor — and is not
+That rendering serves a reader — a diagnostic, a dump, a doc anchor — and is not
 a key. `&Point` renders the pointee bare, so two `Point` declarations in
-different modules produce one string; a registry or a `$defs` map keys on the
+different modules produce one string. A registry or a `$defs` map keys on the
 `TypeInfo` itself, which compares structurally over module, name and arguments
-and tells them apart. Reflection hands out identity as a value; the notation is
-how that value is spoken.
+and tells them apart.
 
 The identity a `DeclInfo` carries is the Wado module symbol, for every case
-alike. A resource and an interface each have a second one — the Component Model
-coordinate (`wasi:io/streams.input-stream`) — and reflection does not carry it,
-with no branch for the CM-backed cases. The friction is real and accepted: a
+alike. A resource and an interface each have a second one, the Component Model
+coordinate (`wasi:io/streams.input-stream`), and reflection carries neither it
+nor a branch for the cases that have one. The friction is real and accepted: a
 consumer keying a registry by CM coordinate cannot get there from `TypeInfo`,
 and a WASI type reads by the name its generated Wado module gives it. One
 identity of one shape is worth more than a second one only some types have.
 
 ### A `Shape` tree belongs to Jade
 
-A facet-style metadata tree — kind-agnostic, walking an unknown type to
-arbitrary depth through lazy `fn() -> Shape` edges — is what a schema library
-ultimately reads, and it is deliberately not here. Written over `match type` it
-is ordinary library code in `wado:jade`; synthesized in the compiler it would be
-a per-type metadata list beside `members()`, which
+A schema library ultimately reads a facet-style metadata tree: kind-agnostic,
+walking an unknown type to arbitrary depth through lazy `fn() -> Shape` edges.
+It is deliberately not here. Written over `match type` it is ordinary library
+code in `wado:jade`; synthesized in the compiler it would be a per-type metadata
+list beside `members()`, which
 [Reflect Derivation](./wep-2026-06-13-reflect-derivation.md) refuses.
 
 ### `match type` — narrowing a subject to its kind
@@ -292,16 +283,16 @@ fn describe<T: Reflect>(v: &T) -> String {
 }
 ```
 
-Each arm proves its kind's bound for its own body. `struct =>` elaborates under
-the hypothesis `T: ReflectStruct`, so `ReflectStruct::<T>::members()` resolves
-inside it and nowhere else.
+A kind arm proves its kind's bound for its own body. `struct =>` elaborates
+under the hypothesis `T: ReflectStruct`, so `ReflectStruct::<T>::members()`
+resolves inside it and nowhere else.
 
 Only the five kind traits have a hypothesis to push. The other arms name a
 classification with no trait behind it, so they add nothing to what `T: Reflect`
 already gives, and neither do they bind: an `array` arm cannot name its element
 type today (Known gaps). An alternation pushes what all its kinds share, which
-is nothing beyond the root, so `enum | flags` is the way to write one body for
-two kinds and `struct | variant` buys nothing over `opaque`.
+is nothing beyond the root, so `enum | flags` is how one body serves two kinds
+and `struct | variant` buys nothing over `opaque`.
 
 A `match type` is exhaustive and carries no `_`. Every case of `TypeInfo` is a
 kind of the type system itself, so a set that closes over them closes over
@@ -311,19 +302,19 @@ the language breaks every `match type` in the ecosystem — which is what adding
 a kind is.
 
 `opaque` is the arm exhaustiveness forces into existence, and it is not `_`
-renamed. The kind arms carry a hypothesis their body relies on, so a subject
-that is a struct the site may not open — private members, or one of the sealed
-member handles — cannot enter `struct` without making that hypothesis false. It
-enters `opaque` instead: a named condition ("declared, not openable here"),
-where `type_info()` still reports what the type is. A future kind does not land
-there; it fails exhaustiveness, as intended.
+renamed. A kind arm carries a hypothesis its body relies on, so a struct the
+site may not open — one with private members, or one of the sealed member
+handles — cannot enter `struct` without making that hypothesis false. It enters
+`opaque` instead, a named condition meaning "declared, not openable here", where
+`type_info()` still reports what the type is. A future kind does not land there;
+it fails exhaustiveness, as intended.
 
 Three rules make it more than sugar over the five blankets:
 
-Arms are checked once, at the definition, under the arm's own hypothesis —
-never per instantiation. This is the requirement Zig's comptime switch does not
-meet, and it is what keeps a diagnostic on the code that is wrong rather than
-on a caller that happens to reach it.
+Arms are checked once, at the definition, under the arm's own hypothesis, never
+per instantiation. This is the requirement Zig's comptime switch does not meet,
+and it keeps a diagnostic on the code that is wrong rather than on a caller that
+happens to reach it.
 
 The unselected arms are dropped at monomorphization, before substitution. The
 compiler has the shape for this: `VariadicForOf` is a TIR node elaborated once
@@ -355,11 +346,11 @@ match type T {
 The binder is spelled as an impl header spells it, association named, so a
 derivation moved from a blanket into an arm reads the same in both places. It
 binds a plain associated type (`Base = B`) the same way it binds a pack. An arm
-that reads neither writes neither — a kind-only branch pays nothing for what it
-never touches — and an arm binds without bounding: `..F: Serialize` belongs to
+that reads neither writes neither, so a kind-only branch pays nothing for what
+it never touches. And an arm binds without bounding: `..F: Serialize` belongs to
 the header of the function the arm delegates to, which keeps the arm about
-proving the kind. Both are revisitable; a derivation that turns out to need the
-bound on the arm is the reason to revisit.
+proving the kind. Both are revisitable, and a derivation that turns out to need
+the bound on the arm is the reason to revisit.
 
 The mechanism underneath is unchanged by the spelling: bounds in force are
 name-keyed in `annotate_ctx.trait_ctx.type_param_bounds`, which
@@ -384,9 +375,9 @@ construct states it alone.
 ### Rejected: dispatching on an associated kind type
 
 `Reflect` could carry `type Kind` (a marker per kind) and a derivation could
-delegate to a `KindOps<T, T::Kind>` whose per-kind impls carry the kind bounds
-— the stand-in Rust reaches for while specialization is unstable. It needs no
-new syntax, and one implication rule (`Reflect<Kind = StructKind>` ⟹
+delegate to a `KindOps<T, T::Kind>` whose per-kind impls carry the kind bounds.
+This is the stand-in Rust reaches for while specialization is unstable. It needs
+no new syntax, and one implication rule (`Reflect<Kind = StructKind>` ⟹
 `ReflectStruct`) would carry it.
 
 It is rejected because the scaffolding is per derivation: every consumer writes

--- a/docs/wep-2026-09-05-total-reflection.md
+++ b/docs/wep-2026-09-05-total-reflection.md
@@ -1,4 +1,4 @@
-# WEP: Reflection over an Unknown Type — `TypeInfo` and `match type`
+# WEP: Total Reflection — `TypeInfo` and `match type`
 
 ## Context
 
@@ -72,6 +72,28 @@ internal trait Reflect {
     fn wire_name_policy() -> CaseStyle;
 }
 
+/// Sealed: cases and fields minted only by `type_info()`, constructible
+/// nowhere else, and not itself reflectable.
+pub variant TypeInfo {
+    Struct(DeclInfo),
+    Variant(DeclInfo),
+    Enum(DeclInfo),
+    Flags(DeclInfo),
+    Newtype(DeclInfo),
+    Resource(DeclInfo),
+    Array(DeclInfo),
+    Primitive(PrimitiveKind),
+    Unit,
+    Never,
+    Tuple(DeclInfo),
+    Reference(RefInfo),
+    Function(FnInfo),
+}
+
+impl TypeInfo {
+    pub fn canonical_name(&self) -> String;    // symbol notation, every case
+}
+
 /// A declaration named with this instantiation's arguments.
 pub struct DeclInfo { … }
 
@@ -81,25 +103,21 @@ impl DeclInfo {
     pub fn type_args(&self) -> List<TypeInfo>; // [String, i32]
 }
 
-pub variant TypeInfo {
-    Struct(DeclInfo),
-    Variant(DeclInfo),
-    Enum(DeclInfo),
-    Flags(DeclInfo),
-    Newtype(DeclInfo),
-    Resource(DeclInfo),
-    Tuple(DeclInfo),
-    Primitive(PrimitiveKind),
-    Array(TypeInfo),
-    Reference { mutable: bool, target: TypeInfo },
-    Function {
-        mutable: bool,                 // `fn mut(…)`
-        params: List<TypeInfo>,
-        result: TypeInfo,
-        effects: List<DeclInfo>,       // the `with E…` row: one interface each
-        stores: List<i32>,             // `stores[…]`, by parameter position
-    },
-    Never,
+pub struct RefInfo { … }
+
+impl RefInfo {
+    pub fn mutable(&self) -> bool;             // `&mut T`
+    pub fn target(&self) -> TypeInfo;
+}
+
+pub struct FnInfo { … }
+
+impl FnInfo {
+    pub fn mutable(&self) -> bool;             // `fn mut(…)`
+    pub fn params(&self) -> List<TypeInfo>;
+    pub fn result(&self) -> TypeInfo;
+    pub fn effects(&self) -> List<DeclInfo>;   // the `with E…` row: one interface each
+    pub fn stores(&self) -> List<u32>;         // `stores[…]`, by parameter position
 }
 
 /// The Wasm primitives, at the granularity the type system has.
@@ -109,11 +127,12 @@ pub enum PrimitiveKind {
     F32, F64,
     Bool, Char, V128,
 }
-
-impl TypeInfo {
-    pub fn canonical_name(&self) -> String;    // symbol notation, every case
-}
 ```
+
+`TypeInfo` keeps the seal the earlier WEP put on it: a program reads a case, and
+mints none. Every payload is a struct, since a Wado variant carries exactly one
+payload type per case — a reference and a function type each need several facts,
+so each gets a sealed struct rather than a shape the language does not have.
 
 A function type is the whole signature or it is not the type: `fn mut(…)`
 differs from `fn(…)`, and `with (Stdout, Stderr)` and `stores[data]` are row
@@ -132,12 +151,25 @@ for the rest, which is the classification this WEP completes:
 | `type N = B`                                              | `Newtype`   |
 | the four sealed member handles                            | `Struct`    |
 | a resource, `Future<T>` / `Stream<T>`                     | `Resource`  |
-| the tuple family, `()`                                    | `Tuple`     |
-| `i8`…`u64`, `f32`, `f64`, `bool`, `char`, `v128`          | `Primitive` |
 | `Array<T>`                                                | `Array`     |
+| `i8`…`u64`, `f32`, `f64`, `bool`, `char`, `v128`          | `Primitive` |
+| `()`                                                      | `Unit`      |
+| `!`                                                       | `Never`     |
+| the tuple family                                          | `Tuple`     |
 | `&T` / `&mut T`                                           | `Reference` |
 | `fn(…) -> R with E…`                                      | `Function`  |
-| `!`                                                       | `Never`     |
+
+`()` is the unit type, not the empty tuple, and the two are held apart
+everywhere else in the language — an impl for `[..T]` is never a candidate for
+it ([Trait Resolution](./wep-2026-09-01-trait-resolution.md)) — so it carries
+its own case rather than reading as a tuple of arity zero. Its declaration
+(`internal type ();`) sits beside the primitives' in the prelude, and `!`'s
+beside it.
+
+A case carries a `DeclInfo` only where the declaration is not determined by the
+case itself. `Primitive`, `Unit` and `Never` each name exactly one declaration
+with no arguments, so the case is the identity and repeating it would be a
+second spelling; the rest carry theirs.
 
 The four member handles are `Struct` because the seal is on structure, not on
 identity: nothing may enumerate their fields, and `match type` is where that
@@ -149,18 +181,14 @@ projection carry no case: none survives monomorphization, which is where a
 typed with its underlying value type, so the wrapper never reaches
 monomorphize.
 
-`Primitive` is named for what it holds — the Wasm primitives — and carries the
-one at the granularity the type system already has, so a consumer branches on
-`PrimitiveKind` rather than on a name string. The granularity sits in the case's
-payload, not in the case set, so `match type`'s arms are unaffected by it: one
-`primitive` arm, an ordinary `match` inside where a body cares. That placement
-is also why the kind is carried now rather than deferred — widening a case's
-payload later breaks every pattern already written against it, so "add it when
-someone needs it" is not the free option it looks like.
-
-The kind is the identity here, so this case carries no `DeclInfo`: the module is
-`core:prelude` and the name is the kind's spelling, both derivable, and
-`canonical_name()` renders them.
+`Primitive` is named for what it holds and carries the kind at the granularity
+the type system already has, so a consumer branches on `PrimitiveKind` rather
+than on a name string. The granularity sits in the case's payload, not in the
+case set, so `match type`'s arms are unaffected by it: one `primitive` arm, an
+ordinary `match` inside where a body cares. That placement is also why the kind
+is carried now rather than deferred — widening a case's payload later breaks
+every pattern already written against it, so "add it when someone needs it" is
+not the free option it looks like.
 
 `String`, `i128` and `u128` read as primitives to a programmer and are none:
 each is a prelude struct — `i128` and `u128` are `#[compiler_item]` structs of
@@ -180,11 +208,11 @@ to a bound the signature already has, or name the type — and a predicate
 telling them apart would serve no branch.
 
 A structural case keeps its components rather than rendering them away, which
-is why the flat "name + module + args" shape the earlier WEP sketched does not
-serve. `type_args()` returns `List<TypeInfo>`, so a type with no answer is not
-contained at the root — `Pair<&Point>` and `struct Handler { cb: fn(i32) -> i32 }`
-put one inside a tree a consumer is already walking. Totality is what keeps
-that tree readable end to end.
+is why a flat "name + module + args" shape does not serve. `type_args()` returns
+`List<TypeInfo>`, so a type with no answer is not contained at the root —
+`Pair<&Point>` and `struct Handler { cb: fn(i32) -> i32 }` put one inside a tree
+a consumer is already walking. Totality is what keeps that tree readable end to
+end.
 
 The visibility gate is unchanged: it sits on the kind traits and never on the
 root ([Reflect Derivation](./wep-2026-06-13-reflect-derivation.md),
@@ -194,36 +222,49 @@ public the moment the type is.
 ### Symbol notation names a structural type too
 
 [Symbol Notation](./wep-2026-06-14-symbol-notation.md) is `MODULE#SYMBOL`, and
-`canonical_name()` renders in its canonical register. A reference, a function
-type and a primitive have no module of their own, which is a gap in the
-notation rather than a reason for reflection to leave them unnamed: the module
-is `core:prelude`, and the symbol is the type's own surface spelling.
+`canonical_name()` renders in its canonical register. Most cases already have a
+module. A primitive, `()` and `!` are `internal type` declarations in
+`core:prelude` and resolve like any other name (`prelude/primitive.wado`,
+`trait_env.rs`'s `ImplTargetKey`); `Array<T>` is the prelude's
+`pub type Array<T>;`; and the tuple family is its `internal type [..T];`, whose
+arguments are the element types — the family-plus-arguments split a generic
+struct has.
+
+Two shapes have no declaration at all — a function type and a reference — which
+is a gap in the notation rather than a reason for reflection to leave them
+unnamed. Their module is `core:prelude` and their symbol is the type's own
+surface spelling:
 
 ```text
 core:prelude#i32
+core:prelude#()
+core:prelude#!
+core:prelude#Array<i32>
 core:prelude#&Point
 core:prelude#&mut Point
 core:prelude#fn(i32) -> i32
 core:prelude#[i32,String]
-core:prelude#()
-core:prelude#!
 ```
 
 This is the rule the notation already follows one level down: a type argument
-renders as its surface spelling (`core:collections#List<String>`), not as a
-nested `MODULE#SYMBOL`. A structural type is the same shape with the operator
-outermost, and the tuple family's anchor — `core:prelude#[i32,String]`, the
-prelude's `pub type [...T];` — was already decided this way.
+renders as its surface spelling (`core:prelude#List<String>`), not as a nested
+`MODULE#SYMBOL`. A structural type is the same shape with the operator
+outermost.
 
-Every type therefore has exactly one identity, and it is a module symbol. A
-resource and an interface each have a second one — the Component Model
-coordinate (`wasi:io/streams.input-stream`) — and reflection does not carry it:
-`DeclInfo` reports the Wado module symbol for every case alike, with no branch
-for the CM-backed ones. The friction is real and accepted: a consumer keying a
-registry by CM coordinate cannot get there from `TypeInfo`, and a WASI type
-reads by the name its generated Wado module gives it. One identity that is
-always the same shape is worth more than a second one that only some types
-have.
+That rendering is for a reader — a diagnostic, a dump, a doc anchor — and is not
+a key. `&Point` renders the pointee bare, so two `Point` declarations in
+different modules produce one string; a registry or a `$defs` map keys on the
+`TypeInfo` itself, which compares structurally over module, name and arguments
+and tells them apart. Reflection hands out identity as a value; the notation is
+how that value is spoken.
+
+The identity a `DeclInfo` carries is the Wado module symbol, for every case
+alike. A resource and an interface each have a second one — the Component Model
+coordinate (`wasi:io/streams.input-stream`) — and reflection does not carry it,
+with no branch for the CM-backed cases. The friction is real and accepted: a
+consumer keying a registry by CM coordinate cannot get there from `TypeInfo`,
+and a WASI type reads by the name its generated Wado module gives it. One
+identity of one shape is worth more than a second one only some types have.
 
 ### A `Shape` tree belongs to Jade
 
@@ -244,9 +285,9 @@ fn describe<T: Reflect>(v: &T) -> String {
         struct(FieldTypes = [..F]) => return fields_of(v),
         variant(CasePayloads = [..P]) => return live_case_of(v),
         enum | flags => return Reflect::<T>::type_name(),
-        newtype => return describe(&B::from(*v)),
-        tuple | primitive | array | reference | function | resource | never | opaque
-            => return Reflect::<T>::type_name(),
+        newtype(Base = B) => return describe(&B::from(*v)),
+        resource | array | primitive | unit | never | tuple | reference
+            | function | opaque => return Reflect::<T>::type_name(),
     }
 }
 ```
@@ -254,6 +295,13 @@ fn describe<T: Reflect>(v: &T) -> String {
 Each arm proves its kind's bound for its own body. `struct =>` elaborates under
 the hypothesis `T: ReflectStruct`, so `ReflectStruct::<T>::members()` resolves
 inside it and nowhere else.
+
+Only the five kind traits have a hypothesis to push. The other arms name a
+classification with no trait behind it, so they add nothing to what `T: Reflect`
+already gives, and neither do they bind: an `array` arm cannot name its element
+type today (Known gaps). An alternation pushes what all its kinds share, which
+is nothing beyond the root, so `enum | flags` is the way to write one body for
+two kinds and `struct | variant` buys nothing over `opaque`.
 
 A `match type` is exhaustive and carries no `_`. Every case of `TypeInfo` is a
 kind of the type system itself, so a set that closes over them closes over
@@ -263,7 +311,7 @@ the language breaks every `match type` in the ecosystem — which is what adding
 a kind is.
 
 `opaque` is the arm exhaustiveness forces into existence, and it is not `_`
-renamed. The other arms carry a hypothesis their body relies on, so a subject
+renamed. The kind arms carry a hypothesis their body relies on, so a subject
 that is a struct the site may not open — private members, or one of the sealed
 member handles — cannot enter `struct` without making that hypothesis false. It
 enters `opaque` instead: a named condition ("declared, not openable here"),
@@ -287,7 +335,7 @@ The call it leaves behind is already a solved problem too — a
 type's synthesized impl, which is how `fn root_name_of<T: Reflect>()` works
 today (`reflect_root_type_name.wado`).
 
-An arm binds the payload pack its kind carries. The pack cannot be left to a
+An arm binds what its kind's trait associates. The pack cannot be left to a
 helper function's header: a call site projects `[..F]` from the _concrete_
 subject (`variadic_free_fn_assoc_pack.wado` — the reflection impls are
 registered by a synthesis phase that runs after elaboration, so the projection
@@ -299,17 +347,19 @@ projection reads:
 match type T {
     struct(FieldTypes = [..F]) => …,      // T: ReflectStruct<FieldTypes = [..F]>
     variant(CasePayloads = [..P]) => …,   // T: ReflectVariant<CasePayloads = [..P]>
+    newtype(Base = B) => …,               // T: ReflectNewtype<Base = B>
     enum => …,                            // binds nothing; T: ReflectEnum
 }
 ```
 
 The binder is spelled as an impl header spells it, association named, so a
-derivation moved from a blanket into an arm reads the same in both places. An
-arm that reads no pack writes none — a kind-only branch pays nothing for a pack
-it never touches — and an arm binds the pack without bounding it: `..F: Serialize`
-belongs to the header of the function the arm delegates to, which keeps the arm
-about proving the kind. Both are revisitable; a derivation that turns out to
-need the bound on the arm is the reason to revisit.
+derivation moved from a blanket into an arm reads the same in both places. It
+binds a plain associated type (`Base = B`) the same way it binds a pack. An arm
+that reads neither writes neither — a kind-only branch pays nothing for what it
+never touches — and an arm binds without bounding: `..F: Serialize` belongs to
+the header of the function the arm delegates to, which keeps the arm about
+proving the kind. Both are revisitable; a derivation that turns out to need the
+bound on the arm is the reason to revisit.
 
 The mechanism underneath is unchanged by the spelling: bounds in force are
 name-keyed in `annotate_ctx.trait_ctx.type_param_bounds`, which
@@ -361,11 +411,11 @@ The LSP path stops after `liveness` and builds no TIR
 it never monomorphizes and every arm stays live in the editor. Hover inside an
 arm reports the hypothesis, not a selected instance.
 
-Minting `Reflect` for a type with no declaration is new work. Today the impls
-are synthesized per TIR declaration in `synthesis/traits.rs`; a primitive, a
-reference and a function type have none, so the root's three methods are minted
-off a `TypeId` instead. The solver side already admits them —
-a primitive lowers to `DeclKey::Builtin(name)`, so the fact table can carry it.
+Minting `Reflect` for the two declaration-less shapes is new work. Today the
+impls are synthesized per TIR declaration in `synthesis/traits.rs`, which a
+primitive and the tuple family reach like any other prelude type; a reference
+and a function type have no declaration, so their root methods are minted off a
+`TypeId` instead.
 
 A `TypeInfo` is a tree where a kind enum would have been a scalar, and it costs
 nothing at a use site: it is a closed constant expression, so
@@ -378,8 +428,7 @@ shorthand serde's `begin_struct` calls.
 
 The value plane for an unknown type is unchanged and stays out of reflection: a
 uniform walk over an unknown _value_ is `core:value::Value` through
-`Serialize`, and reflection answers for the _type_. `docs/spec.md` states that
-boundary so the split is not rediscovered.
+`Serialize`, and reflection answers for the _type_.
 
 ## Known gaps
 
@@ -395,12 +444,42 @@ one back is the harder half, since a structural type has no `AstId` for
 - [ ] Decide what `wado query "core:prelude#&Point"` answers — the target's
       declaration, a synthesized view, or a diagnostic naming the limit.
 
+### An arm with no trait behind it binds nothing
+
+The five kind traits give an arm its hypothesis and its associations. The other
+arms have neither, so an `array` arm cannot name its element type and a
+`function` arm cannot name a parameter's — a body that needs one reads
+`type_info()` and gets a value, not a type it can call a bound method on.
+
+- [ ] Decide whether these arms bind (a second binder form, over the case's own
+      components) or stay value-only.
+
+### An anonymous struct has no declaration to report
+
+An anonymous struct classifies as `Struct`, and `DeclInfo` reports a
+declaration. It has none: the compiler keys it as `Undeclared(module, rendering)`
+(`trait_env.rs`), where the module is the one that wrote the literal and the
+name is the shape's rendering. Two literals of one shape are one type on
+purpose, so the pair is a sound identity — but it is not a declaration, and
+nothing states how it renders in symbol notation.
+
+- [ ] State what `name()` and `module()` answer for an anonymous struct, and how
+      `canonical_name()` spells one.
+
+### The type/value split is unwritten
+
+Reflection answers for the type and `core:value::Value` for the value; that
+boundary is stated here and nowhere a reader of the language would look.
+
+- [ ] State it in `docs/spec.md`, so it is not rediscovered as a missing
+      reflection feature.
+
 ## Related WEPs
 
 - [Library-Defined Derivation over `Reflect*`](./wep-2026-06-13-reflect-derivation.md) — the three planes and the traits this WEP reaches
 - [Variadic Type Parameters](./wep-2026-03-14-variadic-type-parameters.md) — the packs an arm binds, and `VariadicForOf`
-- [Trait Resolution](./wep-2026-09-01-trait-resolution.md) — why a root-bounded blanket beside the kind ones is rank 3
+- [Trait Resolution](./wep-2026-09-01-trait-resolution.md) — why a root-bounded blanket beside the kind ones is rank 3, and why `()` is not a tuple
 - [Struct Walkability](./wep-2026-07-10-struct-walkability.md) — the visibility gate an arm inherits
-- [Symbol Notation](./wep-2026-06-14-symbol-notation.md) — the register `canonical_name()` renders, widened here to structural types
+- [Symbol Notation](./wep-2026-06-14-symbol-notation.md) — the register `canonical_name()` renders, widened here to the declaration-less shapes
 - [Jade](./wep-2026-06-13-jade.md) — where the `Shape` tree is written
 - [Elaborator Architecture](./wep-2026-05-26-elaborator-rearchitecture.md) — where an arm's hypothesis and its expansion live

--- a/docs/wep-2026-09-05-total-reflection.md
+++ b/docs/wep-2026-09-05-total-reflection.md
@@ -14,8 +14,9 @@ author cannot name:
 
 The value plane is inherently static: a bridge's result type is the member's,
 so a walk that does not know the type cannot receive the value. The structure
-plane is not — the compiler knows every type's kind — but it is reached only by
-naming that kind in a bound, and a bound is written before the subject is known.
+plane is not, since the compiler knows every type's kind. But it is reached only
+by naming that kind in a bound, and a bound is written before the subject is
+known.
 
 So a derivation writes one blanket per kind, which is what `Inspect` and
 `core:serde` do. That works and has four costs:
@@ -131,8 +132,8 @@ function type, each holding several facts, take a sealed struct.
 A function type is the whole signature or it is not the type: `fn mut(…)`
 differs from `fn(…)`, and `with (Stdout, Stderr)` and `stores[data]` are row
 members of the type the same way the parameters are. The effect row is where an
-`interface` enters the model — it is a declaration Wado names, so it reads as a
-`DeclInfo` like any other, and no separate identity is invented for it.
+`interface` enters the model. It is a declaration Wado names, so it reads as a
+`DeclInfo` like any other and needs no identity of its own.
 
 Every case is positive: no arm means "something the design has no answer for".
 `TypeTable::reflect_kind` already computes the first five and answers `None`
@@ -166,28 +167,27 @@ with no arguments, so the case is the identity and repeating it would be a
 second spelling; the rest carry theirs.
 
 The four member handles are `Struct` because the seal is on structure, not on
-identity: nothing may enumerate their fields, and `match type` is where that
-shows — they reach no `struct` arm. Naming them was never withheld.
+identity. Nothing may enumerate their fields, and `match type` is where that
+shows: they reach no `struct` arm. Naming them was never withheld.
 
 A type parameter, an inference variable, a pack and an associated-type
-projection carry no case: none survives monomorphization, which is where a
-`Reflect` subject is concrete. `Reactive<T>` is the same — a reactive binding is
-typed with its underlying value type, so the wrapper never reaches
-monomorphize.
+projection carry no case, since none survives monomorphization, which is where a
+`Reflect` subject is concrete. Nor does `Reactive<T>`: a reactive binding is
+typed with its underlying value type, so the wrapper never reaches monomorphize.
 
 `Primitive` is named for what it holds and carries the kind at the granularity
 the type system already has, so a consumer branches on `PrimitiveKind` rather
 than on a name string. The granularity sits in the case's payload, not in the
 case set, so `match type`'s arms are unaffected by it: one `primitive` arm, an
 ordinary `match` inside where a body cares. That placement is also why the kind
-is carried now rather than deferred — widening a case's payload later breaks
+is carried now rather than deferred. Widening a case's payload later breaks
 every pattern already written against it, so "add it when someone needs it" is
 not the free option it looks like.
 
-`String`, `i128` and `u128` read as primitives to a programmer and are none:
-each is a prelude struct — `i128` and `u128` are `#[compiler_item]` structs of
-two 64-bit limbs — with private fields, so they classify as `Struct` and, having
-no visible members downstream, cannot be opened there either.
+`String`, `i128` and `u128` read as primitives to a programmer and are none.
+Each is a prelude struct with private fields — `i128` and `u128` are
+`#[compiler_item]` structs of two 64-bit limbs — so they classify as `Struct`
+and, having no visible members downstream, cannot be opened there either.
 
 That they land in `opaque` rather than beside `i32` leaves nothing unanswered.
 The coarser question, leaf or aggregate, is computed from these cases and never
@@ -209,7 +209,7 @@ there.
 
 The visibility gate is unchanged: it sits on the kind traits and never on the
 root ([Reflect Derivation](./wep-2026-06-13-reflect-derivation.md),
-Visibility). A total root is what that split already implied — a type's name is
+Visibility). That split already implied a total root, since a type's name is
 public the moment the type is.
 
 ### Symbol notation names a reference and a function type
@@ -303,8 +303,8 @@ a kind is.
 
 `opaque` is the arm exhaustiveness forces into existence, and it is not `_`
 renamed. A kind arm carries a hypothesis its body relies on, so a struct the
-site may not open — one with private members, or one of the sealed member
-handles — cannot enter `struct` without making that hypothesis false. It enters
+site may not open (one with private members, or one of the sealed member
+handles) cannot enter `struct` without making that hypothesis false. It enters
 `opaque` instead, a named condition meaning "declared, not openable here", where
 `type_info()` still reports what the type is. A future kind does not land there;
 it fails exhaustiveness, as intended.
@@ -320,11 +320,10 @@ The unselected arms are dropped at monomorphization, before substitution. The
 compiler has the shape for this: `VariadicForOf` is a TIR node elaborated once
 generically and expanded against the concrete pack in `monomorphize/func_inst.rs`,
 and a `match type` node is expanded the same way against the concrete subject.
-The call it leaves behind is already a solved problem too — a
-`Reflect*` static call on a type parameter records a dispatch fact
-(`is_type_param_receiver`) that monomorphization redirects to the concrete
-type's synthesized impl, which is how `fn root_name_of<T: Reflect>()` works
-today (`reflect_root_type_name.wado`).
+The call it leaves behind is a solved problem too: a `Reflect*` static call on a
+type parameter records a dispatch fact (`is_type_param_receiver`) that
+monomorphization redirects to the concrete type's synthesized impl. That is how
+`fn root_name_of<T: Reflect>()` works today (`reflect_root_type_name.wado`).
 
 An arm binds what its kind's trait associates. The pack cannot be left to a
 helper function's header: a call site projects `[..F]` from the _concrete_
@@ -402,11 +401,10 @@ The LSP path stops after `liveness` and builds no TIR
 it never monomorphizes and every arm stays live in the editor. Hover inside an
 arm reports the hypothesis, not a selected instance.
 
-Minting `Reflect` for the two declaration-less shapes is new work. Today the
+Minting `Reflect` for a reference and a function type is new work. Today the
 impls are synthesized per TIR declaration in `synthesis/traits.rs`, which a
-primitive and the tuple family reach like any other prelude type; a reference
-and a function type have no declaration, so their root methods are minted off a
-`TypeId` instead.
+primitive and the tuple family reach like any other prelude type. Those two have
+no declaration, so their root methods are minted off a `TypeId` instead.
 
 A `TypeInfo` is a tree where a kind enum would have been a scalar, and it costs
 nothing at a use site: it is a closed constant expression, so
@@ -417,19 +415,19 @@ allocation, which is what makes a separate scalar query unnecessary rather than
 merely redundant. `type_name()` stays beside it as the allocation-free
 shorthand serde's `begin_struct` calls.
 
-The value plane for an unknown type is unchanged and stays out of reflection: a
-uniform walk over an unknown _value_ is `core:value::Value` through
-`Serialize`, and reflection answers for the _type_.
+The value plane stays out of reflection, as it was: a uniform walk over an
+unknown _value_ is `core:value::Value` through `Serialize`, and reflection
+answers for the _type_.
 
 ## Known gaps
 
-### The structural notation is unwritten and one-way
+### A reference and a function type have no notation yet
 
 `core:prelude#&Point` and `core:prelude#fn(i32) -> i32` are decided above and
 implemented nowhere: `symbol_notation` parses and renders declaration symbols
 only. Rendering is what `canonical_name()` needs, and it comes first; resolving
-one back is the harder half, since a structural type has no `AstId` for
-`wado query` to land on and the notation "runs both ways" today.
+one back is the harder half, since neither has an `AstId` for `wado query` to
+land on and the notation "runs both ways" today.
 
 - [ ] Render every `TypeInfo` case in `symbol_notation`.
 - [ ] Decide what `wado query "core:prelude#&Point"` answers — the target's
@@ -439,7 +437,7 @@ one back is the harder half, since a structural type has no `AstId` for
 
 The five kind traits give an arm its hypothesis and its associations. The other
 arms have neither, so an `array` arm cannot name its element type and a
-`function` arm cannot name a parameter's — a body that needs one reads
+`function` arm cannot name a parameter's. A body that needs one reads
 `type_info()` and gets a value, not a type it can call a bound method on.
 
 - [ ] Decide whether these arms bind (a second binder form, over the case's own
@@ -451,7 +449,7 @@ An anonymous struct classifies as `Struct`, and `DeclInfo` reports a
 declaration. It has none: the compiler keys it as `Undeclared(module, rendering)`
 (`trait_env.rs`), where the module is the one that wrote the literal and the
 name is the shape's rendering. Two literals of one shape are one type on
-purpose, so the pair is a sound identity — but it is not a declaration, and
+purpose, so that pair is a sound identity. It is still not a declaration, and
 nothing states how it renders in symbol notation.
 
 - [ ] State what `name()` and `module()` answer for an anonymous struct, and how
@@ -459,8 +457,8 @@ nothing states how it renders in symbol notation.
 
 ### The type/value split is unwritten
 
-Reflection answers for the type and `core:value::Value` for the value; that
-boundary is stated here and nowhere a reader of the language would look.
+Reflection answers for the type and `core:value::Value` for the value. The spec
+does not say so, and this WEP is not where a reader of the language will look.
 
 - [ ] State it in `docs/spec.md`, so it is not rediscovered as a missing
       reflection feature.
@@ -471,6 +469,6 @@ boundary is stated here and nowhere a reader of the language would look.
 - [Variadic Type Parameters](./wep-2026-03-14-variadic-type-parameters.md) — the packs an arm binds, and `VariadicForOf`
 - [Trait Resolution](./wep-2026-09-01-trait-resolution.md) — why a root-bounded blanket beside the kind ones is rank 3, and why `()` is not a tuple
 - [Struct Walkability](./wep-2026-07-10-struct-walkability.md) — the visibility gate an arm inherits
-- [Symbol Notation](./wep-2026-06-14-symbol-notation.md) — the register `canonical_name()` renders, widened here to the declaration-less shapes
+- [Symbol Notation](./wep-2026-06-14-symbol-notation.md) — the register `canonical_name()` renders, widened here to a reference and a function type
 - [Jade](./wep-2026-06-13-jade.md) — where the `Shape` tree is written
 - [Elaborator Architecture](./wep-2026-05-26-elaborator-rearchitecture.md) — where an arm's hypothesis and its expansion live


### PR DESCRIPTION
Proposes a design for reaching a type's structure without naming its kind in a bound, and records what naming every type costs the WEPs it touches.

## The friction

Reflection has three planes, and only identity serves a subject the author cannot name. The value plane is inherently static: a member bridge's result type is the member's, so a walk that does not know the type cannot receive the value. The structure plane is not — the compiler knows every type's kind — but it is reached only by naming that kind in a bound, and a bound is written before the subject is known.

So a derivation writes one blanket per kind, as `Inspect` and `core:serde` do. Only a trait can dispatch, the framing common to every kind is written once per kind, there is no last-resort arm, and each new kind rewrites every derivation.

## What the WEP proposes

`docs/wep-2026-09-05-total-reflection.md`.

`Reflect` holds of every type. `Inspect` already does (`TraitDef::holds_for_all`), so a total root introduces no resolution shape the language lacks.

The root answers with `TypeInfo`, a sealed variant carrying the classification rather than sitting beside one — a type is exactly one case, so the variant's tag is the kind and no separate enum spells it a second time. A case carries a `DeclInfo` (name, module, type arguments) where the declaration is not determined by the case itself; `Primitive`, `Unit` and `Never` each name one declaration with no arguments, so the case is the identity. A reference and a function type keep their components, since the flat name-plus-arguments shape cannot hold them and they reach a consumer inside `type_args()` rather than at the root.

`match type T` narrows a subject to its kind in the body:

```wado
fn describe<T: Reflect>(v: &T) -> String {
    match type T {
        struct(FieldTypes = [..F]) => return fields_of(v),
        variant(CasePayloads = [..P]) => return live_case_of(v),
        enum | flags => return Reflect::<T>::type_name(),
        newtype(Base = B) => return describe(&B::from(*v)),
        resource | array | primitive | unit | never | tuple | reference
            | function | opaque => return Reflect::<T>::type_name(),
    }
}
```

A kind arm proves its kind's bound for its own body, binds what that kind's trait associates, and is checked once at the definition under that hypothesis rather than per instantiation — which is what keeps a diagnostic on the code that is wrong. The unselected arms are dropped at monomorphization. `match type` is exhaustive with no `_`, and `opaque` is the named condition exhaustiveness forces into existence: declared, not openable here.

Symbol notation gains the two shapes that have no declaration to name them, a reference and a function type; everything else — a primitive, `()`, `!`, `Array<T>`, the tuple family — is already a prelude declaration. Their module is `core:prelude` and their symbol is the surface spelling, which is what a type argument already does one level down.

## What else the branch settles

- `docs/wep-2026-06-13-reflect-derivation.md` — `TypeInfo`'s shape lives in the new WEP, so this one states what a declaration's case carries and defers the rest. "What can be named" answers "every type".
- `docs/wep-2026-09-01-trait-resolution.md` — rank 3 refuses to rank a blanket whose bounds imply another's, and reflection is the first pattern to pay for it. Recorded as a Known gap independent of reflection, with the two questions reopening it takes: what a caller sees when the narrower impl binds an associated type differently, and how incomparable bound sets are ordered.
- `docs/wep-2026-06-14-symbol-notation.md` — a checklist item for naming a reference and a function type, including that the rendering is not a key: `&Point` renders its pointee bare.
- `core:prelude#List<String>` replaces `core:collections#List<String>` in the notation examples here and in `docs/spec.md`. `List` is declared in `core:prelude/list.wado`.

## Known gaps in the new WEP

A reference and a function type have no notation yet, and resolving one back has no `AstId` to land on. An arm outside the five kind traits binds nothing, so an `array` arm cannot name its element type. An anonymous struct reaches no declaration for `DeclInfo` to report. The type/value split is stated here and not in `docs/spec.md`.

## Prerequisite

The classification puts `i128` and `u128` in `Struct`, which they are. #1970 retires the `PrimitiveType::I128` / `U128` spelling that exists beside them, and this WEP is written for a tree where that has landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017JneSWkWGkN6goE9zyBrxB


---
_Generated by [Claude Code](https://claude.ai/code/session_017JneSWkWGkN6goE9zyBrxB)_