### PR TITLE
chore(hooks): drive the review-response and distill steps from hooks

### DIFF
--- a/.claude/hooks/code-review-followup.mts
+++ b/.claude/hooks/code-review-followup.mts
@@ -1,49 +1,28 @@
 #!/usr/bin/env node
 // Hands the findings of a /code-review run to the skill that answers them.
-// Two events, because a skill reaches the session two ways: the user types
-// `/code-review` (UserPromptSubmit), or the model calls it (PostToolUse > Skill).
+
+import { type HookPayload, invokesSkill, readPayload } from "./skill-invocation.mts";
 
 const REMINDER =
   "The findings of this review are claims to answer, not a task list. Invoke the" +
   " `code-review-response` skill once the review reports: verify each finding, fix the class" +
   " it names, and report what was skipped and why.";
 
-const SLASH = /^\s*\/code-review(\s|$)/;
-const SKILL = /(^|:)code-review$/;
-
-export function followUpContext(payload: unknown): string | null {
-  const event = payload as {
-    hook_event_name?: string;
-    prompt?: string;
-    tool_name?: string;
-    tool_input?: { skill?: string };
-  };
-  switch (event?.hook_event_name) {
-    case "UserPromptSubmit":
-      return SLASH.test(event.prompt ?? "") ? REMINDER : null;
-    case "PostToolUse":
-      return event.tool_name === "Skill" && SKILL.test(event.tool_input?.skill ?? "")
-        ? REMINDER
-        : null;
-    default:
-      return null;
-  }
+export function followUpContext(payload: HookPayload | null): string | null {
+  return invokesSkill(payload, "code-review") ? REMINDER : null;
 }
 
 if (import.meta.main) {
-  let input = "";
-  for await (const chunk of process.stdin) input += chunk;
-  let payload: unknown;
-  try {
-    payload = JSON.parse(input);
-  } catch {
-    payload = null;
-  }
+  const payload = await readPayload();
   const context = followUpContext(payload);
   if (context) {
-    const hookEventName = (payload as { hook_event_name: string }).hook_event_name;
     process.stdout.write(
-      JSON.stringify({ hookSpecificOutput: { hookEventName, additionalContext: context } }),
+      JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: payload.hook_event_name,
+          additionalContext: context,
+        },
+      }),
     );
   }
 }

--- a/.claude/hooks/code-review-followup.mts
+++ b/.claude/hooks/code-review-followup.mts
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+// Hands the findings of a /code-review run to the skill that answers them.
+// Two events, because a skill reaches the session two ways: the user types
+// `/code-review` (UserPromptSubmit), or the model calls it (PostToolUse > Skill).
+
+const REMINDER =
+  "The findings of this review are claims to answer, not a task list. Invoke the" +
+  " `code-review-response` skill once the review reports: verify each finding, fix the class" +
+  " it names, and report what was skipped and why.";
+
+const SLASH = /^\s*\/code-review(\s|$)/;
+const SKILL = /(^|:)code-review$/;
+
+export function followUpContext(payload: unknown): string | null {
+  const event = payload as {
+    hook_event_name?: string;
+    prompt?: string;
+    tool_name?: string;
+    tool_input?: { skill?: string };
+  };
+  switch (event?.hook_event_name) {
+    case "UserPromptSubmit":
+      return SLASH.test(event.prompt ?? "") ? REMINDER : null;
+    case "PostToolUse":
+      return event.tool_name === "Skill" && SKILL.test(event.tool_input?.skill ?? "")
+        ? REMINDER
+        : null;
+    default:
+      return null;
+  }
+}
+
+if (import.meta.main) {
+  let input = "";
+  for await (const chunk of process.stdin) input += chunk;
+  let payload: unknown;
+  try {
+    payload = JSON.parse(input);
+  } catch {
+    payload = null;
+  }
+  const context = followUpContext(payload);
+  if (context) {
+    const hookEventName = (payload as { hook_event_name: string }).hook_event_name;
+    process.stdout.write(
+      JSON.stringify({ hookSpecificOutput: { hookEventName, additionalContext: context } }),
+    );
+  }
+}

--- a/.claude/hooks/code-review-followup.test.mts
+++ b/.claude/hooks/code-review-followup.test.mts
@@ -1,0 +1,39 @@
+// mise run test-hooks
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { followUpContext } from "./code-review-followup.mts";
+
+const prompt = (text: string) => ({ hook_event_name: "UserPromptSubmit", prompt: text });
+const skill = (name: string) => ({
+  hook_event_name: "PostToolUse",
+  tool_name: "Skill",
+  tool_input: { skill: name },
+});
+
+test("a /code-review run asks for the response skill", () => {
+  for (const payload of [
+    prompt("/code-review"),
+    prompt("  /code-review --fix high"),
+    skill("code-review"),
+    skill("wado:code-review"),
+  ]) {
+    assert.match(followUpContext(payload) ?? "", /code-review-response/);
+  }
+});
+
+test("anything else is left alone", () => {
+  for (const payload of [
+    prompt("/code-review-response"),
+    prompt("review the diff"),
+    prompt("run /distill"),
+    skill("code-review-response"),
+    skill("distill"),
+    { hook_event_name: "PostToolUse", tool_name: "Bash", tool_input: { command: "/code-review" } },
+    { hook_event_name: "PreToolUse", tool_name: "Skill", tool_input: { skill: "code-review" } },
+    {},
+    null,
+  ]) {
+    assert.equal(followUpContext(payload), null);
+  }
+});

--- a/.claude/hooks/code-review-followup.test.mts
+++ b/.claude/hooks/code-review-followup.test.mts
@@ -4,36 +4,15 @@ import { test } from "node:test";
 
 import { followUpContext } from "./code-review-followup.mts";
 
+// What names a skill is skill-invocation's own test; this one is the reminder.
 const prompt = (text: string) => ({ hook_event_name: "UserPromptSubmit", prompt: text });
-const skill = (name: string) => ({
-  hook_event_name: "PostToolUse",
-  tool_name: "Skill",
-  tool_input: { skill: name },
-});
 
 test("a /code-review run asks for the response skill", () => {
-  for (const payload of [
-    prompt("/code-review"),
-    prompt("  /code-review --fix high"),
-    skill("code-review"),
-    skill("wado:code-review"),
-  ]) {
-    assert.match(followUpContext(payload) ?? "", /code-review-response/);
-  }
+  assert.match(followUpContext(prompt("/code-review --fix high")) ?? "", /code-review-response/);
 });
 
 test("anything else is left alone", () => {
-  for (const payload of [
-    prompt("/code-review-response"),
-    prompt("review the diff"),
-    prompt("run /distill"),
-    skill("code-review-response"),
-    skill("distill"),
-    { hook_event_name: "PostToolUse", tool_name: "Bash", tool_input: { command: "/code-review" } },
-    { hook_event_name: "PreToolUse", tool_name: "Skill", tool_input: { skill: "code-review" } },
-    {},
-    null,
-  ]) {
+  for (const payload of [prompt("/code-review-response"), prompt("review the diff"), {}, null]) {
     assert.equal(followUpContext(payload), null);
   }
 });

--- a/.claude/hooks/distill-reminder.mts
+++ b/.claude/hooks/distill-reminder.mts
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+// Asks for a distill pass before the turn that finished the work ends.
+//
+// Three events: the two ways `distill` reaches a session record that it ran
+// (the user types `/distill`, or the model calls the skill), and Stop decides.
+// A session is asked once — a nudge repeated every turn is noise, not guidance.
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+
+const REMINDER =
+  "This branch has not been distilled. Run the `distill` skill over the whole branch" +
+  " — reuse what exists, drop duplication, dead code and wasted work, turn invariants into" +
+  " asserts, delete the comments the code already speaks — then commit what it changes.";
+
+const SLASH = /^\s*\/distill(\s|$)/;
+const SKILL = /(^|:)distill$/;
+
+type Payload = {
+  hook_event_name?: string;
+  session_id?: string;
+  stop_hook_active?: boolean;
+  prompt?: string;
+  tool_name?: string;
+  tool_input?: { skill?: string };
+};
+
+export type State = "unset" | "asked" | "done";
+export type Action = "record-done" | "ask" | "ignore";
+
+export function decide(payload: Payload, state: State, hasWork: boolean): Action {
+  switch (payload?.hook_event_name) {
+    case "UserPromptSubmit":
+      return SLASH.test(payload.prompt ?? "") ? "record-done" : "ignore";
+    case "PostToolUse":
+      return payload.tool_name === "Skill" && SKILL.test(payload.tool_input?.skill ?? "")
+        ? "record-done"
+        : "ignore";
+    case "Stop":
+      if (payload.stop_hook_active || state !== "unset" || !hasWork) return "ignore";
+      return "ask";
+    default:
+      return "ignore";
+  }
+}
+
+function statePath(sessionId: string): string {
+  const gitDir = execFileSync("git", ["rev-parse", "--git-dir"], { encoding: "utf8" }).trim();
+  const dir = join(gitDir, "wado-hooks");
+  mkdirSync(dir, { recursive: true });
+  return join(dir, `distill.${sessionId.replace(/[^\w.-]/g, "_")}`);
+}
+
+function readState(path: string): State {
+  try {
+    return readFileSync(path, "utf8").trim() as State;
+  } catch {
+    return "unset";
+  }
+}
+
+// Work to distill: anything this branch changed against its merge base, or
+// anything still in the worktree. No merge base — no branch to judge.
+function hasWork(): boolean {
+  const git = (args: string[]) => execFileSync("git", args, { encoding: "utf8" }).trim();
+  try {
+    const base = git(["merge-base", "origin/main", "HEAD"]);
+    return git(["status", "--porcelain"]) !== "" || git(["diff", "--name-only", base]) !== "";
+  } catch {
+    return false;
+  }
+}
+
+if (import.meta.main) {
+  let input = "";
+  for await (const chunk of process.stdin) input += chunk;
+  let payload: Payload = {};
+  try {
+    payload = JSON.parse(input) ?? {};
+  } catch {
+    payload = {};
+  }
+  const sessionId = payload.session_id;
+  if (!sessionId) process.exit(0);
+
+  let path: string;
+  try {
+    path = statePath(sessionId);
+  } catch {
+    process.exit(0); // Not a repository: nothing to distill.
+  }
+  const isStop = payload.hook_event_name === "Stop";
+  const action = decide(payload, readState(path), isStop && hasWork());
+  if (action === "record-done") writeFileSync(path, "done");
+  if (action === "ask") {
+    writeFileSync(path, "asked");
+    process.stderr.write(REMINDER);
+    process.exit(2);
+  }
+}

--- a/.claude/hooks/distill-reminder.mts
+++ b/.claude/hooks/distill-reminder.mts
@@ -9,18 +9,18 @@ import { join } from "node:path";
 import { type HookPayload, invokesSkill, readPayload } from "./skill-invocation.mts";
 
 const REMINDER =
-  "This branch has not been distilled. Run the `distill` skill over the whole branch" +
-  " — reuse what exists, drop duplication, dead code and wasted work, turn invariants into" +
-  " asserts, delete the comments the code already speaks — then commit what it changes.";
+  "This branch has not been distilled. Run the `distill` skill over the whole branch," +
+  " then commit what it changes.";
 
 export type State = "unset" | "asked" | "done";
 export type Action = "record-done" | "ask" | "ignore";
 
-export function decide(payload: HookPayload, state: State, hasWork: boolean): Action {
+// `hasWork` is a thunk: only a Stop that reaches the last test pays for it.
+export function decide(payload: HookPayload, state: State, hasWork: () => boolean): Action {
   if (invokesSkill(payload, "distill")) return "record-done";
   if (payload?.hook_event_name !== "Stop") return "ignore";
-  if (payload.stop_hook_active || state !== "unset" || !hasWork) return "ignore";
-  return "ask";
+  if (payload.stop_hook_active || state !== "unset") return "ignore";
+  return hasWork() ? "ask" : "ignore";
 }
 
 const git = (...args: string[]) => execFileSync("git", args, { encoding: "utf8" }).trim();
@@ -53,9 +53,10 @@ function hasCommittedWork(): boolean {
 
 if (import.meta.main) {
   const payload = await readPayload();
-  const isStop = payload.hook_event_name === "Stop";
-  // Every prompt and every skill call reaches here; only these two touch git.
-  if (!payload.session_id || (!isStop && !invokesSkill(payload, "distill"))) process.exit(0);
+  // Every prompt and every skill call reaches here, so ask the decision itself,
+  // under the inputs most favourable to acting, before spending a git spawn.
+  const couldAct = decide(payload, "unset", () => true) !== "ignore";
+  if (!payload.session_id || !couldAct) process.exit(0);
 
   let path: string;
   try {
@@ -63,7 +64,7 @@ if (import.meta.main) {
   } catch {
     process.exit(0); // Not a repository: nothing to distill.
   }
-  const action = decide(payload, readState(path), isStop && hasCommittedWork());
+  const action = decide(payload, readState(path), hasCommittedWork);
   if (action === "record-done") writeFileSync(path, "done");
   if (action === "ask") {
     writeFileSync(path, "asked");

--- a/.claude/hooks/distill-reminder.mts
+++ b/.claude/hooks/distill-reminder.mts
@@ -39,12 +39,13 @@ function readState(path: string): State {
   }
 }
 
-// Anything the branch changed against its merge base, or anything still in the
-// worktree. Without a merge base there is no branch to judge.
-function hasWork(): boolean {
+// Work to distill is what the branch committed against its merge base. A dirty
+// worktree is the commit-and-push hook's to demand first, so the two Stop hooks
+// run in sequence rather than both at once.
+function hasCommittedWork(): boolean {
   try {
     const base = git("merge-base", "origin/main", "HEAD");
-    return git("status", "--porcelain") !== "" || git("diff", "--name-only", base) !== "";
+    return git("status", "--porcelain") === "" && git("diff", "--name-only", base) !== "";
   } catch {
     return false;
   }
@@ -52,7 +53,9 @@ function hasWork(): boolean {
 
 if (import.meta.main) {
   const payload = await readPayload();
-  if (!payload.session_id) process.exit(0);
+  const isStop = payload.hook_event_name === "Stop";
+  // Every prompt and every skill call reaches here; only these two touch git.
+  if (!payload.session_id || (!isStop && !invokesSkill(payload, "distill"))) process.exit(0);
 
   let path: string;
   try {
@@ -60,8 +63,7 @@ if (import.meta.main) {
   } catch {
     process.exit(0); // Not a repository: nothing to distill.
   }
-  const isStop = payload.hook_event_name === "Stop";
-  const action = decide(payload, readState(path), isStop && hasWork());
+  const action = decide(payload, readState(path), isStop && hasCommittedWork());
   if (action === "record-done") writeFileSync(path, "done");
   if (action === "ask") {
     writeFileSync(path, "asked");

--- a/.claude/hooks/distill-reminder.mts
+++ b/.claude/hooks/distill-reminder.mts
@@ -1,53 +1,32 @@
 #!/usr/bin/env node
 // Asks for a distill pass before the turn that finished the work ends.
-//
-// Three events: the two ways `distill` reaches a session record that it ran
-// (the user types `/distill`, or the model calls the skill), and Stop decides.
-// A session is asked once — a nudge repeated every turn is noise, not guidance.
+// A session is asked once: a nudge repeated every turn is noise, not guidance.
 
+import { execFileSync } from "node:child_process";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { execFileSync } from "node:child_process";
+
+import { type HookPayload, invokesSkill, readPayload } from "./skill-invocation.mts";
 
 const REMINDER =
   "This branch has not been distilled. Run the `distill` skill over the whole branch" +
   " — reuse what exists, drop duplication, dead code and wasted work, turn invariants into" +
   " asserts, delete the comments the code already speaks — then commit what it changes.";
 
-const SLASH = /^\s*\/distill(\s|$)/;
-const SKILL = /(^|:)distill$/;
-
-type Payload = {
-  hook_event_name?: string;
-  session_id?: string;
-  stop_hook_active?: boolean;
-  prompt?: string;
-  tool_name?: string;
-  tool_input?: { skill?: string };
-};
-
 export type State = "unset" | "asked" | "done";
 export type Action = "record-done" | "ask" | "ignore";
 
-export function decide(payload: Payload, state: State, hasWork: boolean): Action {
-  switch (payload?.hook_event_name) {
-    case "UserPromptSubmit":
-      return SLASH.test(payload.prompt ?? "") ? "record-done" : "ignore";
-    case "PostToolUse":
-      return payload.tool_name === "Skill" && SKILL.test(payload.tool_input?.skill ?? "")
-        ? "record-done"
-        : "ignore";
-    case "Stop":
-      if (payload.stop_hook_active || state !== "unset" || !hasWork) return "ignore";
-      return "ask";
-    default:
-      return "ignore";
-  }
+export function decide(payload: HookPayload, state: State, hasWork: boolean): Action {
+  if (invokesSkill(payload, "distill")) return "record-done";
+  if (payload?.hook_event_name !== "Stop") return "ignore";
+  if (payload.stop_hook_active || state !== "unset" || !hasWork) return "ignore";
+  return "ask";
 }
 
+const git = (...args: string[]) => execFileSync("git", args, { encoding: "utf8" }).trim();
+
 function statePath(sessionId: string): string {
-  const gitDir = execFileSync("git", ["rev-parse", "--git-dir"], { encoding: "utf8" }).trim();
-  const dir = join(gitDir, "wado-hooks");
+  const dir = join(git("rev-parse", "--git-dir"), "wado-hooks");
   mkdirSync(dir, { recursive: true });
   return join(dir, `distill.${sessionId.replace(/[^\w.-]/g, "_")}`);
 }
@@ -60,33 +39,24 @@ function readState(path: string): State {
   }
 }
 
-// Work to distill: anything this branch changed against its merge base, or
-// anything still in the worktree. No merge base — no branch to judge.
+// Anything the branch changed against its merge base, or anything still in the
+// worktree. Without a merge base there is no branch to judge.
 function hasWork(): boolean {
-  const git = (args: string[]) => execFileSync("git", args, { encoding: "utf8" }).trim();
   try {
-    const base = git(["merge-base", "origin/main", "HEAD"]);
-    return git(["status", "--porcelain"]) !== "" || git(["diff", "--name-only", base]) !== "";
+    const base = git("merge-base", "origin/main", "HEAD");
+    return git("status", "--porcelain") !== "" || git("diff", "--name-only", base) !== "";
   } catch {
     return false;
   }
 }
 
 if (import.meta.main) {
-  let input = "";
-  for await (const chunk of process.stdin) input += chunk;
-  let payload: Payload = {};
-  try {
-    payload = JSON.parse(input) ?? {};
-  } catch {
-    payload = {};
-  }
-  const sessionId = payload.session_id;
-  if (!sessionId) process.exit(0);
+  const payload = await readPayload();
+  if (!payload.session_id) process.exit(0);
 
   let path: string;
   try {
-    path = statePath(sessionId);
+    path = statePath(payload.session_id);
   } catch {
     process.exit(0); // Not a repository: nothing to distill.
   }

--- a/.claude/hooks/distill-reminder.test.mts
+++ b/.claude/hooks/distill-reminder.test.mts
@@ -5,6 +5,8 @@ import { test } from "node:test";
 import { decide } from "./distill-reminder.mts";
 
 const stop = (extra: object = {}) => ({ hook_event_name: "Stop", ...extra });
+const work = () => true;
+const noWork = () => false;
 
 test("a distill run is recorded, whichever way it was invoked", () => {
   for (const payload of [
@@ -13,22 +15,22 @@ test("a distill run is recorded, whichever way it was invoked", () => {
     { hook_event_name: "PostToolUse", tool_name: "Skill", tool_input: { skill: "distill" } },
     { hook_event_name: "PostToolUse", tool_name: "Skill", tool_input: { skill: "wado:distill" } },
   ]) {
-    assert.equal(decide(payload, "unset", true), "record-done");
+    assert.equal(decide(payload, "unset", work), "record-done");
   }
 });
 
 test("a turn that changed the branch is asked once", () => {
-  assert.equal(decide(stop(), "unset", true), "ask");
-  assert.equal(decide(stop(), "asked", true), "ignore");
-  assert.equal(decide(stop(), "done", true), "ignore");
+  assert.equal(decide(stop(), "unset", work), "ask");
+  assert.equal(decide(stop(), "asked", work), "ignore");
+  assert.equal(decide(stop(), "done", work), "ignore");
 });
 
 test("nothing to distill, nothing to say", () => {
-  assert.equal(decide(stop(), "unset", false), "ignore");
+  assert.equal(decide(stop(), "unset", noWork), "ignore");
 });
 
 test("a stop the hook itself caused never blocks again", () => {
-  assert.equal(decide(stop({ stop_hook_active: true }), "unset", true), "ignore");
+  assert.equal(decide(stop({ stop_hook_active: true }), "unset", work), "ignore");
 });
 
 test("anything else is left alone", () => {
@@ -39,6 +41,6 @@ test("anything else is left alone", () => {
     { hook_event_name: "SessionEnd" },
     {},
   ]) {
-    assert.equal(decide(payload, "unset", true), "ignore");
+    assert.equal(decide(payload, "unset", work), "ignore");
   }
 });

--- a/.claude/hooks/distill-reminder.test.mts
+++ b/.claude/hooks/distill-reminder.test.mts
@@ -1,0 +1,44 @@
+// mise run test-hooks
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { decide } from "./distill-reminder.mts";
+
+const stop = (extra: object = {}) => ({ hook_event_name: "Stop", ...extra });
+
+test("a distill run is recorded, whichever way it was invoked", () => {
+  for (const payload of [
+    { hook_event_name: "UserPromptSubmit", prompt: "/distill" },
+    { hook_event_name: "UserPromptSubmit", prompt: "  /distill the branch" },
+    { hook_event_name: "PostToolUse", tool_name: "Skill", tool_input: { skill: "distill" } },
+    { hook_event_name: "PostToolUse", tool_name: "Skill", tool_input: { skill: "wado:distill" } },
+  ]) {
+    assert.equal(decide(payload, "unset", true), "record-done");
+  }
+});
+
+test("a turn that changed the branch is asked once", () => {
+  assert.equal(decide(stop(), "unset", true), "ask");
+  assert.equal(decide(stop(), "asked", true), "ignore");
+  assert.equal(decide(stop(), "done", true), "ignore");
+});
+
+test("nothing to distill, nothing to say", () => {
+  assert.equal(decide(stop(), "unset", false), "ignore");
+});
+
+test("a stop the hook itself caused never blocks again", () => {
+  assert.equal(decide(stop({ stop_hook_active: true }), "unset", true), "ignore");
+});
+
+test("anything else is left alone", () => {
+  for (const payload of [
+    { hook_event_name: "UserPromptSubmit", prompt: "/distill-something-else" },
+    { hook_event_name: "UserPromptSubmit", prompt: "explain distill" },
+    { hook_event_name: "PostToolUse", tool_name: "Bash", tool_input: { skill: "distill" } },
+    { hook_event_name: "SessionEnd" },
+    {},
+  ]) {
+    assert.equal(decide(payload, "unset", true), "ignore");
+  }
+});

--- a/.claude/hooks/distill-reminder.test.mts
+++ b/.claude/hooks/distill-reminder.test.mts
@@ -4,16 +4,15 @@ import { test } from "node:test";
 
 import { decide } from "./distill-reminder.mts";
 
+// What names a skill is skill-invocation's own test; this one is the decision.
 const stop = (extra: object = {}) => ({ hook_event_name: "Stop", ...extra });
 const work = () => true;
 const noWork = () => false;
 
 test("a distill run is recorded, whichever way it was invoked", () => {
   for (const payload of [
-    { hook_event_name: "UserPromptSubmit", prompt: "/distill" },
-    { hook_event_name: "UserPromptSubmit", prompt: "  /distill the branch" },
+    { hook_event_name: "UserPromptSubmit", prompt: "/distill the branch" },
     { hook_event_name: "PostToolUse", tool_name: "Skill", tool_input: { skill: "distill" } },
-    { hook_event_name: "PostToolUse", tool_name: "Skill", tool_input: { skill: "wado:distill" } },
   ]) {
     assert.equal(decide(payload, "unset", work), "record-done");
   }
@@ -35,9 +34,7 @@ test("a stop the hook itself caused never blocks again", () => {
 
 test("anything else is left alone", () => {
   for (const payload of [
-    { hook_event_name: "UserPromptSubmit", prompt: "/distill-something-else" },
     { hook_event_name: "UserPromptSubmit", prompt: "explain distill" },
-    { hook_event_name: "PostToolUse", tool_name: "Bash", tool_input: { skill: "distill" } },
     { hook_event_name: "SessionEnd" },
     {},
   ]) {

--- a/.claude/hooks/forbidden-commands.mts
+++ b/.claude/hooks/forbidden-commands.mts
@@ -4,17 +4,17 @@
 
 const FORBIDDEN = [
   {
-    pattern: /^(sed|awk|python(3(\.\d+)?)?)$/,
+    pattern: /^(sed|awk|perl|python(3(\.\d+)?)?)$/,
     reason:
-      "sed, awk, python and python3 are forbidden (AGENTS.md > Tooling): a rewrite keeps" +
+      "sed, awk, perl, python and python3 are forbidden (AGENTS.md > Tooling): a rewrite keeps" +
       " matching where it was not aimed. Edit with the editing tools, one call per change" +
       " site; script in Node.js.",
   },
   {
-    pattern: /^nohup$/,
+    pattern: /^(nohup|setsid|disown)$/,
     reason:
-      "nohup is forbidden (AGENTS.md > Tooling): it notifies nobody when the job exits. Run" +
-      " a long job through the harness's background mechanism.",
+      "nohup, setsid and disown are forbidden (AGENTS.md > Tooling): a detached job notifies" +
+      " nobody when it exits. Run a long job through the harness's background mechanism.",
   },
 ];
 

--- a/.claude/hooks/forbidden-commands.test.mts
+++ b/.claude/hooks/forbidden-commands.test.mts
@@ -6,6 +6,10 @@ import { commandNames, denialReason } from "./forbidden-commands.mts";
 
 const DENIED = [
   "sed -i 's/a/b/' f.rs",
+  "perl -pi -e 's/a/b/' f.rs",
+  "bash -c 'perl -0777 -pi -e s/a/b/ f.rs'",
+  "setsid cargo test",
+  "cargo test & disown",
   "set -o pipefail; cat f | sed -n '1,5p'",
   "git log | awk '{print $1}'",
   "python3 -c 'print(1)'",
@@ -112,4 +116,6 @@ test("resolves the command word of every nested source", () => {
 test("gives the reason of the ban that applies", () => {
   assert.match(denialReason("sed -i x f")!, /editing tools/);
   assert.match(denialReason("nohup cargo test &")!, /background/);
+  assert.match(denialReason("perl -pi -e x f")!, /editing tools/);
+  assert.match(denialReason("setsid cargo test")!, /background/);
 });

--- a/.claude/hooks/skill-invocation.mts
+++ b/.claude/hooks/skill-invocation.mts
@@ -1,0 +1,37 @@
+// A skill reaches a session two ways: the user types `/name` (UserPromptSubmit),
+// or the model calls it (PostToolUse > Skill). Both name the skill here.
+
+export type HookPayload = {
+  hook_event_name?: string;
+  session_id?: string;
+  stop_hook_active?: boolean;
+  prompt?: string;
+  tool_name?: string;
+  tool_input?: { skill?: string };
+};
+
+const TYPED = /^\s*\/([\w:.-]+)/;
+const bare = (skill: string) => skill.replace(/^.*:/, "");
+
+export function invokesSkill(payload: HookPayload | null, skill: string): boolean {
+  switch (payload?.hook_event_name) {
+    case "UserPromptSubmit": {
+      const typed = TYPED.exec(payload.prompt ?? "")?.[1];
+      return typed !== undefined && bare(typed) === skill;
+    }
+    case "PostToolUse":
+      return payload.tool_name === "Skill" && bare(payload.tool_input?.skill ?? "") === skill;
+    default:
+      return false;
+  }
+}
+
+export async function readPayload(): Promise<HookPayload> {
+  let input = "";
+  for await (const chunk of process.stdin) input += chunk;
+  try {
+    return JSON.parse(input) ?? {};
+  } catch {
+    return {};
+  }
+}

--- a/.claude/hooks/skill-invocation.mts
+++ b/.claude/hooks/skill-invocation.mts
@@ -21,7 +21,9 @@ const named = (value: unknown): string | null =>
 export function invokesSkill(payload: HookPayload | null, skill: string): boolean {
   switch (payload?.hook_event_name) {
     case "UserPromptSubmit":
-      return named(TYPED.exec(String(payload.prompt ?? ""))?.[1]) === skill;
+      return (
+        typeof payload.prompt === "string" && named(TYPED.exec(payload.prompt)?.[1]) === skill
+      );
     case "PostToolUse":
       return payload.tool_name === "Skill" && named(payload.tool_input?.skill) === skill;
     default:

--- a/.claude/hooks/skill-invocation.mts
+++ b/.claude/hooks/skill-invocation.mts
@@ -10,17 +10,20 @@ export type HookPayload = {
   tool_input?: { skill?: string };
 };
 
-const TYPED = /^\s*\/([\w:.-]+)/;
-const bare = (skill: string) => skill.replace(/^.*:/, "");
+// A typed name runs to the end of its word, so `/distill/foo` names no skill.
+const TYPED = /^\s*\/([\w:.-]+)(?=\s|$)/;
+
+// The payload is parsed JSON, so a declared field is a claim about its shape.
+// Anything but a string names no skill, and a plugin prefix is not part of one.
+const named = (value: unknown): string | null =>
+  typeof value === "string" ? value.replace(/^.*:/, "") : null;
 
 export function invokesSkill(payload: HookPayload | null, skill: string): boolean {
   switch (payload?.hook_event_name) {
-    case "UserPromptSubmit": {
-      const typed = TYPED.exec(payload.prompt ?? "")?.[1];
-      return typed !== undefined && bare(typed) === skill;
-    }
+    case "UserPromptSubmit":
+      return named(TYPED.exec(String(payload.prompt ?? ""))?.[1]) === skill;
     case "PostToolUse":
-      return payload.tool_name === "Skill" && bare(payload.tool_input?.skill ?? "") === skill;
+      return payload.tool_name === "Skill" && named(payload.tool_input?.skill) === skill;
     default:
       return false;
   }

--- a/.claude/hooks/skill-invocation.test.mts
+++ b/.claude/hooks/skill-invocation.test.mts
@@ -27,7 +27,15 @@ test("a typed name ends at its word", () => {
 });
 
 test("a field of the wrong type names no skill", () => {
-  for (const payload of [called(7), called(null), called({ name: "distill" }), typed(7)]) {
+  // An array is the coercion trap: `String(["/distill"])` is `"/distill"`.
+  for (const payload of [
+    called(7),
+    called(null),
+    called({ name: "distill" }),
+    called(["distill"]),
+    typed(7),
+    typed(["/distill"]),
+  ]) {
     assert.equal(invokesSkill(payload, "distill"), false);
   }
 });

--- a/.claude/hooks/skill-invocation.test.mts
+++ b/.claude/hooks/skill-invocation.test.mts
@@ -1,0 +1,40 @@
+// mise run test-hooks
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { type HookPayload, invokesSkill } from "./skill-invocation.mts";
+
+// A payload is parsed JSON, so these hand it fields the declared type forbids.
+const parsed = (fields: object) => fields as HookPayload;
+const typed = (prompt: unknown) => parsed({ hook_event_name: "UserPromptSubmit", prompt });
+const called = (skill: unknown) =>
+  parsed({ hook_event_name: "PostToolUse", tool_name: "Skill", tool_input: { skill } });
+
+test("names the skill a payload invokes", () => {
+  for (const payload of [typed("/distill"), typed("  /distill the branch"), called("distill")]) {
+    assert.ok(invokesSkill(payload, "distill"));
+  }
+});
+
+test("a plugin prefix is not part of the name", () => {
+  assert.ok(invokesSkill(called("wado:distill"), "distill"));
+});
+
+test("a typed name ends at its word", () => {
+  for (const prompt of ["/distill-something", "/distill/foo", "/distill?x", "/distill.md"]) {
+    assert.equal(invokesSkill(typed(prompt), "distill"), false, prompt);
+  }
+});
+
+test("a field of the wrong type names no skill", () => {
+  for (const payload of [called(7), called(null), called({ name: "distill" }), typed(7)]) {
+    assert.equal(invokesSkill(payload, "distill"), false);
+  }
+});
+
+test("only the two invocation events count", () => {
+  for (const event of ["PreToolUse", "Stop", "SessionStart"]) {
+    assert.equal(invokesSkill({ hook_event_name: event, prompt: "/distill" }, "distill"), false);
+  }
+  assert.equal(invokesSkill(null, "distill"), false);
+});

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -39,6 +39,10 @@
           {
             "type": "command",
             "command": "./.claude/hooks/code-review-followup.mts"
+          },
+          {
+            "type": "command",
+            "command": "./.claude/hooks/distill-reminder.mts"
           }
         ]
       }
@@ -50,6 +54,20 @@
           {
             "type": "command",
             "command": "./.claude/hooks/code-review-followup.mts"
+          },
+          {
+            "type": "command",
+            "command": "./.claude/hooks/distill-reminder.mts"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./.claude/hooks/distill-reminder.mts"
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -33,6 +33,27 @@
         ]
       }
     ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./.claude/hooks/code-review-followup.mts"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./.claude/hooks/code-review-followup.mts"
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",

--- a/.claude/skills/code-review-response/SKILL.md
+++ b/.claude/skills/code-review-response/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-review-response
-description: "How to answer code review feedback — a human reviewer, CodeRabbit, or any review bot. Verify each finding before acting, fix only what is real, put design decisions to the user, then run /distill. Invoke when responding to review comments on a pull request."
+description: "How to answer code review feedback — a human reviewer, CodeRabbit, or any review bot. Verify each finding before acting, fix only what is real, put design decisions to the user, then run /distill. Invoke when responding to review comments on a pull request, or to the findings of a /code-review run."
 ---
 
 # Answering a code review

--- a/.claude/skills/code-review-response/SKILL.md
+++ b/.claude/skills/code-review-response/SKILL.md
@@ -21,6 +21,14 @@ that. Record which of these each finding was:
 A severity label and an aggregate "merge risk" verdict track neither the truth
 nor what you have already answered. Neither is evidence of anything.
 
+## Fix the class, not the finding
+
+A finding points at one site. Before fixing it, raise the altitude: what class of
+defect is this, and where else does the class hold? Fix what admits the class —
+the missing invariant, the type that allows the state, the call site nobody has
+to remember. A patch at the site the reviewer named leaves the rest of the class
+in the tree.
+
 ## Tests are held to a higher bar
 
 The question is what the test catches that it did not before. If the case the

--- a/.claude/skills/code-review-response/SKILL.md
+++ b/.claude/skills/code-review-response/SKILL.md
@@ -24,7 +24,7 @@ nor what you have already answered. Neither is evidence of anything.
 ## Fix the class, not the finding
 
 A finding points at one site. Before fixing it, raise the altitude: what class of
-defect is this, and where else does the class hold? Fix what admits the class —
+defect is this, and where else does the class hold? Fix what admits the class:
 the missing invariant, the type that allows the state, the call site nobody has
 to remember. A patch at the site the reviewer named leaves the rest of the class
 in the tree.

--- a/.claude/skills/code-review-response/SKILL.md
+++ b/.claude/skills/code-review-response/SKILL.md
@@ -53,4 +53,6 @@ is the whole branch, as always, not the fixes alone.
 ## Report
 
 One comment on the pull request: what was fixed, and what was skipped with its
-reason. The skips are half the answer, not an omission from it.
+reason. The skips are half the answer, not an omission from it. A review that
+arrived outside a pull request, `/code-review` among them, is reported the same
+way in the session.

--- a/.claude/skills/pull-request/SKILL.md
+++ b/.claude/skills/pull-request/SKILL.md
@@ -64,9 +64,8 @@ the description is broken, and never rewrite prose to work around it.
 
 ## After opening & Periodic status checks
 
-Subscribe to the PR with `subscribe_pr_activity` and keep it subscribed until
-the PR is merged or closed. Handle every event it delivers; skipping one is a
-decision you state.
+Subscribe to the PR with `subscribe_pr_activity`. Handle every event it
+delivers; skipping one is a decision you state.
 
 Check mergeability (`mergeable_state`). If conflicting, resolve it with the
 `git-upstream-sync` skill.

--- a/.claude/skills/pull-request/SKILL.md
+++ b/.claude/skills/pull-request/SKILL.md
@@ -64,5 +64,19 @@ the description is broken, and never rewrite prose to work around it.
 
 ## After opening & Periodic status checks
 
+Subscribe to the PR with `subscribe_pr_activity` and keep it subscribed until
+the PR is merged or closed. Watching is not passive: handle every event or skip
+it deliberately.
+
 Check mergeability (`mergeable_state`). If conflicting, resolve it with the
 `git-upstream-sync` skill.
+
+## Answering a review
+
+A review — human or bot — is a set of claims to weigh, not a task list. Answer
+it with the `code-review-response` skill: verify each finding against the
+current code, fix the ones worth fixing, and say why for the rest. Skipping a
+finding is a decision you state, never silence.
+
+Re-read the review after each push: a finding that returns names the design,
+not the comment.

--- a/.claude/skills/pull-request/SKILL.md
+++ b/.claude/skills/pull-request/SKILL.md
@@ -71,12 +71,5 @@ it deliberately.
 Check mergeability (`mergeable_state`). If conflicting, resolve it with the
 `git-upstream-sync` skill.
 
-## Answering a review
-
-A review — human or bot — is a set of claims to weigh, not a task list. Answer
-it with the `code-review-response` skill: verify each finding against the
-current code, fix the ones worth fixing, and say why for the rest. Skipping a
-finding is a decision you state, never silence.
-
-Re-read the review after each push: a finding that returns names the design,
-not the comment.
+A review that arrives — human or bot — is answered with the
+`code-review-response` skill.

--- a/.claude/skills/pull-request/SKILL.md
+++ b/.claude/skills/pull-request/SKILL.md
@@ -65,11 +65,10 @@ the description is broken, and never rewrite prose to work around it.
 ## After opening & Periodic status checks
 
 Subscribe to the PR with `subscribe_pr_activity` and keep it subscribed until
-the PR is merged or closed. Watching is not passive: handle every event or skip
-it deliberately.
+the PR is merged or closed. Handle every event it delivers; skipping one is a
+decision you state.
 
 Check mergeability (`mergeable_state`). If conflicting, resolve it with the
 `git-upstream-sync` skill.
 
-A review that arrives — human or bot — is answered with the
-`code-review-response` skill.
+Answer a review, human or bot, with the `code-review-response` skill.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,8 +65,7 @@ mise run report-wasm-size  # measures the size of the generated Wasm files and r
 - Add a new integration test to `tests/integration/` and declare it in that directory's `main.rs`. A file dropped directly in `tests/` becomes its own target, and each one statically links the compiler and wasmtime for another ~150 MB.
 - Use the `rust` skill when writing Rust.
 - Use the `wado` skill when writing Wado code or designing Wado language features.
-- Use the `code-review-response` skill when answering review comments, and when
-  answering the findings of a `/code-review` run.
+- Use the `code-review-response` skill when answering review comments, and when answering the findings of a `/code-review` run.
 
 ## The Wado Language
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,8 @@ mise run report-wasm-size  # measures the size of the generated Wasm files and r
 - Add a new integration test to `tests/integration/` and declare it in that directory's `main.rs`. A file dropped directly in `tests/` becomes its own target, and each one statically links the compiler and wasmtime for another ~150 MB.
 - Use the `rust` skill when writing Rust.
 - Use the `wado` skill when writing Wado code or designing Wado language features.
-- Use the `code-review-response` skill when answering review comments.
+- Use the `code-review-response` skill when answering review comments, and when
+  answering the findings of a `/code-review` run.
 
 ## The Wado Language
 

--- a/wado-compiler/tests/generated/fixtures/dot_shadowed_mut_param.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/dot_shadowed_mut_param.wir.wado
@@ -16,60 +16,45 @@ struct core:prelude/string.wado//String {  // TypeId(3)
     mut used: i32,
 }
 
-array Array<i32> (mut i32);  // TypeId(4)
-
-struct core:prelude/slice.wado//Slice<u8> {  // TypeId(5)
+struct core:prelude/slice.wado//Slice<u8> {  // TypeId(4)
     mut repr: ref Array<u8>,
     mut start: i32,
     mut end: i32,
 }
 
-struct core:prelude//List<i32> {  // TypeId(6)
-    mut repr: ref Array<i32>,
-    mut used: i32,
-}
+type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(5)
 
-type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(7)
+type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(6)
 
-type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(8)
+type "functype//wasi/task-return" = fn(i32);  // TypeId(7)
 
-type "functype//wasi/task-return" = fn(i32);  // TypeId(9)
+type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(8)
 
-type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(10)
+type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(9)
 
-type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(11)
+type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(10)
 
-type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(12)
+type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(11)
 
-type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(13)
+type "functype//wasi/wasi:cli/Stdout::write_via_stream" = fn(i32) -> i32;  // TypeId(12)
 
-type "functype//wasi/wasi:cli/Stdout::write_via_stream" = fn(i32) -> i32;  // TypeId(14)
+type "functype//dot_shadowed_mut_param.wado/run" = fn();  // TypeId(13)
 
-type "functype//dot_shadowed_mut_param.wado/run" = fn();  // TypeId(15)
+type "functype//dot_shadowed_mut_param.wado/__cm_binding__Stdout_write_via_stream" = fn(i32) -> i32;  // TypeId(14)
 
-type "functype//dot_shadowed_mut_param.wado/__cm_binding__Stdout_write_via_stream" = fn(i32) -> i32;  // TypeId(16)
+type "functype//dot_shadowed_mut_param.wado/__cm_export__run" = fn();  // TypeId(15)
 
-type "functype//dot_shadowed_mut_param.wado/__cm_export__run" = fn();  // TypeId(17)
+type "functype//core:rt/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(16)
 
-type "functype//core:rt/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(18)
+type "functype//core:prelude/fpfmt.wado/__initialize_module" = fn();  // TypeId(17)
 
-type "functype//core:prelude/fpfmt.wado/__initialize_module" = fn();  // TypeId(19)
+type "functype//core:prelude/types.wado/core:prelude/types.wado/StreamWritable<u8>::write_raw_all" = fn(i32, ref "core:prelude/slice.wado//Slice<u8>") -> "core:prelude/types.wado//enum:CopyResult";  // TypeId(18)
 
-type "functype//core:prelude/string.wado/core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(20)
+type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(19)
 
-type "functype//core:prelude/types.wado/core:prelude/types.wado/StreamWritable<u8>::write_raw_all" = fn(i32, ref "core:prelude/slice.wado//Slice<u8>") -> "core:prelude/types.wado//enum:CopyResult";  // TypeId(21)
+type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(20)
 
-type "functype//core:prelude/list.wado/core:prelude/list.wado/List<i32>::grow" = fn(ref "core:prelude//List<i32>");  // TypeId(22)
-
-type "functype//core:prelude/primitive.wado/i32::fmt_decimal$scalar$spec0$scalar" = fn(i32, ref "core:prelude/string.wado//String");  // TypeId(23)
-
-type "functype//core:prelude/format.wado/core:prelude/format.wado/Formatter::prepare_int_write$spec0$scalar" = fn(ref "core:prelude/string.wado//String", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(24)
-
-type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(25)
-
-type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(26)
-
-type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(27)
+type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(21)
 
 import fn mem/realloc from "mem/realloc";
 import fn wasi/stream-write from "wasi/stream-write";
@@ -85,15 +70,12 @@ import fn wasi/future-drop-readable:transmission-cli from "wasi/future-drop-read
 import fn wasi/stream-drop-writable from "wasi/stream-drop-writable";
 
 global mut global:dot_shadowed_mut_param.wado::__modules_initialized: bool = 0;
-global global:core:prelude/primitive.wado::__const_obj_3: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 };
+global global:dot_shadowed_mut_param.wado::__const_obj_1: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: array.new_fixed<u8>(49, 48, 50), used: 3 };
+global global:dot_shadowed_mut_param.wado::__const_obj_2: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: array.new_fixed<u8>(50), used: 1 };
+global global:dot_shadowed_mut_param.wado::__const_obj_3: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: array.new_fixed<u8>(51), used: 1 };
 
 fn "dot_shadowed_mut_param.wado/run"() with Stdout {
-    let __local_2: ref "core:prelude/string.wado//String";
-    let __local_4_4: ref "core:prelude/string.wado//String";
-    let __local_6: ref "core:prelude/string.wado//String";
-    let elements: ref Array<i32>;
     let handle_12: i32;
-    let items_20: ref "core:prelude//List<i32>";
     let packed_23: i64;
     let rx_24: i32;
     let tx_25: i32;
@@ -111,34 +93,20 @@ fn "dot_shadowed_mut_param.wado/run"() with Stdout {
         "core:prelude/fpfmt.wado/__initialize_module"();
         global:dot_shadowed_mut_param.wado::__modules_initialized = 1;
     };
-    elements = array.new_fixed<i32>(1, 2);
-    __local_2 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(16), used: 0 };
-    items_20 = struct.new "core:prelude//List<i32>" { repr: ref.as_non_null(let __array_clone_dst_2: ref Array<i32>; __array_clone_dst_2 = builtin::array_new<i32>(2); builtin::array_copy<i32>(__array_clone_dst_2, 0, elements, 0, 2); __array_clone_dst_2), used: 2 };
-    if @unlikely(2 >= builtin::array_len(items_20.repr)) {
-        cold_path;
-        "core:prelude/list.wado/core:prelude/list.wado/List<i32>::grow"(items_20);
-    }
-    builtin::array_set<i32>(items_20.repr, 2, 9);
-    items_20.used = 3;
-    "core:prelude/primitive.wado/i32::fmt_decimal$scalar$spec0$scalar"(items_20.used, __local_2);
     rx_24 = builtin::i32_wrap_i64(local.tee packed_23("wasi/stream-new"()));
     tx_25 = builtin::i32_wrap_i64(packed_23 >> 32_i64);
     handle_12 = "dot_shadowed_mut_param.wado/__cm_binding__Stdout_write_via_stream"(rx_24);
-    "core:rt/write_string_to_stream"(tx_25, __local_2, 1);
+    "core:rt/write_string_to_stream"(tx_25, global:dot_shadowed_mut_param.wado::__const_obj_3, 1);
     "wasi/future-drop-readable:transmission-cli"(handle_12);
-    __local_4_4 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(16), used: 0 };
-    "core:prelude/primitive.wado/i32::fmt_decimal$scalar$spec0$scalar"(2, __local_4_4);
     rx_43 = builtin::i32_wrap_i64(local.tee packed_42("wasi/stream-new"()));
     tx_44 = builtin::i32_wrap_i64(packed_42 >> 32_i64);
     handle_33 = "dot_shadowed_mut_param.wado/__cm_binding__Stdout_write_via_stream"(rx_43);
-    "core:rt/write_string_to_stream"(tx_44, __local_4_4, 1);
+    "core:rt/write_string_to_stream"(tx_44, global:dot_shadowed_mut_param.wado::__const_obj_2, 1);
     "wasi/future-drop-readable:transmission-cli"(handle_33);
-    __local_6 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(16), used: 0 };
-    "core:prelude/primitive.wado/i32::fmt_decimal$scalar$spec0$scalar"(102, __local_6);
     rx_63 = builtin::i32_wrap_i64(local.tee packed_62("wasi/stream-new"()));
     tx_64 = builtin::i32_wrap_i64(packed_62 >> 32_i64);
     handle_52 = "dot_shadowed_mut_param.wado/__cm_binding__Stdout_write_via_stream"(rx_63);
-    "core:rt/write_string_to_stream"(tx_64, __local_6, 1);
+    "core:rt/write_string_to_stream"(tx_64, global:dot_shadowed_mut_param.wado::__const_obj_1, 1);
     "wasi/future-drop-readable:transmission-cli"(handle_52);
 }
 
@@ -176,23 +144,6 @@ fn "core:rt/write_string_to_stream"(tx, message, add_newline) {
 fn "core:prelude/fpfmt.wado/__initialize_module"() {
 }
 
-fn "core:prelude/string.wado/core:prelude/string.wado/String::grow"(self, min_capacity) {
-    let capacity: i32;
-    let new_capacity: i32;
-    let new_repr: ref Array<u8>;
-    let a_7: i32;
-    let a_9: i32;
-    capacity = builtin::array_len(self.repr);
-    if min_capacity <= capacity {
-        return;
-    }
-    a_9 = capacity * 2;
-    a_7 = select i32(a_9 > min_capacity, a_9, min_capacity);
-    new_repr = builtin::array_new<u8>(local.tee new_capacity(select i32(a_7 > 8, a_7, 8)));
-    builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
-    self.repr = new_repr;
-}
-
 fn "core:prelude/types.wado/core:prelude/types.wado/StreamWritable<u8>::write_raw_all"(self, data) {
     let repr_2: ref Array<u8>;
     let end_3: i32;
@@ -220,14 +171,14 @@ fn "core:prelude/types.wado/core:prelude/types.wado/StreamWritable<u8>::write_ra
     end_3 = _av_50 + (_av_51 - _av_50);
     offset = data.start;
     block {
-        l5: loop {
+        l3: loop {
             __sroa_data_start = offset;
-            ptr_14 = builtin::i32_wrap_i64(local.tee packed_13(len_23 = end_3 - __sroa_data_start; ptr_24 = "mem/realloc"(0, 0, 1, len_23); i = 0; b6: block {
-                l7: loop {
-                    break_if b6 i >= len_23;
+            ptr_14 = builtin::i32_wrap_i64(local.tee packed_13(len_23 = end_3 - __sroa_data_start; ptr_24 = "mem/realloc"(0, 0, 1, len_23); i = 0; b4: block {
+                l5: loop {
+                    break_if b4 i >= len_23;
                     builtin::store_u8(ptr_24 + i, builtin::array_get_value_u8(repr_2, __sroa_data_start + i));
                     i = i + 1;
-                    continue l7;
+                    continue l5;
                 };
             }; builtin::i64_extend_i32_s(ptr_24) | (builtin::i64_extend_i32_s(len_23) << 32_i64)));
             raw_len = builtin::i32_wrap_i64(packed_13 >> 32_i64);
@@ -259,90 +210,9 @@ fn "core:prelude/types.wado/core:prelude/types.wado/StreamWritable<u8>::write_ra
             if select i32(select i32(written_16.result != 0, 1, written_16.count <= 0), 1, offset >= end_3) {
                 return written_16.result;
             }
-            continue l5;
+            continue l3;
         };
     };
-}
-
-fn "core:prelude/list.wado/core:prelude/list.wado/List<i32>::grow"(self) {
-    let capacity: i32;
-    let new_capacity: i32;
-    let new_repr: ref Array<i32>;
-    let a: i32;
-    a = local.tee capacity(builtin::array_len(self.repr)) * 2;
-    new_repr = builtin::array_new<i32>(local.tee new_capacity(select i32(a > 4, a, 4)));
-    builtin::array_copy<i32>(new_repr, 0, self.repr, 0, self.used);
-    self.repr = new_repr;
-}
-
-fn "core:prelude/primitive.wado/i32::fmt_decimal$scalar$spec0$scalar"(self, f) {
-    let is_negative: bool;
-    let abs_val: u64;
-    let digit_count_4: i32;
-    let offset_5: i32;
-    let val_6: i64;
-    let n: i32;
-    let t_9: u64;
-    let arr: ref Array<u8>;
-    let pos: i32;
-    let t_15: u64;
-    let i: i32;
-    is_negative = self < 0;
-    val_6 = builtin::i64_extend_i32_s(self);
-    abs_val = select i64(val_6 < 0_i64, 0_i64 - val_6, val_6);
-    digit_count_4 = __inline_count_digits_u64_1: block -> i32 {
-        if abs_val == 0_i64 {
-            break __inline_count_digits_u64_1: 1;
-        }
-        n = 0;
-        t_9 = abs_val;
-        b13: block {
-            l14: loop {
-                break_if b13 t_9 <=u 0_i64;
-                n = n + 1;
-                t_9 = t_9 /u 10_i64;
-                continue l14;
-            };
-        };
-        break __inline_count_digits_u64_1: n;
-    };
-    offset_5 = "core:prelude/format.wado/core:prelude/format.wado/Formatter::prepare_int_write$spec0$scalar"(f, is_negative, global:core:prelude/primitive.wado::__const_obj_3, digit_count_4);
-    arr = f.repr;
-    pos = offset_5 + digit_count_4;
-    t_15 = abs_val;
-    i = 0;
-    b15: block {
-        l16: loop {
-            break_if b15 i >= digit_count_4;
-            pos = pos - 1;
-            builtin::array_set_u8(arr, pos, (48 + builtin::i32_wrap_i64(t_15 %u 10_i64)) & 255);
-            t_15 = t_15 /u 10_i64;
-            i = i + 1;
-            continue l16;
-        };
-    };
-}
-
-fn "core:prelude/format.wado/core:prelude/format.wado/Formatter::prepare_int_write$spec0$scalar"(self, is_negative, alt_prefix, digit_count) {
-    let new_used_21: i32;
-    let start_22: i32;
-    let new_used_56: i32;
-    let start_57: i32;
-    if is_negative {
-        new_used_21 = self.used + 1;
-        if @unlikely(new_used_21 > builtin::array_len(self.repr)) {
-            cold_path;
-            "core:prelude/string.wado/core:prelude/string.wado/String::grow"(self, new_used_21);
-        }
-        start_22 = self.used;
-        self.used = new_used_21;
-        builtin::array_set_u8(self.repr, start_22, 45);
-    } else {
-    }
-    return new_used_56 = self.used + digit_count, if @unlikely(new_used_56 > builtin::array_len(self.repr)) {
-        cold_path;
-        "core:prelude/string.wado/core:prelude/string.wado/String::grow"(self, new_used_56);
-    }, start_57 = self.used, self.used = new_used_56, start_57;
 }
 
 export fn "dot_shadowed_mut_param.wado/__cm_export__run" as "run"

--- a/wado-compiler/tests/generated/fixtures/ufcs_inherent_shadows_trait_method.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/ufcs_inherent_shadows_trait_method.wir.wado
@@ -48,19 +48,13 @@ type "functype//core:rt/write_string_to_stream" = fn(i32, ref "core:prelude/stri
 
 type "functype//core:prelude/fpfmt.wado/__initialize_module" = fn();  // TypeId(17)
 
-type "functype//core:prelude/string.wado/core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(18)
+type "functype//core:prelude/types.wado/core:prelude/types.wado/StreamWritable<u8>::write_raw_all" = fn(i32, ref "core:prelude/slice.wado//Slice<u8>") -> "core:prelude/types.wado//enum:CopyResult";  // TypeId(18)
 
-type "functype//core:prelude/types.wado/core:prelude/types.wado/StreamWritable<u8>::write_raw_all" = fn(i32, ref "core:prelude/slice.wado//Slice<u8>") -> "core:prelude/types.wado//enum:CopyResult";  // TypeId(19)
+type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(19)
 
-type "functype//core:prelude/primitive.wado/i32::fmt_decimal$scalar$spec0$scalar" = fn(i32, ref "core:prelude/string.wado//String");  // TypeId(20)
+type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(20)
 
-type "functype//core:prelude/format.wado/core:prelude/format.wado/Formatter::prepare_int_write$spec0$scalar" = fn(ref "core:prelude/string.wado//String", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(21)
-
-type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(22)
-
-type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(23)
-
-type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(24)
+type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(21)
 
 import fn mem/realloc from "mem/realloc";
 import fn wasi/stream-write from "wasi/stream-write";
@@ -76,12 +70,11 @@ import fn wasi/future-drop-readable:transmission-cli from "wasi/future-drop-read
 import fn wasi/stream-drop-writable from "wasi/stream-drop-writable";
 
 global mut global:ufcs_inherent_shadows_trait_method.wado::__modules_initialized: bool = 0;
-global global:core:prelude/primitive.wado::__const_obj_3: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 };
+global global:ufcs_inherent_shadows_trait_method.wado::__const_obj_1: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: array.new_fixed<u8>(51), used: 1 };
+global global:ufcs_inherent_shadows_trait_method.wado::__const_obj_2: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: array.new_fixed<u8>(49, 48, 48), used: 3 };
+global global:ufcs_inherent_shadows_trait_method.wado::__const_obj_3: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: array.new_fixed<u8>(49), used: 1 };
 
 fn "ufcs_inherent_shadows_trait_method.wado/run"() with Stdout {
-    let __local_2: ref "core:prelude/string.wado//String";
-    let __local_4_4: ref "core:prelude/string.wado//String";
-    let __local_6: ref "core:prelude/string.wado//String";
     let handle_11: i32;
     let packed_20: i64;
     let rx_21: i32;
@@ -100,26 +93,20 @@ fn "ufcs_inherent_shadows_trait_method.wado/run"() with Stdout {
         "core:prelude/fpfmt.wado/__initialize_module"();
         global:ufcs_inherent_shadows_trait_method.wado::__modules_initialized = 1;
     };
-    __local_2 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(16), used: 0 };
-    "core:prelude/primitive.wado/i32::fmt_decimal$scalar$spec0$scalar"(1, __local_2);
     rx_21 = builtin::i32_wrap_i64(local.tee packed_20("wasi/stream-new"()));
     tx_22 = builtin::i32_wrap_i64(packed_20 >> 32_i64);
     handle_11 = "ufcs_inherent_shadows_trait_method.wado/__cm_binding__Stdout_write_via_stream"(rx_21);
-    "core:rt/write_string_to_stream"(tx_22, __local_2, 1);
+    "core:rt/write_string_to_stream"(tx_22, global:ufcs_inherent_shadows_trait_method.wado::__const_obj_3, 1);
     "wasi/future-drop-readable:transmission-cli"(handle_11);
-    __local_4_4 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(16), used: 0 };
-    "core:prelude/primitive.wado/i32::fmt_decimal$scalar$spec0$scalar"(100, __local_4_4);
     rx_40 = builtin::i32_wrap_i64(local.tee packed_39("wasi/stream-new"()));
     tx_41 = builtin::i32_wrap_i64(packed_39 >> 32_i64);
     handle_30 = "ufcs_inherent_shadows_trait_method.wado/__cm_binding__Stdout_write_via_stream"(rx_40);
-    "core:rt/write_string_to_stream"(tx_41, __local_4_4, 1);
+    "core:rt/write_string_to_stream"(tx_41, global:ufcs_inherent_shadows_trait_method.wado::__const_obj_2, 1);
     "wasi/future-drop-readable:transmission-cli"(handle_30);
-    __local_6 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(16), used: 0 };
-    "core:prelude/primitive.wado/i32::fmt_decimal$scalar$spec0$scalar"(3, __local_6);
     rx_59 = builtin::i32_wrap_i64(local.tee packed_58("wasi/stream-new"()));
     tx_60 = builtin::i32_wrap_i64(packed_58 >> 32_i64);
     handle_49 = "ufcs_inherent_shadows_trait_method.wado/__cm_binding__Stdout_write_via_stream"(rx_59);
-    "core:rt/write_string_to_stream"(tx_60, __local_6, 1);
+    "core:rt/write_string_to_stream"(tx_60, global:ufcs_inherent_shadows_trait_method.wado::__const_obj_1, 1);
     "wasi/future-drop-readable:transmission-cli"(handle_49);
 }
 
@@ -157,23 +144,6 @@ fn "core:rt/write_string_to_stream"(tx, message, add_newline) {
 fn "core:prelude/fpfmt.wado/__initialize_module"() {
 }
 
-fn "core:prelude/string.wado/core:prelude/string.wado/String::grow"(self, min_capacity) {
-    let capacity: i32;
-    let new_capacity: i32;
-    let new_repr: ref Array<u8>;
-    let a_7: i32;
-    let a_9: i32;
-    capacity = builtin::array_len(self.repr);
-    if min_capacity <= capacity {
-        return;
-    }
-    a_9 = capacity * 2;
-    a_7 = select i32(a_9 > min_capacity, a_9, min_capacity);
-    new_repr = builtin::array_new<u8>(local.tee new_capacity(select i32(a_7 > 8, a_7, 8)));
-    builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
-    self.repr = new_repr;
-}
-
 fn "core:prelude/types.wado/core:prelude/types.wado/StreamWritable<u8>::write_raw_all"(self, data) {
     let repr_2: ref Array<u8>;
     let end_3: i32;
@@ -201,14 +171,14 @@ fn "core:prelude/types.wado/core:prelude/types.wado/StreamWritable<u8>::write_ra
     end_3 = _av_50 + (_av_51 - _av_50);
     offset = data.start;
     block {
-        l4: loop {
+        l3: loop {
             __sroa_data_start = offset;
-            ptr_14 = builtin::i32_wrap_i64(local.tee packed_13(len_23 = end_3 - __sroa_data_start; ptr_24 = "mem/realloc"(0, 0, 1, len_23); i = 0; b5: block {
-                l6: loop {
-                    break_if b5 i >= len_23;
+            ptr_14 = builtin::i32_wrap_i64(local.tee packed_13(len_23 = end_3 - __sroa_data_start; ptr_24 = "mem/realloc"(0, 0, 1, len_23); i = 0; b4: block {
+                l5: loop {
+                    break_if b4 i >= len_23;
                     builtin::store_u8(ptr_24 + i, builtin::array_get_value_u8(repr_2, __sroa_data_start + i));
                     i = i + 1;
-                    continue l6;
+                    continue l5;
                 };
             }; builtin::i64_extend_i32_s(ptr_24) | (builtin::i64_extend_i32_s(len_23) << 32_i64)));
             raw_len = builtin::i32_wrap_i64(packed_13 >> 32_i64);
@@ -240,79 +210,9 @@ fn "core:prelude/types.wado/core:prelude/types.wado/StreamWritable<u8>::write_ra
             if select i32(select i32(written_16.result != 0, 1, written_16.count <= 0), 1, offset >= end_3) {
                 return written_16.result;
             }
-            continue l4;
+            continue l3;
         };
     };
-}
-
-fn "core:prelude/primitive.wado/i32::fmt_decimal$scalar$spec0$scalar"(self, f) {
-    let is_negative: bool;
-    let abs_val: u64;
-    let digit_count_4: i32;
-    let offset_5: i32;
-    let val_6: i64;
-    let n: i32;
-    let t_9: u64;
-    let arr: ref Array<u8>;
-    let pos: i32;
-    let t_15: u64;
-    let i: i32;
-    is_negative = self < 0;
-    val_6 = builtin::i64_extend_i32_s(self);
-    abs_val = select i64(val_6 < 0_i64, 0_i64 - val_6, val_6);
-    digit_count_4 = __inline_count_digits_u64_1: block -> i32 {
-        if abs_val == 0_i64 {
-            break __inline_count_digits_u64_1: 1;
-        }
-        n = 0;
-        t_9 = abs_val;
-        b12: block {
-            l13: loop {
-                break_if b12 t_9 <=u 0_i64;
-                n = n + 1;
-                t_9 = t_9 /u 10_i64;
-                continue l13;
-            };
-        };
-        break __inline_count_digits_u64_1: n;
-    };
-    offset_5 = "core:prelude/format.wado/core:prelude/format.wado/Formatter::prepare_int_write$spec0$scalar"(f, is_negative, global:core:prelude/primitive.wado::__const_obj_3, digit_count_4);
-    arr = f.repr;
-    pos = offset_5 + digit_count_4;
-    t_15 = abs_val;
-    i = 0;
-    b14: block {
-        l15: loop {
-            break_if b14 i >= digit_count_4;
-            pos = pos - 1;
-            builtin::array_set_u8(arr, pos, (48 + builtin::i32_wrap_i64(t_15 %u 10_i64)) & 255);
-            t_15 = t_15 /u 10_i64;
-            i = i + 1;
-            continue l15;
-        };
-    };
-}
-
-fn "core:prelude/format.wado/core:prelude/format.wado/Formatter::prepare_int_write$spec0$scalar"(self, is_negative, alt_prefix, digit_count) {
-    let new_used_21: i32;
-    let start_22: i32;
-    let new_used_56: i32;
-    let start_57: i32;
-    if is_negative {
-        new_used_21 = self.used + 1;
-        if @unlikely(new_used_21 > builtin::array_len(self.repr)) {
-            cold_path;
-            "core:prelude/string.wado/core:prelude/string.wado/String::grow"(self, new_used_21);
-        }
-        start_22 = self.used;
-        self.used = new_used_21;
-        builtin::array_set_u8(self.repr, start_22, 45);
-    } else {
-    }
-    return new_used_56 = self.used + digit_count, if @unlikely(new_used_56 > builtin::array_len(self.repr)) {
-        cold_path;
-        "core:prelude/string.wado/core:prelude/string.wado/String::grow"(self, new_used_56);
-    }, start_57 = self.used, self.used = new_used_56, start_57;
 }
 
 export fn "ufcs_inherent_shadows_trait_method.wado/__cm_export__run" as "run"

--- a/wado-compiler/tests/generated/fixtures/ufcs_inherent_shadows_trait_static.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/ufcs_inherent_shadows_trait_static.wir.wado
@@ -46,19 +46,13 @@ type "functype//core:rt/write_string_to_stream" = fn(i32, ref "core:prelude/stri
 
 type "functype//core:prelude/fpfmt.wado/__initialize_module" = fn();  // TypeId(16)
 
-type "functype//core:prelude/string.wado/core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(17)
+type "functype//core:prelude/types.wado/core:prelude/types.wado/StreamWritable<u8>::write_raw_all" = fn(i32, ref "core:prelude/slice.wado//Slice<u8>") -> "core:prelude/types.wado//enum:CopyResult";  // TypeId(17)
 
-type "functype//core:prelude/types.wado/core:prelude/types.wado/StreamWritable<u8>::write_raw_all" = fn(i32, ref "core:prelude/slice.wado//Slice<u8>") -> "core:prelude/types.wado//enum:CopyResult";  // TypeId(18)
+type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(18)
 
-type "functype//core:prelude/primitive.wado/i32::fmt_decimal$scalar$spec0$scalar" = fn(i32, ref "core:prelude/string.wado//String");  // TypeId(19)
+type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(19)
 
-type "functype//core:prelude/format.wado/core:prelude/format.wado/Formatter::prepare_int_write$spec0$scalar" = fn(ref "core:prelude/string.wado//String", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(20)
-
-type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(21)
-
-type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(22)
-
-type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(23)
+type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(20)
 
 import fn mem/realloc from "mem/realloc";
 import fn wasi/stream-write from "wasi/stream-write";
@@ -74,14 +68,12 @@ import fn wasi/future-drop-readable:transmission-cli from "wasi/future-drop-read
 import fn wasi/stream-drop-writable from "wasi/stream-drop-writable";
 
 global mut global:ufcs_inherent_shadows_trait_static.wado::__modules_initialized: bool = 0;
-global global:core:prelude/primitive.wado::__const_obj_3: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 };
 
 fn "ufcs_inherent_shadows_trait_static.wado/__cm_binding__Stdout_write_via_stream"(data) with Stdout {
     return "wasi/wasi:cli/Stdout::write_via_stream"(data);
 }
 
 fn "ufcs_inherent_shadows_trait_static.wado/__cm_export__run"() {
-    let __r: ref "core:prelude/string.wado//String";
     let handle: i32;
     let packed: i64;
     let rx_14: i32;
@@ -98,12 +90,10 @@ fn "ufcs_inherent_shadows_trait_static.wado/__cm_export__run"() {
         "core:prelude/fpfmt.wado/__initialize_module"();
         global:ufcs_inherent_shadows_trait_static.wado::__modules_initialized = 1;
     };
-    __r = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(16), used: 0 };
-    "core:prelude/primitive.wado/i32::fmt_decimal$scalar$spec0$scalar"(1, __r);
     rx_14 = builtin::i32_wrap_i64(local.tee packed("wasi/stream-new"()));
     tx_15 = builtin::i32_wrap_i64(packed >> 32_i64);
     handle = "ufcs_inherent_shadows_trait_static.wado/__cm_binding__Stdout_write_via_stream"(rx_14);
-    "core:rt/write_string_to_stream"(tx_15, __r, 1);
+    "core:rt/write_string_to_stream"(tx_15, struct.new "core:prelude/string.wado//String" { repr: array.new_fixed<u8>(49), used: 1 }, 1);
     "wasi/future-drop-readable:transmission-cli"(handle);
     "wasi/task-return"(0);
 }
@@ -125,23 +115,6 @@ fn "core:rt/write_string_to_stream"(tx, message, add_newline) {
 }
 
 fn "core:prelude/fpfmt.wado/__initialize_module"() {
-}
-
-fn "core:prelude/string.wado/core:prelude/string.wado/String::grow"(self, min_capacity) {
-    let capacity: i32;
-    let new_capacity: i32;
-    let new_repr: ref Array<u8>;
-    let a_7: i32;
-    let a_9: i32;
-    capacity = builtin::array_len(self.repr);
-    if min_capacity <= capacity {
-        return;
-    }
-    a_9 = capacity * 2;
-    a_7 = select i32(a_9 > min_capacity, a_9, min_capacity);
-    new_repr = builtin::array_new<u8>(local.tee new_capacity(select i32(a_7 > 8, a_7, 8)));
-    builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
-    self.repr = new_repr;
 }
 
 fn "core:prelude/types.wado/core:prelude/types.wado/StreamWritable<u8>::write_raw_all"(self, data) {
@@ -171,14 +144,14 @@ fn "core:prelude/types.wado/core:prelude/types.wado/StreamWritable<u8>::write_ra
     end_3 = _av_50 + (_av_51 - _av_50);
     offset = data.start;
     block {
-        l4: loop {
+        l3: loop {
             __sroa_data_start = offset;
-            ptr_14 = builtin::i32_wrap_i64(local.tee packed_13(len_23 = end_3 - __sroa_data_start; ptr_24 = "mem/realloc"(0, 0, 1, len_23); i = 0; b5: block {
-                l6: loop {
-                    break_if b5 i >= len_23;
+            ptr_14 = builtin::i32_wrap_i64(local.tee packed_13(len_23 = end_3 - __sroa_data_start; ptr_24 = "mem/realloc"(0, 0, 1, len_23); i = 0; b4: block {
+                l5: loop {
+                    break_if b4 i >= len_23;
                     builtin::store_u8(ptr_24 + i, builtin::array_get_value_u8(repr_2, __sroa_data_start + i));
                     i = i + 1;
-                    continue l6;
+                    continue l5;
                 };
             }; builtin::i64_extend_i32_s(ptr_24) | (builtin::i64_extend_i32_s(len_23) << 32_i64)));
             raw_len = builtin::i32_wrap_i64(packed_13 >> 32_i64);
@@ -210,79 +183,9 @@ fn "core:prelude/types.wado/core:prelude/types.wado/StreamWritable<u8>::write_ra
             if select i32(select i32(written_16.result != 0, 1, written_16.count <= 0), 1, offset >= end_3) {
                 return written_16.result;
             }
-            continue l4;
+            continue l3;
         };
     };
-}
-
-fn "core:prelude/primitive.wado/i32::fmt_decimal$scalar$spec0$scalar"(self, f) {
-    let is_negative: bool;
-    let abs_val: u64;
-    let digit_count_4: i32;
-    let offset_5: i32;
-    let val_6: i64;
-    let n: i32;
-    let t_9: u64;
-    let arr: ref Array<u8>;
-    let pos: i32;
-    let t_15: u64;
-    let i: i32;
-    is_negative = self < 0;
-    val_6 = builtin::i64_extend_i32_s(self);
-    abs_val = select i64(val_6 < 0_i64, 0_i64 - val_6, val_6);
-    digit_count_4 = __inline_count_digits_u64_1: block -> i32 {
-        if abs_val == 0_i64 {
-            break __inline_count_digits_u64_1: 1;
-        }
-        n = 0;
-        t_9 = abs_val;
-        b12: block {
-            l13: loop {
-                break_if b12 t_9 <=u 0_i64;
-                n = n + 1;
-                t_9 = t_9 /u 10_i64;
-                continue l13;
-            };
-        };
-        break __inline_count_digits_u64_1: n;
-    };
-    offset_5 = "core:prelude/format.wado/core:prelude/format.wado/Formatter::prepare_int_write$spec0$scalar"(f, is_negative, global:core:prelude/primitive.wado::__const_obj_3, digit_count_4);
-    arr = f.repr;
-    pos = offset_5 + digit_count_4;
-    t_15 = abs_val;
-    i = 0;
-    b14: block {
-        l15: loop {
-            break_if b14 i >= digit_count_4;
-            pos = pos - 1;
-            builtin::array_set_u8(arr, pos, (48 + builtin::i32_wrap_i64(t_15 %u 10_i64)) & 255);
-            t_15 = t_15 /u 10_i64;
-            i = i + 1;
-            continue l15;
-        };
-    };
-}
-
-fn "core:prelude/format.wado/core:prelude/format.wado/Formatter::prepare_int_write$spec0$scalar"(self, is_negative, alt_prefix, digit_count) {
-    let new_used_21: i32;
-    let start_22: i32;
-    let new_used_56: i32;
-    let start_57: i32;
-    if is_negative {
-        new_used_21 = self.used + 1;
-        if @unlikely(new_used_21 > builtin::array_len(self.repr)) {
-            cold_path;
-            "core:prelude/string.wado/core:prelude/string.wado/String::grow"(self, new_used_21);
-        }
-        start_22 = self.used;
-        self.used = new_used_21;
-        builtin::array_set_u8(self.repr, start_22, 45);
-    } else {
-    }
-    return new_used_56 = self.used + digit_count, if @unlikely(new_used_56 > builtin::array_len(self.repr)) {
-        cold_path;
-        "core:prelude/string.wado/core:prelude/string.wado/String::grow"(self, new_used_56);
-    }, start_57 = self.used, self.used = new_used_56, start_57;
 }
 
 export fn "ufcs_inherent_shadows_trait_static.wado/__cm_export__run" as "run"

--- a/wado-compiler/tests/generated/fixtures/ufcs_namespaced_instance_facts.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/ufcs_namespaced_instance_facts.wir.wado
@@ -16,60 +16,45 @@ struct core:prelude/string.wado//String {  // TypeId(3)
     mut used: i32,
 }
 
-array Array<i32> (mut i32);  // TypeId(4)
-
-struct core:prelude/slice.wado//Slice<u8> {  // TypeId(5)
+struct core:prelude/slice.wado//Slice<u8> {  // TypeId(4)
     mut repr: ref Array<u8>,
     mut start: i32,
     mut end: i32,
 }
 
-struct core:prelude//List<i32> {  // TypeId(6)
-    mut repr: ref Array<i32>,
-    mut used: i32,
-}
+type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(5)
 
-type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(7)
+type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(6)
 
-type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(8)
+type "functype//wasi/task-return" = fn(i32);  // TypeId(7)
 
-type "functype//wasi/task-return" = fn(i32);  // TypeId(9)
+type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(8)
 
-type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(10)
+type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(9)
 
-type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(11)
+type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(10)
 
-type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(12)
+type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(11)
 
-type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(13)
+type "functype//wasi/wasi:cli/Stdout::write_via_stream" = fn(i32) -> i32;  // TypeId(12)
 
-type "functype//wasi/wasi:cli/Stdout::write_via_stream" = fn(i32) -> i32;  // TypeId(14)
+type "functype//ufcs_namespaced_instance_facts.wado/run" = fn();  // TypeId(13)
 
-type "functype//ufcs_namespaced_instance_facts.wado/run" = fn();  // TypeId(15)
+type "functype//ufcs_namespaced_instance_facts.wado/__cm_binding__Stdout_write_via_stream" = fn(i32) -> i32;  // TypeId(14)
 
-type "functype//ufcs_namespaced_instance_facts.wado/__cm_binding__Stdout_write_via_stream" = fn(i32) -> i32;  // TypeId(16)
+type "functype//ufcs_namespaced_instance_facts.wado/__cm_export__run" = fn();  // TypeId(15)
 
-type "functype//ufcs_namespaced_instance_facts.wado/__cm_export__run" = fn();  // TypeId(17)
+type "functype//core:rt/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(16)
 
-type "functype//core:rt/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(18)
+type "functype//core:prelude/fpfmt.wado/__initialize_module" = fn();  // TypeId(17)
 
-type "functype//core:prelude/fpfmt.wado/__initialize_module" = fn();  // TypeId(19)
+type "functype//core:prelude/types.wado/core:prelude/types.wado/StreamWritable<u8>::write_raw_all" = fn(i32, ref "core:prelude/slice.wado//Slice<u8>") -> "core:prelude/types.wado//enum:CopyResult";  // TypeId(18)
 
-type "functype//core:prelude/string.wado/core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(20)
+type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(19)
 
-type "functype//core:prelude/types.wado/core:prelude/types.wado/StreamWritable<u8>::write_raw_all" = fn(i32, ref "core:prelude/slice.wado//Slice<u8>") -> "core:prelude/types.wado//enum:CopyResult";  // TypeId(21)
+type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(20)
 
-type "functype//core:prelude/list.wado/core:prelude/list.wado/List<i32>::grow" = fn(ref "core:prelude//List<i32>");  // TypeId(22)
-
-type "functype//core:prelude/primitive.wado/i32::fmt_decimal$scalar$spec0$scalar" = fn(i32, ref "core:prelude/string.wado//String");  // TypeId(23)
-
-type "functype//core:prelude/format.wado/core:prelude/format.wado/Formatter::prepare_int_write$spec0$scalar" = fn(ref "core:prelude/string.wado//String", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(24)
-
-type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(25)
-
-type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(26)
-
-type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(27)
+type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(21)
 
 import fn mem/realloc from "mem/realloc";
 import fn wasi/stream-write from "wasi/stream-write";
@@ -85,13 +70,12 @@ import fn wasi/future-drop-readable:transmission-cli from "wasi/future-drop-read
 import fn wasi/stream-drop-writable from "wasi/stream-drop-writable";
 
 global mut global:ufcs_namespaced_instance_facts.wado::__modules_initialized: bool = 0;
-global global:core:prelude/primitive.wado::__const_obj_3: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 };
+global global:ufcs_namespaced_instance_facts.wado::__const_obj_1: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: array.new_fixed<u8>(49), used: 1 };
+global global:ufcs_namespaced_instance_facts.wado::__const_obj_2: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: array.new_fixed<u8>(50), used: 1 };
+global global:ufcs_namespaced_instance_facts.wado::__const_obj_3: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: array.new_fixed<u8>(49, 51), used: 2 };
+global global:ufcs_namespaced_instance_facts.wado::__const_obj_4: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: array.new_fixed<u8>(49, 54), used: 2 };
 
 fn "ufcs_namespaced_instance_facts.wado/run"() with Stdout {
-    let __local_2: ref "core:prelude/string.wado//String";
-    let __local_4_4: ref "core:prelude/string.wado//String";
-    let __local_6: ref "core:prelude/string.wado//String";
-    let __local_8: ref "core:prelude/string.wado//String";
     let handle_13: i32;
     let packed_24: i64;
     let rx_25: i32;
@@ -100,9 +84,7 @@ fn "ufcs_namespaced_instance_facts.wado/run"() with Stdout {
     let packed_45: i64;
     let rx_46: i32;
     let tx_47: i32;
-    let elements: ref Array<i32>;
     let handle_56: i32;
-    let items_64: ref "core:prelude//List<i32>";
     let packed_67: i64;
     let rx_68: i32;
     let tx_69: i32;
@@ -116,41 +98,25 @@ fn "ufcs_namespaced_instance_facts.wado/run"() with Stdout {
         "core:prelude/fpfmt.wado/__initialize_module"();
         global:ufcs_namespaced_instance_facts.wado::__modules_initialized = 1;
     };
-    __local_2 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(16), used: 0 };
-    "core:prelude/primitive.wado/i32::fmt_decimal$scalar$spec0$scalar"(16, __local_2);
     rx_25 = builtin::i32_wrap_i64(local.tee packed_24("wasi/stream-new"()));
     tx_26 = builtin::i32_wrap_i64(packed_24 >> 32_i64);
     handle_13 = "ufcs_namespaced_instance_facts.wado/__cm_binding__Stdout_write_via_stream"(rx_25);
-    "core:rt/write_string_to_stream"(tx_26, __local_2, 1);
+    "core:rt/write_string_to_stream"(tx_26, global:ufcs_namespaced_instance_facts.wado::__const_obj_4, 1);
     "wasi/future-drop-readable:transmission-cli"(handle_13);
-    __local_4_4 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(16), used: 0 };
-    "core:prelude/primitive.wado/i32::fmt_decimal$scalar$spec0$scalar"(13, __local_4_4);
     rx_46 = builtin::i32_wrap_i64(local.tee packed_45("wasi/stream-new"()));
     tx_47 = builtin::i32_wrap_i64(packed_45 >> 32_i64);
     handle_34 = "ufcs_namespaced_instance_facts.wado/__cm_binding__Stdout_write_via_stream"(rx_46);
-    "core:rt/write_string_to_stream"(tx_47, __local_4_4, 1);
+    "core:rt/write_string_to_stream"(tx_47, global:ufcs_namespaced_instance_facts.wado::__const_obj_3, 1);
     "wasi/future-drop-readable:transmission-cli"(handle_34);
-    elements = array.new_fixed<i32>(7);
-    __local_6 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(16), used: 0 };
-    items_64 = struct.new "core:prelude//List<i32>" { repr: ref.as_non_null(let __array_clone_dst_2: ref Array<i32>; __array_clone_dst_2 = builtin::array_new<i32>(1); builtin::array_copy<i32>(__array_clone_dst_2, 0, elements, 0, 1); __array_clone_dst_2), used: 1 };
-    if @unlikely(1 >= builtin::array_len(items_64.repr)) {
-        cold_path;
-        "core:prelude/list.wado/core:prelude/list.wado/List<i32>::grow"(items_64);
-    }
-    builtin::array_set<i32>(items_64.repr, 1, 1);
-    items_64.used = 2;
-    "core:prelude/primitive.wado/i32::fmt_decimal$scalar$spec0$scalar"(items_64.used, __local_6);
     rx_68 = builtin::i32_wrap_i64(local.tee packed_67("wasi/stream-new"()));
     tx_69 = builtin::i32_wrap_i64(packed_67 >> 32_i64);
     handle_56 = "ufcs_namespaced_instance_facts.wado/__cm_binding__Stdout_write_via_stream"(rx_68);
-    "core:rt/write_string_to_stream"(tx_69, __local_6, 1);
+    "core:rt/write_string_to_stream"(tx_69, global:ufcs_namespaced_instance_facts.wado::__const_obj_2, 1);
     "wasi/future-drop-readable:transmission-cli"(handle_56);
-    __local_8 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(16), used: 0 };
-    "core:prelude/primitive.wado/i32::fmt_decimal$scalar$spec0$scalar"(1, __local_8);
     rx_87 = builtin::i32_wrap_i64(local.tee packed_86("wasi/stream-new"()));
     tx_88 = builtin::i32_wrap_i64(packed_86 >> 32_i64);
     handle_77 = "ufcs_namespaced_instance_facts.wado/__cm_binding__Stdout_write_via_stream"(rx_87);
-    "core:rt/write_string_to_stream"(tx_88, __local_8, 1);
+    "core:rt/write_string_to_stream"(tx_88, global:ufcs_namespaced_instance_facts.wado::__const_obj_1, 1);
     "wasi/future-drop-readable:transmission-cli"(handle_77);
 }
 
@@ -188,23 +154,6 @@ fn "core:rt/write_string_to_stream"(tx, message, add_newline) {
 fn "core:prelude/fpfmt.wado/__initialize_module"() {
 }
 
-fn "core:prelude/string.wado/core:prelude/string.wado/String::grow"(self, min_capacity) {
-    let capacity: i32;
-    let new_capacity: i32;
-    let new_repr: ref Array<u8>;
-    let a_7: i32;
-    let a_9: i32;
-    capacity = builtin::array_len(self.repr);
-    if min_capacity <= capacity {
-        return;
-    }
-    a_9 = capacity * 2;
-    a_7 = select i32(a_9 > min_capacity, a_9, min_capacity);
-    new_repr = builtin::array_new<u8>(local.tee new_capacity(select i32(a_7 > 8, a_7, 8)));
-    builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
-    self.repr = new_repr;
-}
-
 fn "core:prelude/types.wado/core:prelude/types.wado/StreamWritable<u8>::write_raw_all"(self, data) {
     let repr_2: ref Array<u8>;
     let end_3: i32;
@@ -232,14 +181,14 @@ fn "core:prelude/types.wado/core:prelude/types.wado/StreamWritable<u8>::write_ra
     end_3 = _av_50 + (_av_51 - _av_50);
     offset = data.start;
     block {
-        l5: loop {
+        l3: loop {
             __sroa_data_start = offset;
-            ptr_14 = builtin::i32_wrap_i64(local.tee packed_13(len_23 = end_3 - __sroa_data_start; ptr_24 = "mem/realloc"(0, 0, 1, len_23); i = 0; b6: block {
-                l7: loop {
-                    break_if b6 i >= len_23;
+            ptr_14 = builtin::i32_wrap_i64(local.tee packed_13(len_23 = end_3 - __sroa_data_start; ptr_24 = "mem/realloc"(0, 0, 1, len_23); i = 0; b4: block {
+                l5: loop {
+                    break_if b4 i >= len_23;
                     builtin::store_u8(ptr_24 + i, builtin::array_get_value_u8(repr_2, __sroa_data_start + i));
                     i = i + 1;
-                    continue l7;
+                    continue l5;
                 };
             }; builtin::i64_extend_i32_s(ptr_24) | (builtin::i64_extend_i32_s(len_23) << 32_i64)));
             raw_len = builtin::i32_wrap_i64(packed_13 >> 32_i64);
@@ -271,90 +220,9 @@ fn "core:prelude/types.wado/core:prelude/types.wado/StreamWritable<u8>::write_ra
             if select i32(select i32(written_16.result != 0, 1, written_16.count <= 0), 1, offset >= end_3) {
                 return written_16.result;
             }
-            continue l5;
+            continue l3;
         };
     };
-}
-
-fn "core:prelude/list.wado/core:prelude/list.wado/List<i32>::grow"(self) {
-    let capacity: i32;
-    let new_capacity: i32;
-    let new_repr: ref Array<i32>;
-    let a: i32;
-    a = local.tee capacity(builtin::array_len(self.repr)) * 2;
-    new_repr = builtin::array_new<i32>(local.tee new_capacity(select i32(a > 4, a, 4)));
-    builtin::array_copy<i32>(new_repr, 0, self.repr, 0, self.used);
-    self.repr = new_repr;
-}
-
-fn "core:prelude/primitive.wado/i32::fmt_decimal$scalar$spec0$scalar"(self, f) {
-    let is_negative: bool;
-    let abs_val: u64;
-    let digit_count_4: i32;
-    let offset_5: i32;
-    let val_6: i64;
-    let n: i32;
-    let t_9: u64;
-    let arr: ref Array<u8>;
-    let pos: i32;
-    let t_15: u64;
-    let i: i32;
-    is_negative = self < 0;
-    val_6 = builtin::i64_extend_i32_s(self);
-    abs_val = select i64(val_6 < 0_i64, 0_i64 - val_6, val_6);
-    digit_count_4 = __inline_count_digits_u64_1: block -> i32 {
-        if abs_val == 0_i64 {
-            break __inline_count_digits_u64_1: 1;
-        }
-        n = 0;
-        t_9 = abs_val;
-        b13: block {
-            l14: loop {
-                break_if b13 t_9 <=u 0_i64;
-                n = n + 1;
-                t_9 = t_9 /u 10_i64;
-                continue l14;
-            };
-        };
-        break __inline_count_digits_u64_1: n;
-    };
-    offset_5 = "core:prelude/format.wado/core:prelude/format.wado/Formatter::prepare_int_write$spec0$scalar"(f, is_negative, global:core:prelude/primitive.wado::__const_obj_3, digit_count_4);
-    arr = f.repr;
-    pos = offset_5 + digit_count_4;
-    t_15 = abs_val;
-    i = 0;
-    b15: block {
-        l16: loop {
-            break_if b15 i >= digit_count_4;
-            pos = pos - 1;
-            builtin::array_set_u8(arr, pos, (48 + builtin::i32_wrap_i64(t_15 %u 10_i64)) & 255);
-            t_15 = t_15 /u 10_i64;
-            i = i + 1;
-            continue l16;
-        };
-    };
-}
-
-fn "core:prelude/format.wado/core:prelude/format.wado/Formatter::prepare_int_write$spec0$scalar"(self, is_negative, alt_prefix, digit_count) {
-    let new_used_21: i32;
-    let start_22: i32;
-    let new_used_56: i32;
-    let start_57: i32;
-    if is_negative {
-        new_used_21 = self.used + 1;
-        if @unlikely(new_used_21 > builtin::array_len(self.repr)) {
-            cold_path;
-            "core:prelude/string.wado/core:prelude/string.wado/String::grow"(self, new_used_21);
-        }
-        start_22 = self.used;
-        self.used = new_used_21;
-        builtin::array_set_u8(self.repr, start_22, 45);
-    } else {
-    }
-    return new_used_56 = self.used + digit_count, if @unlikely(new_used_56 > builtin::array_len(self.repr)) {
-        cold_path;
-        "core:prelude/string.wado/core:prelude/string.wado/String::grow"(self, new_used_56);
-    }, start_57 = self.used, self.used = new_used_56, start_57;
 }
 
 export fn "ufcs_namespaced_instance_facts.wado/__cm_export__run" as "run"

--- a/wado-compiler/tests/generated/fixtures/ufcs_newtype_instance_method.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/ufcs_newtype_instance_method.wir.wado
@@ -48,19 +48,13 @@ type "functype//core:rt/write_string_to_stream" = fn(i32, ref "core:prelude/stri
 
 type "functype//core:prelude/fpfmt.wado/__initialize_module" = fn();  // TypeId(17)
 
-type "functype//core:prelude/string.wado/core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(18)
+type "functype//core:prelude/types.wado/core:prelude/types.wado/StreamWritable<u8>::write_raw_all" = fn(i32, ref "core:prelude/slice.wado//Slice<u8>") -> "core:prelude/types.wado//enum:CopyResult";  // TypeId(18)
 
-type "functype//core:prelude/types.wado/core:prelude/types.wado/StreamWritable<u8>::write_raw_all" = fn(i32, ref "core:prelude/slice.wado//Slice<u8>") -> "core:prelude/types.wado//enum:CopyResult";  // TypeId(19)
+type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(19)
 
-type "functype//core:prelude/primitive.wado/i32::fmt_decimal$scalar$spec0$scalar" = fn(i32, ref "core:prelude/string.wado//String");  // TypeId(20)
+type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(20)
 
-type "functype//core:prelude/format.wado/core:prelude/format.wado/Formatter::prepare_int_write$spec0$scalar" = fn(ref "core:prelude/string.wado//String", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(21)
-
-type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(22)
-
-type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(23)
-
-type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(24)
+type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(21)
 
 import fn mem/realloc from "mem/realloc";
 import fn wasi/stream-write from "wasi/stream-write";
@@ -76,11 +70,10 @@ import fn wasi/future-drop-readable:transmission-cli from "wasi/future-drop-read
 import fn wasi/stream-drop-writable from "wasi/stream-drop-writable";
 
 global mut global:ufcs_newtype_instance_method.wado::__modules_initialized: bool = 0;
-global global:core:prelude/primitive.wado::__const_obj_3: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 };
+global global:ufcs_newtype_instance_method.wado::__const_obj_1: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: array.new_fixed<u8>(53), used: 1 };
+global global:ufcs_newtype_instance_method.wado::__const_obj_2: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: array.new_fixed<u8>(55), used: 1 };
 
 fn "ufcs_newtype_instance_method.wado/run"() with Stdout {
-    let __local_2: ref "core:prelude/string.wado//String";
-    let __local_4_4: ref "core:prelude/string.wado//String";
     let handle_9: i32;
     let packed_18: i64;
     let rx_19: i32;
@@ -95,19 +88,15 @@ fn "ufcs_newtype_instance_method.wado/run"() with Stdout {
         "core:prelude/fpfmt.wado/__initialize_module"();
         global:ufcs_newtype_instance_method.wado::__modules_initialized = 1;
     };
-    __local_2 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(16), used: 0 };
-    "core:prelude/primitive.wado/i32::fmt_decimal$scalar$spec0$scalar"(7, __local_2);
     rx_19 = builtin::i32_wrap_i64(local.tee packed_18("wasi/stream-new"()));
     tx_20 = builtin::i32_wrap_i64(packed_18 >> 32_i64);
     handle_9 = "ufcs_newtype_instance_method.wado/__cm_binding__Stdout_write_via_stream"(rx_19);
-    "core:rt/write_string_to_stream"(tx_20, __local_2, 1);
+    "core:rt/write_string_to_stream"(tx_20, global:ufcs_newtype_instance_method.wado::__const_obj_2, 1);
     "wasi/future-drop-readable:transmission-cli"(handle_9);
-    __local_4_4 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(16), used: 0 };
-    "core:prelude/primitive.wado/i32::fmt_decimal$scalar$spec0$scalar"(5, __local_4_4);
     rx_38 = builtin::i32_wrap_i64(local.tee packed_37("wasi/stream-new"()));
     tx_39 = builtin::i32_wrap_i64(packed_37 >> 32_i64);
     handle_28 = "ufcs_newtype_instance_method.wado/__cm_binding__Stdout_write_via_stream"(rx_38);
-    "core:rt/write_string_to_stream"(tx_39, __local_4_4, 1);
+    "core:rt/write_string_to_stream"(tx_39, global:ufcs_newtype_instance_method.wado::__const_obj_1, 1);
     "wasi/future-drop-readable:transmission-cli"(handle_28);
 }
 
@@ -145,23 +134,6 @@ fn "core:rt/write_string_to_stream"(tx, message, add_newline) {
 fn "core:prelude/fpfmt.wado/__initialize_module"() {
 }
 
-fn "core:prelude/string.wado/core:prelude/string.wado/String::grow"(self, min_capacity) {
-    let capacity: i32;
-    let new_capacity: i32;
-    let new_repr: ref Array<u8>;
-    let a_7: i32;
-    let a_9: i32;
-    capacity = builtin::array_len(self.repr);
-    if min_capacity <= capacity {
-        return;
-    }
-    a_9 = capacity * 2;
-    a_7 = select i32(a_9 > min_capacity, a_9, min_capacity);
-    new_repr = builtin::array_new<u8>(local.tee new_capacity(select i32(a_7 > 8, a_7, 8)));
-    builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
-    self.repr = new_repr;
-}
-
 fn "core:prelude/types.wado/core:prelude/types.wado/StreamWritable<u8>::write_raw_all"(self, data) {
     let repr_2: ref Array<u8>;
     let end_3: i32;
@@ -189,14 +161,14 @@ fn "core:prelude/types.wado/core:prelude/types.wado/StreamWritable<u8>::write_ra
     end_3 = _av_50 + (_av_51 - _av_50);
     offset = data.start;
     block {
-        l4: loop {
+        l3: loop {
             __sroa_data_start = offset;
-            ptr_14 = builtin::i32_wrap_i64(local.tee packed_13(len_23 = end_3 - __sroa_data_start; ptr_24 = "mem/realloc"(0, 0, 1, len_23); i = 0; b5: block {
-                l6: loop {
-                    break_if b5 i >= len_23;
+            ptr_14 = builtin::i32_wrap_i64(local.tee packed_13(len_23 = end_3 - __sroa_data_start; ptr_24 = "mem/realloc"(0, 0, 1, len_23); i = 0; b4: block {
+                l5: loop {
+                    break_if b4 i >= len_23;
                     builtin::store_u8(ptr_24 + i, builtin::array_get_value_u8(repr_2, __sroa_data_start + i));
                     i = i + 1;
-                    continue l6;
+                    continue l5;
                 };
             }; builtin::i64_extend_i32_s(ptr_24) | (builtin::i64_extend_i32_s(len_23) << 32_i64)));
             raw_len = builtin::i32_wrap_i64(packed_13 >> 32_i64);
@@ -228,79 +200,9 @@ fn "core:prelude/types.wado/core:prelude/types.wado/StreamWritable<u8>::write_ra
             if select i32(select i32(written_16.result != 0, 1, written_16.count <= 0), 1, offset >= end_3) {
                 return written_16.result;
             }
-            continue l4;
+            continue l3;
         };
     };
-}
-
-fn "core:prelude/primitive.wado/i32::fmt_decimal$scalar$spec0$scalar"(self, f) {
-    let is_negative: bool;
-    let abs_val: u64;
-    let digit_count_4: i32;
-    let offset_5: i32;
-    let val_6: i64;
-    let n: i32;
-    let t_9: u64;
-    let arr: ref Array<u8>;
-    let pos: i32;
-    let t_15: u64;
-    let i: i32;
-    is_negative = self < 0;
-    val_6 = builtin::i64_extend_i32_s(self);
-    abs_val = select i64(val_6 < 0_i64, 0_i64 - val_6, val_6);
-    digit_count_4 = __inline_count_digits_u64_1: block -> i32 {
-        if abs_val == 0_i64 {
-            break __inline_count_digits_u64_1: 1;
-        }
-        n = 0;
-        t_9 = abs_val;
-        b12: block {
-            l13: loop {
-                break_if b12 t_9 <=u 0_i64;
-                n = n + 1;
-                t_9 = t_9 /u 10_i64;
-                continue l13;
-            };
-        };
-        break __inline_count_digits_u64_1: n;
-    };
-    offset_5 = "core:prelude/format.wado/core:prelude/format.wado/Formatter::prepare_int_write$spec0$scalar"(f, is_negative, global:core:prelude/primitive.wado::__const_obj_3, digit_count_4);
-    arr = f.repr;
-    pos = offset_5 + digit_count_4;
-    t_15 = abs_val;
-    i = 0;
-    b14: block {
-        l15: loop {
-            break_if b14 i >= digit_count_4;
-            pos = pos - 1;
-            builtin::array_set_u8(arr, pos, (48 + builtin::i32_wrap_i64(t_15 %u 10_i64)) & 255);
-            t_15 = t_15 /u 10_i64;
-            i = i + 1;
-            continue l15;
-        };
-    };
-}
-
-fn "core:prelude/format.wado/core:prelude/format.wado/Formatter::prepare_int_write$spec0$scalar"(self, is_negative, alt_prefix, digit_count) {
-    let new_used_21: i32;
-    let start_22: i32;
-    let new_used_56: i32;
-    let start_57: i32;
-    if is_negative {
-        new_used_21 = self.used + 1;
-        if @unlikely(new_used_21 > builtin::array_len(self.repr)) {
-            cold_path;
-            "core:prelude/string.wado/core:prelude/string.wado/String::grow"(self, new_used_21);
-        }
-        start_22 = self.used;
-        self.used = new_used_21;
-        builtin::array_set_u8(self.repr, start_22, 45);
-    } else {
-    }
-    return new_used_56 = self.used + digit_count, if @unlikely(new_used_56 > builtin::array_len(self.repr)) {
-        cold_path;
-        "core:prelude/string.wado/core:prelude/string.wado/String::grow"(self, new_used_56);
-    }, start_57 = self.used, self.used = new_used_56, start_57;
 }
 
 export fn "ufcs_newtype_instance_method.wado/__cm_export__run" as "run"

--- a/wado-compiler/tests/generated/fixtures/ufcs_shadowing_is_per_kind.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/ufcs_shadowing_is_per_kind.wir.wado
@@ -48,19 +48,13 @@ type "functype//core:rt/write_string_to_stream" = fn(i32, ref "core:prelude/stri
 
 type "functype//core:prelude/fpfmt.wado/__initialize_module" = fn();  // TypeId(17)
 
-type "functype//core:prelude/string.wado/core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(18)
+type "functype//core:prelude/types.wado/core:prelude/types.wado/StreamWritable<u8>::write_raw_all" = fn(i32, ref "core:prelude/slice.wado//Slice<u8>") -> "core:prelude/types.wado//enum:CopyResult";  // TypeId(18)
 
-type "functype//core:prelude/types.wado/core:prelude/types.wado/StreamWritable<u8>::write_raw_all" = fn(i32, ref "core:prelude/slice.wado//Slice<u8>") -> "core:prelude/types.wado//enum:CopyResult";  // TypeId(19)
+type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(19)
 
-type "functype//core:prelude/primitive.wado/i32::fmt_decimal$scalar$spec0$scalar" = fn(i32, ref "core:prelude/string.wado//String");  // TypeId(20)
+type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(20)
 
-type "functype//core:prelude/format.wado/core:prelude/format.wado/Formatter::prepare_int_write$spec0$scalar" = fn(ref "core:prelude/string.wado//String", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(21)
-
-type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(22)
-
-type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(23)
-
-type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(24)
+type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(21)
 
 import fn mem/realloc from "mem/realloc";
 import fn wasi/stream-write from "wasi/stream-write";
@@ -76,13 +70,12 @@ import fn wasi/future-drop-readable:transmission-cli from "wasi/future-drop-read
 import fn wasi/stream-drop-writable from "wasi/stream-drop-writable";
 
 global mut global:ufcs_shadowing_is_per_kind.wado::__modules_initialized: bool = 0;
-global global:core:prelude/primitive.wado::__const_obj_3: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 };
+global global:ufcs_shadowing_is_per_kind.wado::__const_obj_1: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: array.new_fixed<u8>(50, 48, 48), used: 3 };
+global global:ufcs_shadowing_is_per_kind.wado::__const_obj_2: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: array.new_fixed<u8>(51), used: 1 };
+global global:ufcs_shadowing_is_per_kind.wado::__const_obj_3: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: array.new_fixed<u8>(57), used: 1 };
+global global:ufcs_shadowing_is_per_kind.wado::__const_obj_4: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: array.new_fixed<u8>(49, 48, 48), used: 3 };
 
 fn "ufcs_shadowing_is_per_kind.wado/run"() with Stdout {
-    let __local_1: ref "core:prelude/string.wado//String";
-    let __local_3: ref "core:prelude/string.wado//String";
-    let __local_5: ref "core:prelude/string.wado//String";
-    let __local_7: ref "core:prelude/string.wado//String";
     let handle_12: i32;
     let packed_20: i64;
     let rx_21: i32;
@@ -105,33 +98,25 @@ fn "ufcs_shadowing_is_per_kind.wado/run"() with Stdout {
         "core:prelude/fpfmt.wado/__initialize_module"();
         global:ufcs_shadowing_is_per_kind.wado::__modules_initialized = 1;
     };
-    __local_1 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(16), used: 0 };
-    "core:prelude/primitive.wado/i32::fmt_decimal$scalar$spec0$scalar"(100, __local_1);
     rx_21 = builtin::i32_wrap_i64(local.tee packed_20("wasi/stream-new"()));
     tx_22 = builtin::i32_wrap_i64(packed_20 >> 32_i64);
     handle_12 = "ufcs_shadowing_is_per_kind.wado/__cm_binding__Stdout_write_via_stream"(rx_21);
-    "core:rt/write_string_to_stream"(tx_22, __local_1, 1);
+    "core:rt/write_string_to_stream"(tx_22, global:ufcs_shadowing_is_per_kind.wado::__const_obj_4, 1);
     "wasi/future-drop-readable:transmission-cli"(handle_12);
-    __local_3 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(16), used: 0 };
-    "core:prelude/primitive.wado/i32::fmt_decimal$scalar$spec0$scalar"(9, __local_3);
     rx_40 = builtin::i32_wrap_i64(local.tee packed_39("wasi/stream-new"()));
     tx_41 = builtin::i32_wrap_i64(packed_39 >> 32_i64);
     handle_30 = "ufcs_shadowing_is_per_kind.wado/__cm_binding__Stdout_write_via_stream"(rx_40);
-    "core:rt/write_string_to_stream"(tx_41, __local_3, 1);
+    "core:rt/write_string_to_stream"(tx_41, global:ufcs_shadowing_is_per_kind.wado::__const_obj_3, 1);
     "wasi/future-drop-readable:transmission-cli"(handle_30);
-    __local_5 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(16), used: 0 };
-    "core:prelude/primitive.wado/i32::fmt_decimal$scalar$spec0$scalar"(3, __local_5);
     rx_59 = builtin::i32_wrap_i64(local.tee packed_58("wasi/stream-new"()));
     tx_60 = builtin::i32_wrap_i64(packed_58 >> 32_i64);
     handle_49 = "ufcs_shadowing_is_per_kind.wado/__cm_binding__Stdout_write_via_stream"(rx_59);
-    "core:rt/write_string_to_stream"(tx_60, __local_5, 1);
+    "core:rt/write_string_to_stream"(tx_60, global:ufcs_shadowing_is_per_kind.wado::__const_obj_2, 1);
     "wasi/future-drop-readable:transmission-cli"(handle_49);
-    __local_7 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(16), used: 0 };
-    "core:prelude/primitive.wado/i32::fmt_decimal$scalar$spec0$scalar"(200, __local_7);
     rx_78 = builtin::i32_wrap_i64(local.tee packed_77("wasi/stream-new"()));
     tx_79 = builtin::i32_wrap_i64(packed_77 >> 32_i64);
     handle_68 = "ufcs_shadowing_is_per_kind.wado/__cm_binding__Stdout_write_via_stream"(rx_78);
-    "core:rt/write_string_to_stream"(tx_79, __local_7, 1);
+    "core:rt/write_string_to_stream"(tx_79, global:ufcs_shadowing_is_per_kind.wado::__const_obj_1, 1);
     "wasi/future-drop-readable:transmission-cli"(handle_68);
 }
 
@@ -169,23 +154,6 @@ fn "core:rt/write_string_to_stream"(tx, message, add_newline) {
 fn "core:prelude/fpfmt.wado/__initialize_module"() {
 }
 
-fn "core:prelude/string.wado/core:prelude/string.wado/String::grow"(self, min_capacity) {
-    let capacity: i32;
-    let new_capacity: i32;
-    let new_repr: ref Array<u8>;
-    let a_7: i32;
-    let a_9: i32;
-    capacity = builtin::array_len(self.repr);
-    if min_capacity <= capacity {
-        return;
-    }
-    a_9 = capacity * 2;
-    a_7 = select i32(a_9 > min_capacity, a_9, min_capacity);
-    new_repr = builtin::array_new<u8>(local.tee new_capacity(select i32(a_7 > 8, a_7, 8)));
-    builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
-    self.repr = new_repr;
-}
-
 fn "core:prelude/types.wado/core:prelude/types.wado/StreamWritable<u8>::write_raw_all"(self, data) {
     let repr_2: ref Array<u8>;
     let end_3: i32;
@@ -213,14 +181,14 @@ fn "core:prelude/types.wado/core:prelude/types.wado/StreamWritable<u8>::write_ra
     end_3 = _av_50 + (_av_51 - _av_50);
     offset = data.start;
     block {
-        l4: loop {
+        l3: loop {
             __sroa_data_start = offset;
-            ptr_14 = builtin::i32_wrap_i64(local.tee packed_13(len_23 = end_3 - __sroa_data_start; ptr_24 = "mem/realloc"(0, 0, 1, len_23); i = 0; b5: block {
-                l6: loop {
-                    break_if b5 i >= len_23;
+            ptr_14 = builtin::i32_wrap_i64(local.tee packed_13(len_23 = end_3 - __sroa_data_start; ptr_24 = "mem/realloc"(0, 0, 1, len_23); i = 0; b4: block {
+                l5: loop {
+                    break_if b4 i >= len_23;
                     builtin::store_u8(ptr_24 + i, builtin::array_get_value_u8(repr_2, __sroa_data_start + i));
                     i = i + 1;
-                    continue l6;
+                    continue l5;
                 };
             }; builtin::i64_extend_i32_s(ptr_24) | (builtin::i64_extend_i32_s(len_23) << 32_i64)));
             raw_len = builtin::i32_wrap_i64(packed_13 >> 32_i64);
@@ -252,79 +220,9 @@ fn "core:prelude/types.wado/core:prelude/types.wado/StreamWritable<u8>::write_ra
             if select i32(select i32(written_16.result != 0, 1, written_16.count <= 0), 1, offset >= end_3) {
                 return written_16.result;
             }
-            continue l4;
+            continue l3;
         };
     };
-}
-
-fn "core:prelude/primitive.wado/i32::fmt_decimal$scalar$spec0$scalar"(self, f) {
-    let is_negative: bool;
-    let abs_val: u64;
-    let digit_count_4: i32;
-    let offset_5: i32;
-    let val_6: i64;
-    let n: i32;
-    let t_9: u64;
-    let arr: ref Array<u8>;
-    let pos: i32;
-    let t_15: u64;
-    let i: i32;
-    is_negative = self < 0;
-    val_6 = builtin::i64_extend_i32_s(self);
-    abs_val = select i64(val_6 < 0_i64, 0_i64 - val_6, val_6);
-    digit_count_4 = __inline_count_digits_u64_1: block -> i32 {
-        if abs_val == 0_i64 {
-            break __inline_count_digits_u64_1: 1;
-        }
-        n = 0;
-        t_9 = abs_val;
-        b12: block {
-            l13: loop {
-                break_if b12 t_9 <=u 0_i64;
-                n = n + 1;
-                t_9 = t_9 /u 10_i64;
-                continue l13;
-            };
-        };
-        break __inline_count_digits_u64_1: n;
-    };
-    offset_5 = "core:prelude/format.wado/core:prelude/format.wado/Formatter::prepare_int_write$spec0$scalar"(f, is_negative, global:core:prelude/primitive.wado::__const_obj_3, digit_count_4);
-    arr = f.repr;
-    pos = offset_5 + digit_count_4;
-    t_15 = abs_val;
-    i = 0;
-    b14: block {
-        l15: loop {
-            break_if b14 i >= digit_count_4;
-            pos = pos - 1;
-            builtin::array_set_u8(arr, pos, (48 + builtin::i32_wrap_i64(t_15 %u 10_i64)) & 255);
-            t_15 = t_15 /u 10_i64;
-            i = i + 1;
-            continue l15;
-        };
-    };
-}
-
-fn "core:prelude/format.wado/core:prelude/format.wado/Formatter::prepare_int_write$spec0$scalar"(self, is_negative, alt_prefix, digit_count) {
-    let new_used_21: i32;
-    let start_22: i32;
-    let new_used_56: i32;
-    let start_57: i32;
-    if is_negative {
-        new_used_21 = self.used + 1;
-        if @unlikely(new_used_21 > builtin::array_len(self.repr)) {
-            cold_path;
-            "core:prelude/string.wado/core:prelude/string.wado/String::grow"(self, new_used_21);
-        }
-        start_22 = self.used;
-        self.used = new_used_21;
-        builtin::array_set_u8(self.repr, start_22, 45);
-    } else {
-    }
-    return new_used_56 = self.used + digit_count, if @unlikely(new_used_56 > builtin::array_len(self.repr)) {
-        cold_path;
-        "core:prelude/string.wado/core:prelude/string.wado/String::grow"(self, new_used_56);
-    }, start_57 = self.used, self.used = new_used_56, start_57;
 }
 
 export fn "ufcs_shadowing_is_per_kind.wado/__cm_export__run" as "run"

--- a/wado-compiler/tests/generated/fixtures/variant_inherent_method.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/variant_inherent_method.wir.wado
@@ -86,12 +86,12 @@ import fn wasi/future-drop-readable:transmission-cli from "wasi/future-drop-read
 import fn wasi/stream-drop-writable from "wasi/stream-drop-writable";
 
 global mut global:variant_inherent_method.wado::__modules_initialized: bool = 0;
-global global:core:prelude/primitive.wado::__const_obj_3: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 };
+global global:variant_inherent_method.wado::__const_obj_1: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: array.new_fixed<u8>(49), used: 1 };
+global global:core:prelude/primitive.wado::__const_obj_4: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 };
 
 fn "variant_inherent_method.wado/run"() with Stdout {
     let p: ref "variant_inherent_method.wado//Plain";
     let __local_2: ref "core:prelude/string.wado//String";
-    let __local_4_4: ref "core:prelude/string.wado//String";
     let handle_9: i32;
     let self_17: i32;
     let packed_19: i64;
@@ -117,12 +117,10 @@ fn "variant_inherent_method.wado/run"() with Stdout {
     handle_9 = "variant_inherent_method.wado/__cm_binding__Stdout_write_via_stream"(rx_20);
     "core:rt/write_string_to_stream"(tx_21, __local_2, 1);
     "wasi/future-drop-readable:transmission-cli"(handle_9);
-    __local_4_4 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(16), used: 0 };
-    "core:prelude/primitive.wado/i32::fmt_decimal$scalar$spec0$scalar"(1, __local_4_4);
     rx_40 = builtin::i32_wrap_i64(local.tee packed_39("wasi/stream-new"()));
     tx_41 = builtin::i32_wrap_i64(packed_39 >> 32_i64);
     handle_29 = "variant_inherent_method.wado/__cm_binding__Stdout_write_via_stream"(rx_40);
-    "core:rt/write_string_to_stream"(tx_41, __local_4_4, 1);
+    "core:rt/write_string_to_stream"(tx_41, global:variant_inherent_method.wado::__const_obj_1, 1);
     "wasi/future-drop-readable:transmission-cli"(handle_29);
 }
 
@@ -279,7 +277,7 @@ fn "core:prelude/primitive.wado/i32::fmt_decimal$scalar$spec0$scalar"(self, f) {
         };
         break __inline_count_digits_u64_1: n;
     };
-    offset_5 = "core:prelude/format.wado/core:prelude/format.wado/Formatter::prepare_int_write$spec0$scalar"(f, is_negative, global:core:prelude/primitive.wado::__const_obj_3, digit_count_4);
+    offset_5 = "core:prelude/format.wado/core:prelude/format.wado/Formatter::prepare_int_write$spec0$scalar"(f, is_negative, global:core:prelude/primitive.wado::__const_obj_4, digit_count_4);
     arr = f.repr;
     pos = offset_5 + digit_count_4;
     t_15 = abs_val;


### PR DESCRIPTION
Three hook-driven steps, and the skill rules they point at.

**Answering a review.** A `/code-review` run, typed or called as a skill, draws a reminder to answer its findings with the `code-review-response` skill. That skill states the altitude to answer at: a finding names one site, and the fix belongs where the class of defect is admitted — the missing invariant, the type that allows the state, the call site nobody has to remember. `AGENTS.md` and the skill's own description name a `/code-review` run alongside PR review comments.

**Distilling.** A `Stop` hook asks for a distill pass over the branch, once per session, when the worktree is clean and the branch carries commits against its merge base. A dirty worktree is the environment's commit-and-push hook's to demand, so the two Stop hooks run in sequence rather than both at once. Invoking `distill` records that it ran, under `.git/wado-hooks/`; `stop_hook_active` keeps the nudge from repeating.

**Watching a pull request.** `pull-request` says to subscribe with `subscribe_pr_activity`, to handle every event it delivers, and to answer a review with `code-review-response`.

**The command guard.** `perl`, `setsid` and `disown` are denied wherever the word resolves — nested in `bash -c`, behind `xargs`, `env` or `timeout` — which is the reach `permissions.deny` lacks, matching on a literal prefix.

`skill-invocation.mts` names the skill a hook payload invokes, covering both the `/name` prompt and the `Skill` tool call, so a hook compares a name instead of matching a pattern against one. `mise run test-hooks` covers each hook's decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQLDnS14EdK8qiSUyWqiRB