### PR TITLE
fix(kiln): harvest clauses from every module, one redirect per declaring site

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -176,3 +176,4 @@ omission goes in Decision.
 - [Trait Resolution — One Order, Written Down](./wep-2026-09-01-trait-resolution.md)
 - [JSON Web Tokens (`core:jwt`)](./wep-2026-09-02-core-jwt.md)
 - [Total Reflection — `TypeInfo` and `match type`](./wep-2026-09-05-total-reflection.md)
+- [Package File Exports — Assets and Submodules as API](./wep-2026-09-06-package-file-exports.md)

--- a/docs/wep-2026-02-14-package-manifest.md
+++ b/docs/wep-2026-02-14-package-manifest.md
@@ -70,6 +70,7 @@ an open coordinate `ns:pkg`, or a `lib:` nickname for indirection. Bare keys
 | `authors`              | `string[]` | No       | Contact details of the people or organization responsible                                     |
 | `wado-version`         | `string`   | No       | Minimum Wado compiler version required to build (e.g., `">=0.5"`)                             |
 | `publish`              | `bool`     | No       | `false` opts a namespaced package out of publishing. Default `true`                           |
+| `exports`              | `string[]` | No       | Files consumers may name: assets and submodules, package-root-relative, extension required    |
 
 `namespace` and `name` together form the registry identity (`namespace:name`, e.g., `myorg:my-app`). Without `namespace`, the package cannot be published to a registry — this is the natural state for closed-source applications and internal tools. A namespaced package can still opt out explicitly with `publish = false`.
 
@@ -82,6 +83,10 @@ Both `namespace` and `name` must match `[a-zA-Z0-9_-]+` (minimum 1 character, ma
 Dependency keys in `[dependencies]` are quoted specifiers — an open coordinate `"ns:pkg"` or a `"lib:nick"` nickname — each segment matching the same `[a-zA-Z0-9_-]+` rule. The `lib:`-or-coordinate form makes a real registry identity and a local indirection distinguishable on sight.
 
 A package must declare at least one world: a `[world]` entry, `[package].lib`, or both.
+
+#### `exports`
+
+`exports` is the allowlist of files outside the entry module that a consumer may name — a grammar, a schema, a template, an image, or a `.wado` submodule. A file not listed does not exist to a consumer, and the refusal names the package rather than the path. The list is API: adding to it is additive, removing from it breaks consumers, and `wado publish` ships exactly what it names. See [Package File Exports](./wep-2026-09-06-package-file-exports.md).
 
 #### Unknown keys
 

--- a/docs/wep-2026-03-02-include-str.md
+++ b/docs/wep-2026-03-02-include-str.md
@@ -20,7 +20,7 @@ let icon: List<u8> = #include_bytes("./assets/logo.png");
 let cert = #include_bytes("./certs/root.der");
 ```
 
-The argument is a string literal (not a runtime expression). The path is resolved relative to the source file containing the expression — the same convention as `#file`.
+The argument is a string literal (not a runtime expression). A `./` or `../` path is resolved relative to the source file containing the expression — the same convention as `#file`. A file a dependency exports is named the way every other specifier names it (`#include_str("ns:pkg@ver/templates/index.html")`, see [Package File Exports](./wep-2026-09-06-package-file-exports.md)); an unlisted file is refused at the package, not reported as missing.
 
 Unlike the argument-free compile-time literals (`#file`, `#line`, `#function`, `#data`), `#include_str` and `#include_bytes` take a parenthesized string literal argument. The parser distinguishes argument-free from argument-taking forms by looking ahead for `(` after the identifier.
 

--- a/docs/wep-2026-03-02-include-str.md
+++ b/docs/wep-2026-03-02-include-str.md
@@ -20,7 +20,7 @@ let icon: List<u8> = #include_bytes("./assets/logo.png");
 let cert = #include_bytes("./certs/root.der");
 ```
 
-The argument is a string literal (not a runtime expression). A `./` or `../` path is resolved relative to the source file containing the expression — the same convention as `#file`. A file a dependency exports is named the way every other specifier names it (`#include_str("ns:pkg@ver/templates/index.html")`, see [Package File Exports](./wep-2026-09-06-package-file-exports.md)); an unlisted file is refused at the package, not reported as missing.
+The argument is a string literal (not a runtime expression). A `./` or `../` path is resolved relative to the source file containing the expression — the same convention as `#file`. A file a dependency exports is named by its specifier: `#include_str("ns:pkg@ver/templates/index.html")`. An unlisted file is refused at the package, not reported as missing. See [Package File Exports](./wep-2026-09-06-package-file-exports.md).
 
 Unlike the argument-free compile-time literals (`#file`, `#line`, `#function`, `#data`), `#include_str` and `#include_bytes` take a parenthesized string literal argument. The parser distinguishes argument-free from argument-taking forms by looking ahead for `(` after the identifier.
 

--- a/docs/wep-2026-04-12-kiln.md
+++ b/docs/wep-2026-04-12-kiln.md
@@ -276,10 +276,13 @@ with {
 - The literal after `from` is the primary schema; `inputs` lists supplementary
   schemas the generator cannot discover from the primary alone (a parser grammar
   assuming its lexer grammar, an OpenAPI spec with an external components file).
-  Both must be `./` or `../` relative paths resolved against the declaring file,
-  the same convention as a local module import. A schema with transitive
-  references — a `.proto` importing another, GraphQL `extend type`, WIT `use` —
-  lists each of them here; there is no run-time discovery.
+  Both are either a `./` or `../` path resolved against the declaring file — the
+  same convention as a local module import — or a file a dependency exports
+  (`"ns:pkg@ver/grammar/Calc.g4"`,
+  [Package File Exports](./wep-2026-09-06-package-file-exports.md)). A schema
+  with transitive references — a `.proto` importing another, GraphQL
+  `extend type`, WIT `use` — lists each of them here; there is no run-time
+  discovery.
 - `module` follows the same rules as any module specifier
   ([package and module syntax](./wep-2026-06-17-package-module-syntax.md)): a
   relative path compiles from source; a `[build-dependencies]` coordinate
@@ -324,8 +327,10 @@ the generated file directly:
 The redirect is scoped to the file that declared the `with` clause. An unrelated
 file that imports the same schema with no clause of its own gets the
 missing-clause error rather than being silently routed through someone else's
-invocation. A `with` clause in an imported module still applies to that module's
-own imports, so a generated module can be produced deep in a dependency tree.
+invocation. Kiln's unit is the module, not the entry: clauses are harvested from
+every module reachable from the entry, and one in an imported module applies to
+that module's own imports, so a generated module can be produced deep in the
+module graph.
 
 ### The `kiln:` URI scheme
 
@@ -366,7 +371,16 @@ An invocation's cache key covers the resolved generator identity and its source,
 the content of the primary and supplementary schemas, the canonical form of the
 options value, and the world protocol version. Every ingredient is known before
 the generator runs, so the key is exact on the first build rather than converging
-after one. The compiled generator component is not part of the
+after one.
+
+A schema is keyed by how the use site named it, never by where the file sits on
+this machine. A dependency's exported file lives under `$WADO_ROOT` at a path
+that varies with the root, the version, and the checkout, so hashing that path
+would make the key machine-dependent and the committed-cache workflow below
+would miss on every other machine. The logical reference
+(`ns:pkg@ver/grammar/Calc.g4`) is what the key records; likewise the outputs go
+to the consuming project's output directory, never into the shared, immutable
+dependency checkout. The compiled generator component is not part of the
 key: its content is already determined by the generator source and the compiler
 version, both captured elsewhere, and hashing it would force every generator to
 re-run on a compiler upgrade for no added safety.
@@ -531,6 +545,14 @@ its completions at the `use` site.
 
 ## Open questions
 
+- [ ] Harvest clauses across the dependency edge. The walk covers the local
+      module graph and stops there, so a package that generates from its own
+      exported files does not work when consumed: its clauses are never seen,
+      and its schema paths and output directory would need re-anchoring in the
+      consuming project.
+- [ ] Binary schemas. `input-file.content` is a `string`, so an image or any
+      other non-UTF-8 input cannot reach a generator; carrying bytes is a world
+      version bump.
 - [ ] Enforce committed-source freshness in CI by running `wado check`.
 - [ ] Watch mode. The caching design supports it; the command surface is
       unspecified.
@@ -582,6 +604,8 @@ its completions at the `use` site.
   struct becomes a WIT record.
 - [Compile-Time File Inclusion](./wep-2026-03-02-include-str.md) — complementary,
   for files that need no generation.
+- [Package File Exports](./wep-2026-09-06-package-file-exports.md) — how a schema
+  inside a dependency is named.
 - [WebIDL Binding Generator](./wep-2026-04-01-tide.md) — the bootstrap tool that
   stays out of Kiln.
 - [Gale](./wep-2026-03-02-gale.md) — the grammar generator driven through Kiln.

--- a/docs/wep-2026-04-12-kiln.md
+++ b/docs/wep-2026-04-12-kiln.md
@@ -551,10 +551,11 @@ its completions at the `use` site.
       and its schema paths and output directory would need re-anchoring in the
       consuming project.
 - [ ] Binary schemas. `input-file.content` is a `string`, so an image or any
-      other non-UTF-8 input cannot reach a generator. It becomes
-      `variant content { text(string), bytes(list<u8>) }`, which is a world
-      version bump. What picks the arm — the file's bytes, its extension, or
-      the use site — is unsettled.
+      other non-UTF-8 input cannot reach a generator. It becomes `list<u8>`:
+      one type for every input, and a text generator decodes what it received.
+      A variant of text and bytes was rejected as the more complex half of a
+      choice nothing needs to make. This is a world version bump, and it
+      invalidates every cached invocation.
 - [ ] Enforce committed-source freshness in CI by running `wado check`.
 - [ ] Watch mode. The caching design supports it; the command surface is
       unspecified.

--- a/docs/wep-2026-04-12-kiln.md
+++ b/docs/wep-2026-04-12-kiln.md
@@ -276,9 +276,9 @@ with {
 - The literal after `from` is the primary schema; `inputs` lists supplementary
   schemas the generator cannot discover from the primary alone (a parser grammar
   assuming its lexer grammar, an OpenAPI spec with an external components file).
-  Both are either a `./` or `../` path resolved against the declaring file — the
-  same convention as a local module import — or a file a dependency exports
-  (`"ns:pkg@ver/grammar/Calc.g4"`,
+  Each is either a `./` or `../` path resolved against the declaring file, the
+  same convention as a local module import, or a file a dependency exports
+  (`"ns:pkg@ver/grammar/Calc.g4"`, see
   [Package File Exports](./wep-2026-09-06-package-file-exports.md)). A schema
   with transitive references — a `.proto` importing another, GraphQL
   `extend type`, WIT `use` — lists each of them here; there is no run-time
@@ -377,10 +377,10 @@ A schema is keyed by how the use site named it, never by where the file sits on
 this machine. A dependency's exported file lives under `$WADO_ROOT` at a path
 that varies with the root, the version, and the checkout, so hashing that path
 would make the key machine-dependent and the committed-cache workflow below
-would miss on every other machine. The logical reference
-(`ns:pkg@ver/grammar/Calc.g4`) is what the key records; likewise the outputs go
-to the consuming project's output directory, never into the shared, immutable
-dependency checkout. The compiled generator component is not part of the
+would miss on every other machine. The key records the logical reference
+(`ns:pkg@ver/grammar/Calc.g4`) instead. Outputs likewise go to the consuming
+project's output directory, never into the shared dependency checkout, which no
+build writes to. The compiled generator component is not part of the
 key: its content is already determined by the generator source and the compiler
 version, both captured elsewhere, and hashing it would force every generator to
 re-run on a compiler upgrade for no added safety.

--- a/docs/wep-2026-04-12-kiln.md
+++ b/docs/wep-2026-04-12-kiln.md
@@ -330,7 +330,9 @@ missing-clause error rather than being silently routed through someone else's
 invocation. Kiln's unit is the module, not the entry: clauses are harvested from
 every module reachable from the entry, and one in an imported module applies to
 that module's own imports, so a generated module can be produced deep in the
-module graph.
+module graph. That reach crosses into a dependency, whose clauses fire in the
+consuming build under the cache rule below
+([Package File Exports](./wep-2026-09-06-package-file-exports.md)).
 
 ### The `kiln:` URI scheme
 
@@ -407,6 +409,14 @@ Two workflows fall out of `output_dir`. Left at its default, generated source an
 cache state live under a gitignored build directory and a clean checkout
 regenerates them. Pointed at a tracked directory, both are committed, so review
 sees the generated source and web-based editors can navigate it.
+
+The same two workflows decide what happens when the package is consumed. A
+committed output travels with it and the consuming build uses it, resolving no
+generator; without one, the consuming build runs the generator through the
+package's own `[build-dependencies]` and writes the result into the consuming
+project. A travelled output is trusted rather than re-keyed, since re-deriving
+the key means resolving and hashing the generator that the record exists to
+avoid.
 
 ### Consume-only mode
 
@@ -545,11 +555,6 @@ its completions at the `use` site.
 
 ## Open questions
 
-- [ ] Harvest clauses across the dependency edge. The walk covers the local
-      module graph and stops there, so a package that generates from its own
-      exported files does not work when consumed: its clauses are never seen,
-      and its schema paths and output directory would need re-anchoring in the
-      consuming project.
 - [ ] Binary schemas. `input-file.content` is a `string`, so an image or any
       other non-UTF-8 input cannot reach a generator. It becomes `list<u8>`:
       one type for every input, and a text generator decodes what it received.

--- a/docs/wep-2026-04-12-kiln.md
+++ b/docs/wep-2026-04-12-kiln.md
@@ -551,8 +551,10 @@ its completions at the `use` site.
       and its schema paths and output directory would need re-anchoring in the
       consuming project.
 - [ ] Binary schemas. `input-file.content` is a `string`, so an image or any
-      other non-UTF-8 input cannot reach a generator; carrying bytes is a world
-      version bump.
+      other non-UTF-8 input cannot reach a generator. It becomes
+      `variant content { text(string), bytes(list<u8>) }`, which is a world
+      version bump. What picks the arm — the file's bytes, its extension, or
+      the use site — is unsettled.
 - [ ] Enforce committed-source freshness in CI by running `wado check`.
 - [ ] Watch mode. The caching design supports it; the command surface is
       unspecified.

--- a/docs/wep-2026-04-12-kiln.md
+++ b/docs/wep-2026-04-12-kiln.md
@@ -330,7 +330,7 @@ missing-clause error rather than being silently routed through someone else's
 invocation. Kiln's unit is the module, not the entry: clauses are harvested from
 every module reachable from the entry, and one in an imported module applies to
 that module's own imports, so a generated module can be produced deep in the
-module graph. That reach crosses into a dependency, whose clauses fire in the
+module graph. The reach crosses into a dependency too: its clauses fire in the
 consuming build under the cache rule below
 ([Package File Exports](./wep-2026-09-06-package-file-exports.md)).
 
@@ -376,13 +376,15 @@ the generator runs, so the key is exact on the first build rather than convergin
 after one.
 
 A schema is keyed by how the use site named it, never by where the file sits on
-this machine. A dependency's exported file lives under `$WADO_ROOT` at a path
-that varies with the root, the version, and the checkout, so hashing that path
-would make the key machine-dependent and the committed-cache workflow below
-would miss on every other machine. The key records the logical reference
+this machine. A dependency's exported file lives under `$WADO_ROOT`, at a path
+that varies with the root, the version, and the checkout. Hashing that path would
+key the invocation to one machine, and the committed-cache workflow below would
+then miss on every other one. The key records the logical reference
 (`ns:pkg@ver/grammar/Calc.g4`) instead. Outputs likewise go to the consuming
 project's output directory, never into the shared dependency checkout, which no
-build writes to. The compiled generator component is not part of the
+build writes to.
+
+The compiled generator component is not part of the
 key: its content is already determined by the generator source and the compiler
 version, both captured elsewhere, and hashing it would force every generator to
 re-run on a compiler upgrade for no added safety.
@@ -558,9 +560,7 @@ its completions at the `use` site.
 - [ ] Binary schemas. `input-file.content` is a `string`, so an image or any
       other non-UTF-8 input cannot reach a generator. It becomes `list<u8>`:
       one type for every input, and a text generator decodes what it received.
-      A variant of text and bytes was rejected as the more complex half of a
-      choice nothing needs to make. This is a world version bump, and it
-      invalidates every cached invocation.
+      This is a world version bump, and it invalidates every cached invocation.
 - [ ] Enforce committed-source freshness in CI by running `wado check`.
 - [ ] Watch mode. The caching design supports it; the command surface is
       unspecified.

--- a/docs/wep-2026-06-17-package-module-syntax.md
+++ b/docs/wep-2026-06-17-package-module-syntax.md
@@ -38,17 +38,32 @@ remote URL. Two principles anchor the rest:
 | `core:…` `wasi:…` `web:…` | Reserved → compiler-bundled                   |
 | `ns:pkg[@ver]` (open ns)  | Default registry, or `with`/manifest override |
 | `lib:nick`                | Indirection: alias / rename / private dep     |
+| `<coordinate>/<path.ext>` | One file the package exports                  |
 | `./` `../`                | Local file                                    |
 | `http(s)://`              | Remote                                        |
 
 `core:`/`wasi:`/`web:` are not a separate scheme — they are coordinates whose
 namespace happens to be bundled. Nested namespaces (`a:b:pkg`) follow WIT.
 
-A specifier names a **package only**; it carries no interface segment.
-Interfaces and their members are selected in the `use { ... }` list (`Iface`,
-`Iface::{op}`), as Wado already does. A package's internal file layout (the
-bundled stdlib's `core:prelude/array.wado`-style splits) is a loader detail,
-never a user-facing specifier.
+A specifier carries no interface segment. Interfaces and their members are
+selected in the `use { ... }` list (`Iface`, `Iface::{op}`), as Wado already
+does.
+
+A specifier names a package, optionally followed by one file that package
+exports:
+
+```
+<coordinate>[/<path.ext>]
+```
+
+With no path segment it resolves to the package's `[package].lib` entry. With
+one, it names a file the package listed in `[package].exports` — an asset or a
+submodule — and the mandatory extension is what tells the two forms apart. The
+allowlist is the API: an unlisted file does not exist to a consumer, whatever
+the package directory holds
+([Package File Exports](./wep-2026-09-06-package-file-exports.md)). A package's
+_unlisted_ file layout stays a loader detail, as the bundled stdlib's
+`core:prelude/array.wado`-style splits are.
 
 ### `lib:` is the sole home for indirection
 

--- a/docs/wep-2026-06-17-package-module-syntax.md
+++ b/docs/wep-2026-06-17-package-module-syntax.md
@@ -58,12 +58,14 @@ exports:
 
 With no path segment it resolves to the package's `[package].lib` entry. With
 one, it names a file the package listed in `[package].exports` — an asset or a
-submodule — and the mandatory extension is what tells the two forms apart. The
-allowlist is the API: an unlisted file does not exist to a consumer, whatever
-the package directory holds
-([Package File Exports](./wep-2026-09-06-package-file-exports.md)). A package's
-_unlisted_ file layout stays a loader detail, as the bundled stdlib's
-`core:prelude/array.wado`-style splits are.
+submodule. The extension is mandatory, because it is what tells the two forms
+apart.
+
+The allowlist is the API. An unlisted file does not exist to a consumer,
+whatever the package directory holds
+([Package File Exports](./wep-2026-09-06-package-file-exports.md)), so an
+unlisted layout stays a loader detail — the bundled stdlib's
+`core:prelude/array.wado`-style splits, for instance.
 
 ### `lib:` is the sole home for indirection
 

--- a/docs/wep-2026-07-26-provider-metadata.md
+++ b/docs/wep-2026-07-26-provider-metadata.md
@@ -19,19 +19,22 @@ A published package is a source package with a prebuilt CM binary attached, deli
 
 The package's Wado source travels in a custom section named `wado:package`:
 
-| Content                       | Purpose                                            |
-| ----------------------------- | -------------------------------------------------- |
-| Format version                | Consumer compatibility gate                        |
-| Compiler version              | Producing compiler, for the degradation rule below |
-| `wado.toml`                   | The package's own dependencies and entry points    |
-| The package's `.wado` sources | Bodies for `pub` items, and everything they reach  |
-| The files `exports` names     | Assets a consumer may name, verbatim               |
+| Content                       | Purpose                                                   |
+| ----------------------------- | --------------------------------------------------------- |
+| Format version                | Consumer compatibility gate                               |
+| Compiler version              | Producing compiler, for the degradation rule below        |
+| `wado.toml`                   | The package's own dependencies and entry points           |
+| The package's `.wado` sources | Bodies for `pub` items, and everything they reach         |
+| The files `exports` names     | Assets a consumer may name, verbatim                      |
+| Committed Kiln cache records  | So a consuming build reuses the output, not the generator |
 
 The section content is deterministic: sorted file order, no timestamps, fixed compression level. Same input, same bytes, same digest — otherwise `integrity` and reproducible builds break.
 
 Sources are included whole rather than pruned to the `pub`-reachable set. A `pub` generic body calls `internal` helpers, so most of a package is reachable anyway; pruning can follow if size proves to matter.
 
 Assets travel because consumers name them: a dependency's `.g4` feeds a Kiln generator, a template is inlined with `#include_str` ([Package File Exports](./wep-2026-09-06-package-file-exports.md)). They are bytes rather than text, so the section carries them verbatim. A consumer on the CM path has no section, and therefore no files — the same all-or-nothing selection as everything else here.
+
+A package whose Kiln output is committed also carries each `<primary>.kiln.json` beside the generated `.wado` files those records describe. Without the record a consuming build cannot tell which generated module an import resolves to, and would run the generator to find out.
 
 A custom section is not instantiated, so this costs distribution bytes only, never runtime size.
 

--- a/docs/wep-2026-07-26-provider-metadata.md
+++ b/docs/wep-2026-07-26-provider-metadata.md
@@ -31,7 +31,7 @@ The section content is deterministic: sorted file order, no timestamps, fixed co
 
 Sources are included whole rather than pruned to the `pub`-reachable set. A `pub` generic body calls `internal` helpers, so most of a package is reachable anyway; pruning can follow if size proves to matter.
 
-An asset travels because naming it is how a consumer uses it: a dependency's `.g4` fed to a Kiln generator, a template inlined with `#include_str` ([Package File Exports](./wep-2026-09-06-package-file-exports.md)). Assets are bytes, not text, so the section carries them verbatim rather than as UTF-8. A consumer on the CM path has no section and therefore no files, which is the same all-or-nothing selection the rest of this WEP describes.
+Assets travel because consumers name them: a dependency's `.g4` feeds a Kiln generator, a template is inlined with `#include_str` ([Package File Exports](./wep-2026-09-06-package-file-exports.md)). They are bytes rather than text, so the section carries them verbatim. A consumer on the CM path has no section, and therefore no files — the same all-or-nothing selection as everything else here.
 
 A custom section is not instantiated, so this costs distribution bytes only, never runtime size.
 

--- a/docs/wep-2026-07-26-provider-metadata.md
+++ b/docs/wep-2026-07-26-provider-metadata.md
@@ -25,10 +25,13 @@ The package's Wado source travels in a custom section named `wado:package`:
 | Compiler version              | Producing compiler, for the degradation rule below |
 | `wado.toml`                   | The package's own dependencies and entry points    |
 | The package's `.wado` sources | Bodies for `pub` items, and everything they reach  |
+| The files `exports` names     | Assets a consumer may name, verbatim               |
 
 The section content is deterministic: sorted file order, no timestamps, fixed compression level. Same input, same bytes, same digest — otherwise `integrity` and reproducible builds break.
 
 Sources are included whole rather than pruned to the `pub`-reachable set. A `pub` generic body calls `internal` helpers, so most of a package is reachable anyway; pruning can follow if size proves to matter.
+
+An asset travels because naming it is how a consumer uses it: a dependency's `.g4` fed to a Kiln generator, a template inlined with `#include_str` ([Package File Exports](./wep-2026-09-06-package-file-exports.md)). Assets are bytes, not text, so the section carries them verbatim rather than as UTF-8. A consumer on the CM path has no section and therefore no files, which is the same all-or-nothing selection the rest of this WEP describes.
 
 A custom section is not instantiated, so this costs distribution bytes only, never runtime size.
 

--- a/docs/wep-2026-09-06-package-file-exports.md
+++ b/docs/wep-2026-09-06-package-file-exports.md
@@ -134,8 +134,13 @@ selected in the `use { … }` list, and a file is not an interface.
 
 ### Deliberate omissions
 
-Globs at a use site and directory listing, both already refused for local Kiln
-inputs: a package boundary is not the place to relax them. Writing into a
+Glob patterns, in the allowlist as much as at a use site. A pattern would spare
+a package with many assets some typing, and would cost the list its whole point:
+what is offered would depend on what happens to sit in the directory, so a file
+dropped in becomes API and a file renamed silently stops being it. Naming each
+file is the mechanism, not the ceremony around it.
+
+Directory listing, already refused for local Kiln inputs. Writing into a
 dependency. Reaching a file of a dependency's dependency.
 
 ## Roadmap
@@ -164,10 +169,6 @@ dependency. Reaching a file of a dependency's dependency.
 
 ## Known gaps
 
-- Glob patterns in the allowlist (`grammar/*.g4`). Exact entries are what a use
-  site needs and what publish can verify; a package with many assets will want
-  patterns. Closing it means saying what a pattern means for the stability
-  promise and for what publish uploads.
 - A dependency's own Kiln invocations. The clause-harvest walks the local module
   graph and stops at the dependency edge, so a package that generates from its
   own assets does not work when consumed. Closing it means harvesting through

--- a/docs/wep-2026-09-06-package-file-exports.md
+++ b/docs/wep-2026-09-06-package-file-exports.md
@@ -196,10 +196,10 @@ without the exception.
 5. Registry distribution: assets travel in the `wado:package` section and are
    extracted into the shared cache on fetch, so `CompilerHost::load_source`
    serves them like any other file.
-6. Binary assets through Kiln: `input-file.content` becomes a variant of text
-   and bytes ([Kiln](./wep-2026-04-12-kiln.md) §"Open questions"), so an image
-   can reach a generator. Done when the `core:kiln` world carries it and its
-   version bump invalidates the caches that need it.
+6. Binary assets through Kiln: `input-file.content` becomes `list<u8>`
+   ([Kiln](./wep-2026-04-12-kiln.md) §"Open questions"), so an image can reach a
+   generator. Done when the `core:kiln` world carries bytes and its version bump
+   invalidates the caches.
 7. The unreachable-`pub` lint: a `pub` item that no exported file reaches,
    reported in the unused family. Done when a package with a `pub` item outside
    its `lib` reach and outside `exports` reports it, and adding the file to

--- a/docs/wep-2026-09-06-package-file-exports.md
+++ b/docs/wep-2026-09-06-package-file-exports.md
@@ -153,10 +153,41 @@ valid.
   literally at the use site (principle 2), since a package coordinate in front
   of the path does not make the set dynamic, and the generator still receives
   its inputs by value under the same sandbox (principle 1).
-- The clause stays the consumer's. Naming a dependency's `.g4` means running the
-  generator yourself, with your options. A package that wants to own its own
-  generation instead runs Kiln on its own files and exports the resulting
-  module, which needs the harvest to cross the dependency edge (see Known gaps).
+- Naming a dependency's `.g4` yourself means running the generator yourself,
+  with your options. A package that wants to own its generation instead runs
+  Kiln on its own files and exports the resulting module, which is the next
+  section.
+
+### A dependency's own invocations follow the cache rule
+
+A package may generate from its own assets and export what comes out. Its
+clauses then have to fire in a consuming build, since the loader meets that
+package's `use { … } from "./grammar/Wado.g4"` while compiling it. Clauses are
+therefore harvested across the dependency edge, and each one is resolved by the
+rule Kiln already applies to a local invocation
+([Kiln](./wep-2026-04-12-kiln.md) §"Caching"):
+
+- A recorded output travels with the package — the generated `.wado` files and
+  the `<primary>.kiln.json` beside them. The consuming build uses them and
+  resolves no generator at all.
+- Nothing recorded, and the consuming build runs the generator: it resolves it
+  through the _dependency's_ `[build-dependencies]`, and writes the output into
+  the consuming project's tree.
+
+Which arm a package takes is the one it already chose with `output_dir`: a
+tracked directory commits the output and ships it, the default gitignored one
+does not. No new switch, and no policy the boundary invents for itself.
+
+A recorded output is trusted, not verified. Re-deriving its cache key means
+resolving and hashing the dependency's generator, which is the work the record
+exists to avoid — the same reasoning consume-only mode already runs on. Keeping
+that record fresh is the dependency's own `wado check`.
+
+Both arms rest on the sandbox. Running a generator the consumer never named is
+acceptable because a generator is a pure function of its inputs, with no clock,
+no network, no filesystem and no environment (principle 1). Reusing a recorded
+output is acceptable for the same reason: purity is what makes the recorded
+bytes reproducible rather than a snapshot of someone's machine.
 
 ### Deliberate omissions
 
@@ -191,32 +222,43 @@ without the exception.
    the logical form, write outputs into the consumer's tree. Done when
    `grammar/Wado.g4` can be consumed from a second package with a warm,
    machine-independent cache.
-4. `#include_str` / `#include_bytes`: the same reference, resolved through the
+4. Harvest across the dependency edge: walk a dependency's modules, anchor each
+   clause's paths on that dependency's package root as `ns:pkg@ver/path`, and
+   key its redirect by the identity the loader gives that module. Done when a
+   consuming build reports a dependency's malformed clause instead of ignoring
+   it.
+5. Consume a recorded output: resolve a dependency's invocation from the
+   `<primary>.kiln.json` beside its committed output, as consume-only mode does.
+   Done when `package-gale-highlight-wado` builds as a dependency with no
+   generator run in the consuming build.
+6. Run what has no record: resolve the generator through the dependency's own
+   `[build-dependencies]`, pin it in the consuming project's lock as part of the
+   transitive build graph, and write the output into that project's tree. Done
+   when a dependency that commits no output builds in a consumer, and a second
+   build of it hits a warm cache.
+7. `#include_str` / `#include_bytes`: the same reference, resolved through the
    same path.
-5. Registry distribution: assets travel in the `wado:package` section and are
-   extracted into the shared cache on fetch, so `CompilerHost::load_source`
-   serves them like any other file.
-6. Binary assets through Kiln: `input-file.content` becomes `list<u8>`
+8. Registry distribution: assets and recorded Kiln outputs travel in the
+   `wado:package` section and are extracted into the shared cache on fetch, so
+   `CompilerHost::load_source` serves them like any other file.
+9. Binary assets through Kiln: `input-file.content` becomes `list<u8>`
    ([Kiln](./wep-2026-04-12-kiln.md) §"Open questions"), so an image can reach a
    generator. Done when the `core:kiln` world carries bytes and its version bump
    invalidates the caches.
-7. The unreachable-`pub` lint: a `pub` item that no exported file reaches,
-   reported in the unused family. Done when a package with a `pub` item outside
-   its `lib` reach and outside `exports` reports it, and adding the file to
-   `exports` clears it.
+10. The unreachable-`pub` lint: a `pub` item that no exported file reaches,
+    reported in the unused family. Done when a package with a `pub` item outside
+    its `lib` reach and outside `exports` reports it, and adding the file to
+    `exports` clears it.
 
 ## Known gaps
 
-- A dependency's own Kiln invocations. The clause-harvest walks the local module
-  graph and stops at the dependency edge, so a package that generates from its
-  own assets does not work when consumed — `package-gale-highlight-wado` is that
-  package today. What closes it is one decision with several downstream of it:
-  whether a dependency's generators run in the consuming build at all, or a
-  dependency is always consumed from its committed output the way a
-  consume-only host reads it. Running them settles nothing by itself — where
-  the outputs and cache state live, whose `[build-dependencies]` and lock pin
-  the generator, how deep the graph is followed, and whose diagnostic a
-  dependency's generator failure is, all follow from it.
+- How deep a dependency's generation is followed. Roadmap 4-6 cover a direct
+  dependency; whether a dependency of a dependency generating from its own
+  assets is reached the same way is unexamined, and the answer is one traversal
+  rule plus whatever the transitive build lock has to record.
+- Whose diagnostic a dependency's generator failure is. The span names a file
+  the consumer cannot edit, and the useful report is one that names the
+  dependency and its version rather than a path under `$WADO_ROOT`.
 - Whether a `lib` entry and an exported submodule that reach the same file
   resolve to one module identity. Two identities would make one declaration two
   nominal types, which

--- a/docs/wep-2026-09-06-package-file-exports.md
+++ b/docs/wep-2026-09-06-package-file-exports.md
@@ -22,9 +22,9 @@ not exist:
   dependency there is no file on disk to reach even if the syntax existed.
 
 A package cannot say which of its files it offers, and a consumer cannot name
-one. Both are needed, and they have to arrive together: a file reference looks
-like a filesystem path, and a package's directory layout must not become its API
-by accident.
+one. Neither half is useful alone: a reference reads as a filesystem path, so
+adding one without the list would make a package's directory layout its API by
+accident.
 
 ## Decision
 
@@ -46,8 +46,8 @@ exports = [
 
 One list covers assets and `.wado` submodules alike. What differs between them
 is what a consumer does with the file: import it as a module, feed it to a
-generator, inline it. What the package promises is the same either way, and
-deciding it is the owner's, as it is for `pub` and `export` on an item.
+generator, inline it. The package promises the same thing either way, and its
+owner decides, exactly as `pub` and `export` decide for an item.
 
 The key is `exports`, after npm's field of the same name and meaning. It sits
 beside the `export` visibility keyword without colliding: `export` marks one
@@ -82,7 +82,7 @@ let template = #include_str("wado-lang:my-pkg/templates/index.html");
   required rather than conventional. It also keeps a file reference from reading
   like a WIT interface segment.
 - Every specifier form that can carry a package coordinate carries a path the
-  same way: an open coordinate (`ns:name[@ver]`) and a `lib:` nickname alike.
+  same way: an open coordinate (`ns:pkg[@ver]`) and a `lib:` nickname alike.
 - `..` and absolute paths are rejected, not resolved. The path is a key into the
   allowlist, not a traversal that happens to start at the package root.
 - The reference resolves against the consuming manifest's own `[dependencies]`
@@ -140,7 +140,7 @@ valid.
 - `from` and `inputs` accept an exported-file reference wherever they accept a
   `./` path today.
 - The invocation's identity records the logical reference
-  (`ns:name@ver/path`), never where the file sits on this machine. That covers
+  (`ns:pkg@ver/path`), never where the file sits on this machine. That covers
   the cache key, the dedup tuple, and the `sources` of the `#![generated]`
   header. A dependency's checkout lives under `$WADO_ROOT` at a
   version-dependent path, so hashing that path would make the cache
@@ -155,8 +155,7 @@ valid.
   its inputs by value under the same sandbox (principle 1).
 - Naming a dependency's `.g4` yourself means running the generator yourself,
   with your options. A package that wants to own its generation instead runs
-  Kiln on its own files and exports the resulting module, which is the next
-  section.
+  Kiln on its own files and exports the resulting module.
 
 ### A dependency's own invocations follow the cache rule
 
@@ -167,7 +166,7 @@ therefore harvested across the dependency edge at any depth, and each one is
 resolved by the rule Kiln already applies to a local invocation
 ([Kiln](./wep-2026-04-12-kiln.md) §"Caching"):
 
-- A recorded output travels with the package — the generated `.wado` files and
+- A recorded output travels with the package: the generated `.wado` files and
   the `<primary>.kiln.json` beside them. The consuming build uses them and
   resolves no generator at all.
 - Nothing recorded, and the consuming build runs the generator: it resolves it
@@ -176,12 +175,12 @@ resolved by the rule Kiln already applies to a local invocation
 
 Which arm a package takes is the one it already chose with `output_dir`: a
 tracked directory commits the output and ships it, the default gitignored one
-does not. No new switch, and no policy the boundary invents for itself.
+does not. The boundary adds no switch of its own.
 
 A recorded output is trusted, not verified. Re-deriving its cache key means
 resolving and hashing the dependency's generator, which is the work the record
-exists to avoid — the same reasoning consume-only mode already runs on. Keeping
-that record fresh is the dependency's own `wado check`.
+exists to avoid. Consume-only mode already trusts an artifact on that reasoning.
+Keeping the record fresh is the dependency's own `wado check`.
 
 Both arms rest on the sandbox. Running a generator the consumer never named is
 acceptable because a generator is a pure function of its inputs, with no clock,
@@ -191,8 +190,8 @@ bytes reproducible rather than a snapshot of someone's machine.
 
 What goes wrong inside a dependency is reported against that dependency: the
 package coordinate and its version, whatever the generator failed on. A path
-under `$WADO_ROOT` names a directory the user did not create and cannot edit,
-and it changes with the version — the coordinate is what tells them which
+under `$WADO_ROOT` names a directory the user did not create, cannot edit, and
+will not see again after a version bump. The coordinate is what tells them which
 package to pin, patch, or report to.
 
 ### Deliberate omissions
@@ -204,7 +203,10 @@ dropped in becomes API and a file renamed silently stops being it. Naming each
 file is the mechanism, not the ceremony around it.
 
 Directory listing, already refused for local Kiln inputs. Writing into a
-dependency. Reaching a file of a dependency's dependency.
+dependency. Naming a file of a dependency's dependency: a reference resolves
+against your own `[dependencies]`, and a package you did not declare offers you
+nothing. (Its own generation still runs, at whatever depth it sits — that is the
+package's business, not a file you named.)
 
 Files from a reserved namespace. `core:` / `wasi:` / `web:` are bundled in the
 compiler and have no `wado.toml` to carry an allowlist, so they export nothing.
@@ -222,8 +224,8 @@ without the exception.
    already separates the segment), resolve the package through the dependency
    index, check the allowlist under NFC with case compared exactly, and refuse
    at package granularity. Done when `use { … } from "lib:x/src/y.wado"`
-   compiles against a path dependency, and an unlisted path — a case-only
-   mismatch among them — produces the package-level diagnostic.
+   compiles against a path dependency, and an unlisted path produces the
+   package-level diagnostic, a case-only mismatch among them.
 3. Kiln `from` / `inputs`: accept the reference, key the cache and the header on
    the logical form, write outputs into the consumer's tree. Done when
    `grammar/Wado.g4` can be consumed from a second package with a warm,

--- a/docs/wep-2026-09-06-package-file-exports.md
+++ b/docs/wep-2026-09-06-package-file-exports.md
@@ -49,6 +49,11 @@ is what a consumer does with the file: import it as a module, feed it to a
 generator, inline it. What the package promises is the same either way, and
 deciding it is the owner's, as it is for `pub` and `export` on an item.
 
+The key is `exports`, after npm's field of the same name and meaning. It sits
+beside the `export` visibility keyword without colliding: `export` marks one
+item as crossing the CM ABI, `exports` lists the files a package offers, and no
+position accepts both.
+
 A refusal names the package, not the path. Reaching for an unlisted file answers
 "package `X` exports no file `Y`" whether or not the file is there, so the list
 never doubles as a directory listing.
@@ -159,9 +164,6 @@ dependency. Reaching a file of a dependency's dependency.
 
 ## Known gaps
 
-- The key's name. `exports` reads as "part of the API", but `export` already
-  means "crosses the CM ABI" on an item, and these files cross nothing. `public`
-  and `files` are the alternatives.
 - Glob patterns in the allowlist (`grammar/*.g4`). Exact entries are what a use
   site needs and what publish can verify; a package with many assets will want
   patterns. Closing it means saying what a pattern means for the stability

--- a/docs/wep-2026-09-06-package-file-exports.md
+++ b/docs/wep-2026-09-06-package-file-exports.md
@@ -163,8 +163,8 @@ valid.
 A package may generate from its own assets and export what comes out. Its
 clauses then have to fire in a consuming build, since the loader meets that
 package's `use { … } from "./grammar/Wado.g4"` while compiling it. Clauses are
-therefore harvested across the dependency edge, and each one is resolved by the
-rule Kiln already applies to a local invocation
+therefore harvested across the dependency edge at any depth, and each one is
+resolved by the rule Kiln already applies to a local invocation
 ([Kiln](./wep-2026-04-12-kiln.md) §"Caching"):
 
 - A recorded output travels with the package — the generated `.wado` files and
@@ -188,6 +188,12 @@ acceptable because a generator is a pure function of its inputs, with no clock,
 no network, no filesystem and no environment (principle 1). Reusing a recorded
 output is acceptable for the same reason: purity is what makes the recorded
 bytes reproducible rather than a snapshot of someone's machine.
+
+What goes wrong inside a dependency is reported against that dependency: the
+package coordinate and its version, whatever the generator failed on. A path
+under `$WADO_ROOT` names a directory the user did not create and cannot edit,
+and it changes with the version — the coordinate is what tells them which
+package to pin, patch, or report to.
 
 ### Deliberate omissions
 
@@ -252,13 +258,6 @@ without the exception.
 
 ## Known gaps
 
-- How deep a dependency's generation is followed. Roadmap 4-6 cover a direct
-  dependency; whether a dependency of a dependency generating from its own
-  assets is reached the same way is unexamined, and the answer is one traversal
-  rule plus whatever the transitive build lock has to record.
-- Whose diagnostic a dependency's generator failure is. The span names a file
-  the consumer cannot edit, and the useful report is one that names the
-  dependency and its version rather than a path under `$WADO_ROOT`.
 - Whether a `lib` entry and an exported submodule that reach the same file
   resolve to one module identity. Two identities would make one declaration two
   nominal types, which

--- a/docs/wep-2026-09-06-package-file-exports.md
+++ b/docs/wep-2026-09-06-package-file-exports.md
@@ -109,6 +109,32 @@ selected in the `use { … }` list, and a file is not an interface.
   stays all-or-nothing: a dependency consumed through the CM path has no files
   to offer, and says so.
 
+### An exported submodule offers its `pub` items
+
+`pub` already means "public API"
+([Visibility](./wep-2026-06-25-visibility-internal-pub-export.md)); the
+allowlist decides which files carry it. A consumer that names an exported
+submodule may use every `pub` item in it, whether or not the `lib` entry
+re-exports that item. `internal` stays package-local, and a file the allowlist
+does not name offers nothing.
+
+A `pub` item that no exported file reaches is therefore public in name only. The
+compiler says so, as a lint in the unused family: the declaration claims an API
+the package does not offer, and the fix is to export the file or drop the item
+to `internal`.
+
+### Paths compare after NFC, and case must match
+
+A reference and an allowlist entry are compared after NFC normalization, so a
+name that round-trips through a decomposing filesystem still matches. Case is
+not folded: `grammar/wado.g4` does not name `grammar/Wado.g4`, on any
+filesystem. A case-insensitive filesystem would otherwise let a package build on
+its author's machine and fail on a consumer's, or the reverse.
+
+A case-only mismatch is an error like any other unlisted file. Naming the near
+match in the diagnostic is better ergonomics; it does not make the reference
+valid.
+
 ### Kiln
 
 - `from` and `inputs` accept an exported-file reference wherever they accept a
@@ -143,17 +169,24 @@ file is the mechanism, not the ceremony around it.
 Directory listing, already refused for local Kiln inputs. Writing into a
 dependency. Reaching a file of a dependency's dependency.
 
+Files from a reserved namespace. `core:` / `wasi:` / `web:` are bundled in the
+compiler and have no `wado.toml` to carry an allowlist, so they export nothing.
+Nothing rules it out later — a bundled allowlist would be a table in the
+compiler — but no need has come up, and the specifier rule is easier to state
+without the exception.
+
 ## Roadmap
 
 1. `[package].exports` in `wado-manifest`: parse, and validate each entry as a
-   package-root-relative path with an extension and no `..`. Done when a
-   manifest round-trips it and `wado publish` refuses a list naming a file the
-   package does not carry.
+   package-root-relative path with an extension and no `..`, NFC-normalized.
+   Done when a manifest round-trips it and `wado publish` refuses a list naming
+   a file the package does not carry.
 2. Specifier resolution: split `<coordinate>/<path.ext>` once (`kiln::parse_spec`
    already separates the segment), resolve the package through the dependency
-   index, check the allowlist, and refuse at package granularity. Done when
-   `use { … } from "lib:x/src/y.wado"` compiles against a path dependency and an
-   unlisted path produces the package-level diagnostic.
+   index, check the allowlist under NFC with case compared exactly, and refuse
+   at package granularity. Done when `use { … } from "lib:x/src/y.wado"`
+   compiles against a path dependency, and an unlisted path — a case-only
+   mismatch among them — produces the package-level diagnostic.
 3. Kiln `from` / `inputs`: accept the reference, key the cache and the header on
    the logical form, write outputs into the consumer's tree. Done when
    `grammar/Wado.g4` can be consumed from a second package with a warm,
@@ -163,24 +196,33 @@ dependency. Reaching a file of a dependency's dependency.
 5. Registry distribution: assets travel in the `wado:package` section and are
    extracted into the shared cache on fetch, so `CompilerHost::load_source`
    serves them like any other file.
-6. Binary assets through Kiln: `input-file.content` is a `string`, so an image
-   cannot cross the generator boundary. Done when the `core:kiln` world carries
-   bytes and its version bump invalidates the caches that need it.
+6. Binary assets through Kiln: `input-file.content` becomes a variant of text
+   and bytes ([Kiln](./wep-2026-04-12-kiln.md) §"Open questions"), so an image
+   can reach a generator. Done when the `core:kiln` world carries it and its
+   version bump invalidates the caches that need it.
+7. The unreachable-`pub` lint: a `pub` item that no exported file reaches,
+   reported in the unused family. Done when a package with a `pub` item outside
+   its `lib` reach and outside `exports` reports it, and adding the file to
+   `exports` clears it.
 
 ## Known gaps
 
 - A dependency's own Kiln invocations. The clause-harvest walks the local module
   graph and stops at the dependency edge, so a package that generates from its
-  own assets does not work when consumed. Closing it means harvesting through
-  dependency modules and anchoring their invocation paths and outputs in the
-  consuming project.
-- Whether an exported submodule may offer items its `lib` entry does not, and
-  how that interacts with `pub` / `export`
-  ([Visibility](./wep-2026-06-25-visibility-internal-pub-export.md)).
-- Reserved namespaces (`core:` / `wasi:` / `web:`) expose no files. Whether a
-  bundled asset should ever be nameable is unexamined.
-- Case-insensitive and Unicode-normalizing filesystems: the allowlist is
-  compared as bytes, and a path that matches on one machine may not on another.
+  own assets does not work when consumed — `package-gale-highlight-wado` is that
+  package today. What closes it is one decision with several downstream of it:
+  whether a dependency's generators run in the consuming build at all, or a
+  dependency is always consumed from its committed output the way a
+  consume-only host reads it. Running them settles nothing by itself — where
+  the outputs and cache state live, whose `[build-dependencies]` and lock pin
+  the generator, how deep the graph is followed, and whose diagnostic a
+  dependency's generator failure is, all follow from it.
+- Whether a `lib` entry and an exported submodule that reach the same file
+  resolve to one module identity. Two identities would make one declaration two
+  nominal types, which
+  [Module Loader](./wep-2026-01-24-module-loader.md) §"Canonical module
+  identity" avoids for local paths; the package boundary has not been checked
+  against it.
 
 ## References
 

--- a/docs/wep-2026-09-06-package-file-exports.md
+++ b/docs/wep-2026-09-06-package-file-exports.md
@@ -1,0 +1,189 @@
+# WEP: Package File Exports — Assets and Submodules as API
+
+## Context
+
+A Wado package ships more than its entry module. `package-gale-highlight-wado`
+carries `grammar/Wado.g4` and `grammar/Wado.highlights.scm`; another package
+carries a `.proto`, a JSON Schema, a `.css`, an icon. Inside the package those
+files are ordinary Kiln inputs and `#include_str` arguments. Outside it they do
+not exist:
+
+- A Kiln `from` / `inputs` path must start with `./` or `../` and resolves
+  against the declaring file ([Kiln](./wep-2026-04-12-kiln.md) §"Use-site
+  syntax"). Nothing names a file inside a dependency.
+- A module specifier names a package and resolves to its `[package].lib` entry;
+  it "carries no interface segment"
+  ([Package and Module Specifier Syntax](./wep-2026-06-17-package-module-syntax.md)),
+  and no file segment either. A package's other `.wado` modules are unreachable
+  the same way its `.g4` is.
+- `#include_str` resolves relative to the including file
+  ([Compile-Time File Inclusion](./wep-2026-03-02-include-str.md)).
+- `wado publish` uploads a component and nothing else, so for a registry
+  dependency there is no file on disk to reach even if the syntax existed.
+
+Two things are missing, and they are one thing: a way for a package to say which
+of its files are part of what it offers, and a way for a consumer to name one of
+them. A file reference looks like a filesystem path, but a package's directory
+layout must not become its API by accident.
+
+## Decision
+
+### One allowlist, both kinds of file
+
+A package declares the files a consumer may name. Everything else is invisible,
+whatever the directory contains.
+
+```toml
+[package]
+name = "gale-highlight-wado"
+lib = "src/lib.wado"
+exports = [
+    "grammar/Wado.g4",
+    "grammar/Wado.highlights.scm",
+    "src/highlight.wado",
+]
+```
+
+An asset and a `.wado` submodule sit in one list because they differ only in
+what the consumer does with the file — import it as a module, feed it to a
+generator, or inline it — never in what the package is promising. Visibility is
+the package owner's, exactly as with `pub` and `export` on an item.
+
+Refusal names the package, not the path: reaching for an unlisted file is
+"package `X` exports no file `Y`", the same answer whether or not the file is
+there. A directory layout is not a directory listing.
+
+### Naming an exported file
+
+```
+"<package-specifier>/<path>"
+```
+
+The path is relative to the package root (the directory holding its
+`wado.toml`), forward-slash separated, and **carries its extension**:
+
+```wado
+use { highlight } from "wado-lang:gale-highlight-wado/src/highlight.wado";
+
+use { Parser } from "lib:gale-highlight-wado/grammar/Wado.g4" with {
+    generator: { module: "lib:gale" },
+};
+
+let template = #include_str("wado-lang:my-pkg/templates/index.html");
+```
+
+- A specifier with no path segment keeps its current meaning: the package's
+  `[package].lib` entry. The mandatory extension is what separates the two, so
+  it is load-bearing rather than stylistic — and it keeps a file reference from
+  ever reading like a WIT interface segment.
+- Every specifier form that can carry a package coordinate carries a path the
+  same way: an open coordinate (`ns:name[@ver]`) and a `lib:` nickname alike.
+- `..` and absolute paths are rejected, not resolved. The path is a key into the
+  allowlist, not a traversal that happens to start at the package root.
+- The reference resolves against the consuming manifest's own `[dependencies]`
+  / `[build-dependencies]`, like every other specifier. There is no path into a
+  transitive dependency.
+
+This revises §"Specifier forms" of
+[Package and Module Specifier Syntax](./wep-2026-06-17-package-module-syntax.md):
+a specifier names a package, optionally followed by one exported file. The
+prohibition it states is on _interface_ segments, which stands — an interface is
+selected in the `use { … }` list, and a file is not an interface.
+
+### The allowlist is API
+
+- Adding an entry is additive. Removing or renaming one breaks consumers, like
+  removing an `export fn`.
+- `wado publish` ships every listed file, and refuses to publish a list naming a
+  file the package does not carry — the failure belongs to the publisher, not to
+  a consumer six months later.
+- A source dependency (path / git) serves the files from its checkout. A
+  registry dependency carries them in the `wado:package` section
+  ([Provider Metadata](./wep-2026-07-26-provider-metadata.md)), which grows an
+  asset area beside the `.wado` sources it already carries. Consumer selection
+  stays all-or-nothing: a dependency consumed through the CM path has no files
+  to offer, and says so.
+
+### Kiln
+
+- `from` and `inputs` accept an exported-file reference wherever they accept a
+  `./` path today.
+- The invocation's identity — cache key, dedup tuple, and the `sources` of the
+  `#![generated]` header — records the logical reference (`ns:name@ver/path`),
+  never where the file happens to sit on this machine. A dependency's checkout
+  lives under `$WADO_ROOT` at a version-dependent path; hashing that path would
+  make the invocation cache machine-dependent and break the committed-cache
+  workflow ([Kiln](./wep-2026-04-12-kiln.md) §"Caching") the moment an input
+  came from a dependency.
+- Generated files land in the consuming project's output tree, exactly as they
+  do for a local schema. A dependency's checkout is shared between projects and
+  is never written to.
+- Kiln's design principles hold unchanged. Every input is still enumerated
+  literally at the use site (principle 2) — a package coordinate in front of the
+  path does not make the set dynamic — and the generator still receives its
+  inputs by value under the same sandbox (principle 1).
+- The clause stays the consumer's: naming a dependency's `.g4` means running the
+  generator yourself, with your options. A package that wants to own its own
+  generation runs Kiln on its own files and exports the resulting module — which
+  requires the harvest to cross the dependency edge (see Known gaps).
+
+### Deliberate omissions
+
+Globs at a use site, and directory listing: both are already refused for local
+Kiln inputs, and a package boundary is not the place to relax them. Writing into
+a dependency. Reaching a file of a dependency's dependency.
+
+## Roadmap
+
+1. `[package].exports` in `wado-manifest`: parse, and validate each entry as a
+   package-root-relative path with an extension and no `..`. Done when a
+   manifest round-trips it and `wado publish` refuses a list naming a file the
+   package does not carry.
+2. Specifier resolution: split `<coordinate>/<path.ext>` once (`kiln::parse_spec`
+   already separates the segment), resolve the package through the dependency
+   index, check the allowlist, and refuse at package granularity. Done when
+   `use { … } from "lib:x/src/y.wado"` compiles against a path dependency and an
+   unlisted path produces the package-level diagnostic.
+3. Kiln `from` / `inputs`: accept the reference, key the cache and the header on
+   the logical form, write outputs into the consumer's tree. Done when
+   `grammar/Wado.g4` can be consumed from a second package with a warm,
+   machine-independent cache.
+4. `#include_str` / `#include_bytes`: the same reference, resolved through the
+   same path.
+5. Registry distribution: assets travel in the `wado:package` section and are
+   extracted into the shared cache on fetch, so `CompilerHost::load_source`
+   serves them like any other file.
+6. Binary assets through Kiln: `input-file.content` is a `string`, so an image
+   cannot cross the generator boundary. Done when the `core:kiln` world carries
+   bytes and its version bump invalidates the caches that need it.
+
+## Known gaps
+
+- The key's name. `exports` reads as "part of the API", but `export` already
+  means "crosses the CM ABI" on an item, and these files cross nothing. `public`
+  and `files` are the alternatives.
+- Glob patterns in the allowlist (`grammar/*.g4`). Exact entries are what a use
+  site needs and what publish can verify; a package with many assets will want
+  patterns. Closing it means saying what a pattern means for the stability
+  promise and for what publish uploads.
+- A dependency's own Kiln invocations. The clause-harvest walks the local module
+  graph and stops at the dependency edge, so a package that generates from its
+  own assets does not work when consumed. Closing it means harvesting through
+  dependency modules and anchoring their invocation paths and outputs in the
+  consuming project.
+- Whether an exported submodule may offer items its `lib` entry does not, and
+  how that interacts with `pub` / `export`
+  ([Visibility](./wep-2026-06-25-visibility-internal-pub-export.md)).
+- Reserved namespaces (`core:` / `wasi:` / `web:`) expose no files. Whether a
+  bundled asset should ever be nameable is unexamined.
+- Case-insensitive and Unicode-normalizing filesystems: the allowlist is
+  compared as bytes, and a path that matches on one machine may not on another.
+
+## References
+
+- [Kiln — Keyed IDL Lowering Notation](./wep-2026-04-12-kiln.md)
+- [Package and Module Specifier Syntax](./wep-2026-06-17-package-module-syntax.md)
+- [Package Manifest (`wado.toml`)](./wep-2026-02-14-package-manifest.md)
+- [Provider Metadata — Source-Bundled Package Artifacts](./wep-2026-07-26-provider-metadata.md)
+- [Compile-Time File Inclusion (`#include_str`)](./wep-2026-03-02-include-str.md)
+- [Visibility — `internal` / `pub` / `export`](./wep-2026-06-25-visibility-internal-pub-export.md)

--- a/docs/wep-2026-09-06-package-file-exports.md
+++ b/docs/wep-2026-09-06-package-file-exports.md
@@ -21,10 +21,10 @@ not exist:
 - `wado publish` uploads a component and nothing else, so for a registry
   dependency there is no file on disk to reach even if the syntax existed.
 
-Two things are missing, and they are one thing: a way for a package to say which
-of its files are part of what it offers, and a way for a consumer to name one of
-them. A file reference looks like a filesystem path, but a package's directory
-layout must not become its API by accident.
+A package cannot say which of its files it offers, and a consumer cannot name
+one. Both are needed, and they have to arrive together: a file reference looks
+like a filesystem path, and a package's directory layout must not become its API
+by accident.
 
 ## Decision
 
@@ -44,14 +44,14 @@ exports = [
 ]
 ```
 
-An asset and a `.wado` submodule sit in one list because they differ only in
-what the consumer does with the file — import it as a module, feed it to a
-generator, or inline it — never in what the package is promising. Visibility is
-the package owner's, exactly as with `pub` and `export` on an item.
+One list covers assets and `.wado` submodules alike. What differs between them
+is what a consumer does with the file: import it as a module, feed it to a
+generator, inline it. What the package promises is the same either way, and
+deciding it is the owner's, as it is for `pub` and `export` on an item.
 
-Refusal names the package, not the path: reaching for an unlisted file is
-"package `X` exports no file `Y`", the same answer whether or not the file is
-there. A directory layout is not a directory listing.
+A refusal names the package, not the path. Reaching for an unlisted file answers
+"package `X` exports no file `Y`" whether or not the file is there, so the list
+never doubles as a directory listing.
 
 ### Naming an exported file
 
@@ -60,7 +60,7 @@ there. A directory layout is not a directory listing.
 ```
 
 The path is relative to the package root (the directory holding its
-`wado.toml`), forward-slash separated, and **carries its extension**:
+`wado.toml`), forward-slash separated, and carries its extension:
 
 ```wado
 use { highlight } from "wado-lang:gale-highlight-wado/src/highlight.wado";
@@ -73,9 +73,9 @@ let template = #include_str("wado-lang:my-pkg/templates/index.html");
 ```
 
 - A specifier with no path segment keeps its current meaning: the package's
-  `[package].lib` entry. The mandatory extension is what separates the two, so
-  it is load-bearing rather than stylistic — and it keeps a file reference from
-  ever reading like a WIT interface segment.
+  `[package].lib` entry. The extension separates the two forms, so it is
+  required rather than conventional. It also keeps a file reference from reading
+  like a WIT interface segment.
 - Every specifier form that can carry a package coordinate carries a path the
   same way: an open coordinate (`ns:name[@ver]`) and a `lib:` nickname alike.
 - `..` and absolute paths are rejected, not resolved. The path is a key into the
@@ -86,17 +86,17 @@ let template = #include_str("wado-lang:my-pkg/templates/index.html");
 
 This revises §"Specifier forms" of
 [Package and Module Specifier Syntax](./wep-2026-06-17-package-module-syntax.md):
-a specifier names a package, optionally followed by one exported file. The
-prohibition it states is on _interface_ segments, which stands — an interface is
+a specifier names a package, optionally followed by one exported file. Its
+prohibition is on interface segments, and that one stands. An interface is
 selected in the `use { … }` list, and a file is not an interface.
 
 ### The allowlist is API
 
 - Adding an entry is additive. Removing or renaming one breaks consumers, like
   removing an `export fn`.
-- `wado publish` ships every listed file, and refuses to publish a list naming a
-  file the package does not carry — the failure belongs to the publisher, not to
-  a consumer six months later.
+- `wado publish` ships every listed file, and refuses a list naming a file the
+  package does not carry. The publisher sees that failure, instead of a consumer
+  months later.
 - A source dependency (path / git) serves the files from its checkout. A
   registry dependency carries them in the `wado:package` section
   ([Provider Metadata](./wep-2026-07-26-provider-metadata.md)), which grows an
@@ -108,30 +108,30 @@ selected in the `use { … }` list, and a file is not an interface.
 
 - `from` and `inputs` accept an exported-file reference wherever they accept a
   `./` path today.
-- The invocation's identity — cache key, dedup tuple, and the `sources` of the
-  `#![generated]` header — records the logical reference (`ns:name@ver/path`),
-  never where the file happens to sit on this machine. A dependency's checkout
-  lives under `$WADO_ROOT` at a version-dependent path; hashing that path would
-  make the invocation cache machine-dependent and break the committed-cache
-  workflow ([Kiln](./wep-2026-04-12-kiln.md) §"Caching") the moment an input
-  came from a dependency.
+- The invocation's identity records the logical reference
+  (`ns:name@ver/path`), never where the file sits on this machine. That covers
+  the cache key, the dedup tuple, and the `sources` of the `#![generated]`
+  header. A dependency's checkout lives under `$WADO_ROOT` at a
+  version-dependent path, so hashing that path would make the cache
+  machine-dependent and break the committed-cache workflow
+  ([Kiln](./wep-2026-04-12-kiln.md) §"Caching").
 - Generated files land in the consuming project's output tree, exactly as they
   do for a local schema. A dependency's checkout is shared between projects and
   is never written to.
 - Kiln's design principles hold unchanged. Every input is still enumerated
-  literally at the use site (principle 2) — a package coordinate in front of the
-  path does not make the set dynamic — and the generator still receives its
-  inputs by value under the same sandbox (principle 1).
-- The clause stays the consumer's: naming a dependency's `.g4` means running the
+  literally at the use site (principle 2), since a package coordinate in front
+  of the path does not make the set dynamic, and the generator still receives
+  its inputs by value under the same sandbox (principle 1).
+- The clause stays the consumer's. Naming a dependency's `.g4` means running the
   generator yourself, with your options. A package that wants to own its own
-  generation runs Kiln on its own files and exports the resulting module — which
-  requires the harvest to cross the dependency edge (see Known gaps).
+  generation instead runs Kiln on its own files and exports the resulting
+  module, which needs the harvest to cross the dependency edge (see Known gaps).
 
 ### Deliberate omissions
 
-Globs at a use site, and directory listing: both are already refused for local
-Kiln inputs, and a package boundary is not the place to relax them. Writing into
-a dependency. Reaching a file of a dependency's dependency.
+Globs at a use site and directory listing, both already refused for local Kiln
+inputs: a package boundary is not the place to relax them. Writing into a
+dependency. Reaching a file of a dependency's dependency.
 
 ## Roadmap
 

--- a/wado-cli/src/check.rs
+++ b/wado-cli/src/check.rs
@@ -141,6 +141,7 @@ pub async fn run(opts: CheckOptions) -> Result<(), CliExit> {
     // Same setup `wado compile` runs its generators through — only the pipeline
     // below differs: `check` dry-runs and byte-compares instead of writing.
     let kiln = crate::compile::prepare_kiln(path, &host, opts.knobs.no_cache, manifest_pair)
+        .await
         .map_err(silent_or_reported)?;
     let outcome = match kiln {
         None => CheckOutcome::default(),

--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -607,7 +607,7 @@ pub(crate) struct KilnSetup {
 /// Shared by [`maybe_run_pipeline`] (which runs them) and `wado check` (which
 /// dry-runs them and byte-compares), so both tiers resolve generators through
 /// one identical setup.
-pub(crate) fn prepare_kiln(
+pub(crate) async fn prepare_kiln(
     entry_file: &Path,
     host: &FilesystemCompilerHost,
     no_cache: bool,
@@ -620,7 +620,8 @@ pub(crate) fn prepare_kiln(
             .unwrap_or_else(|| std::path::PathBuf::from("."))
     });
     let (mut invocations, identities, inline_diagnostics) =
-        collect_inline_invocations_for_entry_with_identities(entry_file, &probe_manifest_root);
+        collect_inline_invocations_for_entry_with_identities(entry_file, &probe_manifest_root)
+            .await;
 
     // Fail on a malformed clause here, with its own diagnostics, so the clear
     // error is not buried under the downstream failure of the unredirected
@@ -703,7 +704,7 @@ pub(crate) async fn maybe_run_pipeline(
     no_cache: bool,
     project: Option<manifest::ProjectManifest>,
 ) -> Result<PipelineOutcome, PipelineError> {
-    let Some(mut kiln) = prepare_kiln(entry_file, host, no_cache, project)? else {
+    let Some(mut kiln) = prepare_kiln(entry_file, host, no_cache, project).await? else {
         return Ok(PipelineOutcome::default());
     };
     let mut outcome = crate::kiln_driver::run_pipeline(
@@ -845,7 +846,7 @@ pub fn empty_manifest() -> wado_manifest::Manifest {
 /// keys through this map (see `remap_index_decl_files`). The loader identity is
 /// canonical (see [`wado_compiler::name::canonical_local_path`]), so the map is
 /// single-valued.
-fn collect_inline_invocations_for_entry_with_identities(
+async fn collect_inline_invocations_for_entry_with_identities(
     entry_file: &Path,
     manifest_root: &Path,
 ) -> (
@@ -853,88 +854,19 @@ fn collect_inline_invocations_for_entry_with_identities(
     wado_compiler::hashmap::IndexMap<String, String>,
     Vec<wado_compiler::Diagnostic>,
 ) {
-    use std::collections::VecDeque;
-    use wado_compiler::name::{
-        canonical_local_path, normalize_module_path, resolve_local_identity, resolve_module_path,
-    };
-
-    let mut modules =
-        wado_compiler::hashmap::IndexMap::<String, wado_compiler::ast::Module>::default();
-    let mut identities: wado_compiler::hashmap::IndexMap<String, String> =
-        wado_compiler::hashmap::IndexMap::default();
-
-    // (harvest_key, loader_identity, filesystem_path, is_entry)
-    let mut queue: VecDeque<(String, String, std::path::PathBuf, bool)> = VecDeque::new();
     // The entry's harvest key must stay byte-identical to its
     // `EntryPoint.filename` (interned verbatim by the loader), so the redirect
     // it keys is found at resolve time — do not normalize it here.
-    // `resolve_module_path` (used for children below) is panic-free on its own,
-    // so a path with URI-unsafe characters no longer crashes (#1417).
     let entry_key = entry_file.to_string_lossy().to_string();
-    let entry_dir = wado_compiler::name::module_parent_dir(&entry_key).to_string();
-    identities.insert(entry_key.clone(), entry_key.clone());
-    queue.push_back((
-        entry_key.clone(),
-        entry_key.clone(),
-        entry_file.to_path_buf(),
-        true,
-    ));
-
-    while let Some((key, loader_id, fs_path, is_entry)) = queue.pop_front() {
-        if modules.contains_key(&key) {
-            continue;
-        }
-        let Ok(source) = fs::read_to_string(&fs_path) else {
-            continue;
-        };
-        // `parse` is resilient; if a module has recovered lex or parse errors
-        // the AST is partial. Refuse to harvest from a partial tree so a
-        // mid-edit source can't trigger surprising codegen side effects —
-        // matches the prior fail-on-parse-error behaviour.
-        let Ok(parsed) = wado_compiler::parse(&source).into_fail_fast() else {
-            continue;
-        };
-        let ast = parsed.ast;
-
-        let parent_dir = fs_path
-            .parent()
-            .map(std::path::Path::to_path_buf)
-            .unwrap_or_default();
-        for item in &ast.items {
-            let wado_compiler::ast::Item::Use(use_decl) = item else {
-                continue;
-            };
-            let src = use_decl.source.as_str();
-            // Only follow local `.wado` modules. Non-`.wado` schemas (`.g4`,
-            // …) are the Kiln targets themselves, and `core:` / `wasi:` /
-            // bare dependency imports are not consumer modules to scan.
-            if !(src.starts_with("./") || src.starts_with("../"))
-                || !src.to_ascii_lowercase().ends_with(".wado")
-            {
-                continue;
-            }
-            let child_key = resolve_module_path(&key, src);
-            // Must match the loader's identity derivation (entry vs deeper).
-            let child_loader_id = if is_entry {
-                canonical_local_path(&entry_dir, &normalize_module_path(src))
-            } else {
-                resolve_local_identity(&entry_dir, &loader_id, src)
-            };
-            // Don't overwrite the entry's pinned identity (back-refs fold to it).
-            if child_key != entry_key {
-                identities.insert(child_key.clone(), child_loader_id.clone());
-            }
-            if !modules.contains_key(&child_key) {
-                queue.push_back((child_key, child_loader_id, parent_dir.join(src), false));
-            }
-        }
-        modules.insert(key, ast);
-    }
+    let harvest = wado_compiler::kiln::harvest_module_graph(&entry_key, None, async |path| {
+        fs::read_to_string(path).ok()
+    })
+    .await;
 
     let descriptors = wado_compiler::hashmap::IndexMap::default();
     let manifest_root_str = manifest_root.to_string_lossy();
     let (invocations, diagnostics) = match wado_compiler::kiln::collect_inline_invocations(
-        modules.iter().map(|(k, v)| (k.as_str(), v)),
+        harvest.modules.iter().map(|(k, v)| (k.as_str(), v)),
         &descriptors,
         &manifest_root_str,
     ) {
@@ -943,55 +875,10 @@ fn collect_inline_invocations_for_entry_with_identities(
         // clause produces no invocations.
         Err(diags) => (Vec::new(), diags),
     };
-    (invocations, identities, diagnostics)
+    (invocations, harvest.identities, diagnostics)
 }
 
-/// Rewrite the index's `decl_file` keys from harvest keys to loader identities
-/// (keys absent from `identities` pass through). Returns a diagnostic for each
-/// *conflict* — two keys resolving to the same `(loader_identity, from)` but
-/// different targets — instead of silently dropping a redirect (last-write-wins);
-/// matching targets are a harmless duplicate. Unreachable with canonical
-/// identities; guards against a future identity-scheme regression.
-#[must_use]
-fn remap_index_decl_files(
-    index: &mut wado_compiler::kiln::InvocationIndex,
-    identities: &wado_compiler::hashmap::IndexMap<String, String>,
-) -> Vec<wado_compiler::Diagnostic> {
-    let rewritten: Vec<(String, String, String)> = index
-        .entries()
-        .map(|(decl, from, uri)| {
-            let decl = identities.get(decl).map_or(decl, String::as_str);
-            (decl.to_string(), from.to_string(), uri.to_string())
-        })
-        .collect();
-
-    let mut diagnostics = Vec::new();
-    let mut fresh = wado_compiler::kiln::InvocationIndex::new();
-    for (decl, from, uri) in rewritten {
-        // `redirect` normalizes `from` identically to `insert`, so this sees
-        // the key `insert` would write.
-        if let Some(existing) = fresh.redirect(&decl, &from)
-            && existing != uri
-        {
-            diagnostics.push(wado_compiler::Diagnostic {
-                severity: wado_compiler::Severity::Error,
-                code: wado_compiler::Code::KilnRedirectConflict,
-                message: format!(
-                    "kiln: two generator invocations for `use ... from {from:?}` in `{decl}` \
-                     redirect to different generated modules (`{existing}` and `{uri}`); \
-                     a module cannot resolve one import to two generated entries",
-                ),
-                span: None,
-            });
-            continue;
-        }
-        fresh.insert(&decl, &from, &uri);
-    }
-    *index = fresh;
-    diagnostics
-}
-
-/// Remap `index` to loader identities via [`remap_index_decl_files`], emit any
+/// Remap `index` to loader identities via [`wado_compiler::kiln::remap_decl_files`], emit any
 /// conflict diagnostics through `host`, and return the count of `Error`-severity
 /// conflicts. Reached through [`KilnSetup::remap_conflicts`], which both
 /// `compile` and `check` use.
@@ -1000,7 +887,7 @@ fn remap_and_report_conflicts(
     identities: &wado_compiler::hashmap::IndexMap<String, String>,
     host: &FilesystemCompilerHost,
 ) -> usize {
-    let conflicts = remap_index_decl_files(index, identities);
+    let conflicts = wado_compiler::kiln::remap_decl_files(index, identities);
     let errors = conflicts
         .iter()
         .filter(|d| d.severity == wado_compiler::Severity::Error)
@@ -1329,6 +1216,21 @@ mod kiln_dir_module_tests {
         std::env::temp_dir().join(format!("wado-kiln-dir-{tag}-{}", std::process::id()))
     }
 
+    /// The harvest, driven to completion: its reads are filesystem-immediate,
+    /// so a test needs no runtime around them.
+    fn harvest(
+        entry: &Path,
+        root: &Path,
+    ) -> (
+        Vec<wado_compiler::kiln::Invocation>,
+        wado_compiler::hashmap::IndexMap<String, String>,
+        Vec<wado_compiler::Diagnostic>,
+    ) {
+        futures::executor::block_on(collect_inline_invocations_for_entry_with_identities(
+            entry, root,
+        ))
+    }
+
     #[test]
     fn package_generator_entry_reads_world_entry() {
         let root = unique_tmp("entry");
@@ -1414,8 +1316,7 @@ mod kiln_dir_module_tests {
         .unwrap();
 
         let entry = example.join("main.wado");
-        let (invs, identities, _diags) =
-            collect_inline_invocations_for_entry_with_identities(&entry, &root);
+        let (invs, identities, _diags) = harvest(&entry, &root);
 
         assert_eq!(invs.len(), 1, "should harvest the imported module's clause");
         let inv = &invs[0];
@@ -1469,8 +1370,7 @@ mod kiln_dir_module_tests {
         .unwrap();
 
         let entry = root.join("src/main.wado");
-        let (invs, identities, _d) =
-            collect_inline_invocations_for_entry_with_identities(&entry, &root);
+        let (invs, identities, _d) = harvest(&entry, &root);
         assert_eq!(invs.len(), 1);
         let parser_key = &invs[0].decl_site.module;
         assert_eq!(
@@ -1481,7 +1381,7 @@ mod kiln_dir_module_tests {
 
         let mut idx = wado_compiler::kiln::InvocationIndex::new();
         idx.insert(parser_key, "./G.g4", "kiln:file:///g/parser.wado");
-        let conflicts = remap_index_decl_files(&mut idx, &identities);
+        let conflicts = wado_compiler::kiln::remap_decl_files(&mut idx, &identities);
         assert!(conflicts.is_empty());
         assert_eq!(
             idx.redirect("./gen/parser.wado", "./G.g4"),
@@ -1512,8 +1412,7 @@ mod kiln_dir_module_tests {
 
         let entry = root.join("src/main.wado");
         let entry_key = entry.to_string_lossy().to_string();
-        let (_invs, identities, _d) =
-            collect_inline_invocations_for_entry_with_identities(&entry, &root);
+        let (_invs, identities, _d) = harvest(&entry, &root);
         assert_eq!(
             identities.get(&entry_key).map(String::as_str),
             Some(entry_key.as_str()),
@@ -1525,84 +1424,6 @@ mod kiln_dir_module_tests {
         );
 
         let _ = std::fs::remove_dir_all(&root);
-    }
-
-    #[test]
-    fn remap_index_decl_files_swaps_to_loader_identity() {
-        use wado_compiler::kiln::InvocationIndex;
-
-        let mut idx = InvocationIndex::new();
-        idx.insert(
-            "/abs/example/eval.wado",
-            "./Arith.g4",
-            "kiln:file:///g/arith.wado",
-        );
-
-        let mut identities = wado_compiler::hashmap::IndexMap::default();
-        identities.insert(
-            "/abs/example/eval.wado".to_string(),
-            "./eval.wado".to_string(),
-        );
-
-        let conflicts = remap_index_decl_files(&mut idx, &identities);
-        assert!(conflicts.is_empty(), "no conflict for a single mapping");
-
-        assert!(
-            idx.redirect("/abs/example/eval.wado", "./Arith.g4")
-                .is_none(),
-            "the harvest-key decl_file must no longer redirect"
-        );
-        assert_eq!(
-            idx.redirect("./eval.wado", "./Arith.g4"),
-            Some("kiln:file:///g/arith.wado"),
-            "the loader identity must redirect to the same URI"
-        );
-    }
-
-    // Two keys collapsing onto one `(identity, from)` with different targets
-    // must be reported, not silently resolved last-write-wins (#1423).
-    #[test]
-    fn remap_index_decl_files_reports_conflict_on_identity_collision() {
-        use wado_compiler::kiln::InvocationIndex;
-
-        let mut idx = InvocationIndex::new();
-        idx.insert("/abs/a.wado", "./G.g4", "kiln:file:///g/from_a.wado");
-        idx.insert("/abs/b.wado", "./G.g4", "kiln:file:///g/from_b.wado");
-
-        let mut identities = wado_compiler::hashmap::IndexMap::default();
-        identities.insert("/abs/a.wado".to_string(), "./shared.wado".to_string());
-        identities.insert("/abs/b.wado".to_string(), "./shared.wado".to_string());
-
-        let conflicts = remap_index_decl_files(&mut idx, &identities);
-        assert_eq!(conflicts.len(), 1, "the collision must be reported");
-        assert_eq!(conflicts[0].code, wado_compiler::Code::KilnRedirectConflict);
-        assert_eq!(conflicts[0].severity, wado_compiler::Severity::Error);
-        // The first redirect survives; the conflicting second is dropped.
-        assert_eq!(
-            idx.redirect("./shared.wado", "./G.g4"),
-            Some("kiln:file:///g/from_a.wado"),
-        );
-    }
-
-    // Same identity *and* target is a benign duplicate: no diagnostic.
-    #[test]
-    fn remap_index_decl_files_allows_duplicate_identical_target() {
-        use wado_compiler::kiln::InvocationIndex;
-
-        let mut idx = InvocationIndex::new();
-        idx.insert("/abs/a.wado", "./G.g4", "kiln:file:///g/shared.wado");
-        idx.insert("/abs/b.wado", "./G.g4", "kiln:file:///g/shared.wado");
-
-        let mut identities = wado_compiler::hashmap::IndexMap::default();
-        identities.insert("/abs/a.wado".to_string(), "./shared.wado".to_string());
-        identities.insert("/abs/b.wado".to_string(), "./shared.wado".to_string());
-
-        let conflicts = remap_index_decl_files(&mut idx, &identities);
-        assert!(conflicts.is_empty(), "identical target is not a conflict");
-        assert_eq!(
-            idx.redirect("./shared.wado", "./G.g4"),
-            Some("kiln:file:///g/shared.wado"),
-        );
     }
 
     // An in-directory diamond already collapses to one canonical identity.
@@ -1631,8 +1452,7 @@ mod kiln_dir_module_tests {
         .unwrap();
 
         let entry = ex.join("main.wado");
-        let (invs, identities, _d) =
-            collect_inline_invocations_for_entry_with_identities(&entry, &root);
+        let (invs, identities, _d) = harvest(&entry, &root);
 
         assert_eq!(invs.len(), 1, "the generator clause is harvested once");
         let foo_key = &invs[0].decl_site.module;
@@ -1644,7 +1464,7 @@ mod kiln_dir_module_tests {
 
         let mut idx = wado_compiler::kiln::InvocationIndex::new();
         idx.insert(foo_key, "./G.g4", "kiln:file:///g/foo.wado");
-        let conflicts = remap_index_decl_files(&mut idx, &identities);
+        let conflicts = wado_compiler::kiln::remap_decl_files(&mut idx, &identities);
         assert!(conflicts.is_empty());
         assert_eq!(
             idx.redirect("./a/foo.wado", "./G.g4"),

--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -845,23 +845,30 @@ async fn collect_inline_invocations_for_entry_with_identities(
     Vec<wado_compiler::Diagnostic>,
 ) {
     let entry_key = entry_file.to_string_lossy().to_string();
-    let harvest = wado_compiler::kiln::harvest_module_graph(&entry_key, None, async |path| {
-        fs::read_to_string(path).ok()
-    })
-    .await;
+    // An unreadable entry, or one whose parse recovered from an error, harvests
+    // nothing; the compile that follows reports it.
+    let Ok(entry_source) = fs::read_to_string(entry_file) else {
+        return Default::default();
+    };
+    let Ok(entry) = wado_compiler::parse(&entry_source).into_fail_fast() else {
+        return Default::default();
+    };
+    // A loader identity is anchored on the entry's directory, so that is what
+    // an import joins onto.
+    let entry_dir = entry_file.parent().unwrap_or(Path::new(".")).to_path_buf();
+    let harvest =
+        wado_compiler::kiln::harvest_module_graph(&entry_key, entry.ast, async |identity| {
+            fs::read_to_string(entry_dir.join(identity)).ok()
+        })
+        .await;
 
     let descriptors = wado_compiler::hashmap::IndexMap::default();
     let manifest_root_str = manifest_root.to_string_lossy();
-    let (invocations, diagnostics) = match wado_compiler::kiln::collect_inline_invocations(
+    let (invocations, diagnostics) = wado_compiler::kiln::collect_inline_invocations(
         harvest.modules.iter().map(|(k, v)| (k.as_str(), v)),
         &descriptors,
         &manifest_root_str,
-    ) {
-        Ok(invs) => (invs, Vec::new()),
-        // Hand the diagnostics back for the caller to surface; a malformed
-        // clause produces no invocations.
-        Err(diags) => (Vec::new(), diags),
-    };
+    );
     (invocations, harvest.identities, diagnostics)
 }
 
@@ -1170,13 +1177,13 @@ mod kiln_dir_module_tests {
 
     fn local_invocation(module_path: &str) -> Invocation {
         Invocation {
-            decl_site: DeclSite {
+            decl_sites: vec![DeclSite {
                 module: "consumer.wado".to_string(),
+                source: InvocationPath::normalize("./grammar.g4"),
                 synthetic_id: "kiln-test".to_string(),
-            },
+            }],
             module: GeneratorModule::LocalPath(InvocationPath::normalize(module_path)),
             from: InvocationPath::normalize("grammar.g4"),
-            source: InvocationPath::normalize("./grammar.g4"),
             inputs: Vec::new(),
             output_dir: InvocationPath::normalize("build"),
             options: wado_compiler::kiln::CanonicalOptions::default(),
@@ -1313,12 +1320,12 @@ mod kiln_dir_module_tests {
             inv.from.as_str()
         );
         assert!(
-            inv.decl_site.module.ends_with("example/eval.wado"),
+            inv.decl_site().module.ends_with("example/eval.wado"),
             "decl_site.module should be eval.wado's full path, got {}",
-            inv.decl_site.module
+            inv.decl_site().module
         );
         assert_eq!(
-            identities.get(&inv.decl_site.module).map(String::as_str),
+            identities.get(&inv.decl_site().module).map(String::as_str),
             Some("./eval.wado"),
             "harvest key must map to the loader identity"
         );
@@ -1359,7 +1366,7 @@ mod kiln_dir_module_tests {
         let entry = root.join("src/main.wado");
         let (invs, identities, _d) = harvest(&entry, &root);
         assert_eq!(invs.len(), 1);
-        let parser_key = &invs[0].decl_site.module;
+        let parser_key = &invs[0].decl_site().module;
         assert_eq!(
             identities.get(parser_key).map(String::as_str),
             Some("./gen/parser.wado"),
@@ -1442,7 +1449,7 @@ mod kiln_dir_module_tests {
         let (invs, identities, _d) = harvest(&entry, &root);
 
         assert_eq!(invs.len(), 1, "the generator clause is harvested once");
-        let foo_key = &invs[0].decl_site.module;
+        let foo_key = &invs[0].decl_site().module;
         assert_eq!(
             identities.get(foo_key).map(String::as_str),
             Some("./a/foo.wado"),

--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -832,20 +832,10 @@ pub fn empty_manifest() -> wado_manifest::Manifest {
     }
 }
 
-/// Harvest inline Kiln invocations from `entry_file` *and its transitive local
-/// `.wado` imports*, plus the map needed to fix up the redirect index.
-///
-/// Kiln generation runs as a pre-pass before the loader, so a
-/// `with { generator: ... }` clause in an imported module (not just the entry)
-/// must be discovered here; otherwise that module's grammar `use` falls through
-/// to the Wado lexer.
-///
-/// Returns the invocations plus a `harvest_key → loader_identity` map: the
-/// harvest keys `decl_site.module` by full path, but the loader presents a
-/// base-relative identity at resolve time, so the caller rewrites the index's
-/// keys through this map (see `remap_index_decl_files`). The loader identity is
-/// canonical (see [`wado_compiler::name::canonical_local_path`]), so the map is
-/// single-valued.
+/// Harvest inline Kiln invocations from `entry_file` and its transitive local
+/// `.wado` imports, plus the `harvest_key → loader_identity` map the caller
+/// rewrites the redirect index through
+/// ([`wado_compiler::kiln::remap_decl_files`]).
 async fn collect_inline_invocations_for_entry_with_identities(
     entry_file: &Path,
     manifest_root: &Path,
@@ -854,9 +844,6 @@ async fn collect_inline_invocations_for_entry_with_identities(
     wado_compiler::hashmap::IndexMap<String, String>,
     Vec<wado_compiler::Diagnostic>,
 ) {
-    // The entry's harvest key must stay byte-identical to its
-    // `EntryPoint.filename` (interned verbatim by the loader), so the redirect
-    // it keys is found at resolve time — do not normalize it here.
     let entry_key = entry_file.to_string_lossy().to_string();
     let harvest = wado_compiler::kiln::harvest_module_graph(&entry_key, None, async |path| {
         fs::read_to_string(path).ok()

--- a/wado-cli/src/kiln_driver.rs
+++ b/wado-cli/src/kiln_driver.rs
@@ -369,14 +369,12 @@ fn to_meta_file_hash(f: &FileHash) -> MetaFileHash {
 }
 
 /// Point every module that declared `invocation` at the generated entry it
-/// produced, keyed by the literal `from "<source>"` that module wrote — what
-/// the loader looks up, where `invocation.from` is the resolved path that
-/// loaded the input and keyed the cache.
+/// produced, under `entry_path` in the output directory.
 ///
-/// Canonicalizing the path here means the loader needs neither the manifest
-/// root nor the importer's working directory at resolve time. The
-/// un-canonicalized join stands in when the file is not on disk (a stale-cache
-/// path), which keeps the URI well-formed enough for diagnostics.
+/// Canonicalizing here means the loader needs neither the manifest root nor the
+/// importer's working directory at resolve time. The un-canonicalized join
+/// stands in when the file is not on disk (a stale-cache path), keeping the URI
+/// well-formed enough for diagnostics.
 fn record_redirects(
     index: &mut wado_compiler::kiln::InvocationIndex,
     invocation: &Invocation,
@@ -385,10 +383,7 @@ fn record_redirects(
 ) {
     let joined = manifest_root.join(entry_path);
     let abs = std::fs::canonicalize(&joined).unwrap_or(joined);
-    let uri = path_to_kiln_uri(&abs);
-    for site in &invocation.decl_sites {
-        index.insert(&site.module, site.source.as_str(), &uri);
-    }
+    index.insert_invocation(invocation, &path_to_kiln_uri(&abs));
 }
 
 /// Compose the `kiln:` redirect URI for an absolute filesystem path.

--- a/wado-cli/src/kiln_driver.rs
+++ b/wado-cli/src/kiln_driver.rs
@@ -287,7 +287,7 @@ pub async fn execute_with_mode<H: CompilerHost>(
                 {
                     emit_generated_regenerated_notice(
                         host,
-                        &invocation.decl_site.synthetic_id,
+                        &invocation.decl_site().synthetic_id,
                         normalized.as_str(),
                     );
                 }
@@ -365,6 +365,29 @@ fn to_meta_file_hash(f: &FileHash) -> MetaFileHash {
     MetaFileHash {
         path: f.path.clone(),
         hash: hex_digest(&f.hash),
+    }
+}
+
+/// Point every module that declared `invocation` at the generated entry it
+/// produced, keyed by the literal `from "<source>"` that module wrote — what
+/// the loader looks up, where `invocation.from` is the resolved path that
+/// loaded the input and keyed the cache.
+///
+/// Canonicalizing the path here means the loader needs neither the manifest
+/// root nor the importer's working directory at resolve time. The
+/// un-canonicalized join stands in when the file is not on disk (a stale-cache
+/// path), which keeps the URI well-formed enough for diagnostics.
+fn record_redirects(
+    index: &mut wado_compiler::kiln::InvocationIndex,
+    invocation: &Invocation,
+    manifest_root: &Path,
+    entry_path: &str,
+) {
+    let joined = manifest_root.join(entry_path);
+    let abs = std::fs::canonicalize(&joined).unwrap_or(joined);
+    let uri = path_to_kiln_uri(&abs);
+    for site in &invocation.decl_sites {
+        index.insert(&site.module, site.source.as_str(), &uri);
     }
 }
 
@@ -1064,23 +1087,12 @@ where
                 }
             }
             if let Some(entry_path) = metadata.outputs.iter().find(|o| o.entry).map(|o| &o.path) {
-                let decl_file = invocation.decl_site.module.clone();
-                // Compose a `file:` URI from the canonicalized absolute
-                // path. Canonicalizing here means the loader does not
-                // need to know the manifest root or the importer's
-                // working directory at resolve time. Falling back to the
-                // un-canonicalized join (rare: only when the file does
-                // not yet exist on disk, e.g. a stale-cache path) keeps
-                // the URI well-formed enough for diagnostics.
-                let joined = manifest_root.join(entry_path);
-                let abs = std::fs::canonicalize(&joined).unwrap_or(joined);
-                let uri = path_to_kiln_uri(&abs);
-                // Key by the literal `from "<source>"` string (frame-independent),
-                // which is what the loader looks up — `invocation.from` is the
-                // resolved path used for input loading and the cache key.
-                outcome
-                    .invocations
-                    .insert(&decl_file, invocation.source.as_str(), &uri);
+                record_redirects(
+                    &mut outcome.invocations,
+                    invocation,
+                    manifest_root,
+                    entry_path,
+                );
             }
             if executed
                 && let Err(source) = kiln_metadata::save(
@@ -1190,13 +1202,12 @@ where
         outcome.checked.push(invocation_name.clone());
 
         if let Some(entry_path) = run.outputs.iter().find(|o| o.is_entry).map(|o| &o.path) {
-            let decl_file = invocation.decl_site.module.clone();
-            let joined = manifest_root.join(entry_path);
-            let abs = std::fs::canonicalize(&joined).unwrap_or(joined);
-            let uri = path_to_kiln_uri(&abs);
-            outcome
-                .invocations
-                .insert(&decl_file, invocation.source.as_str(), &uri);
+            record_redirects(
+                &mut outcome.invocations,
+                invocation,
+                manifest_root,
+                entry_path,
+            );
         }
 
         for output in &run.outputs {
@@ -1367,7 +1378,7 @@ fn typed_encode_options<H: CompilerHost>(
             other => other,
         };
         let anchor = OptionsAnchor {
-            file: &inv.decl_site.module,
+            file: &inv.decl_site().module,
             span: inv.options_span,
         };
         match validate_options(&descriptor, supplied, anchor) {
@@ -1410,7 +1421,7 @@ where
 }
 
 fn invocation_id(inv: &Invocation) -> String {
-    inv.decl_site.synthetic_id.clone()
+    inv.decl_site().synthetic_id.clone()
 }
 
 fn emit_metadata_load_warning<H: CompilerHost>(
@@ -1494,13 +1505,13 @@ mod tests {
 
         fn sample_invocation() -> Invocation {
             Invocation {
-                decl_site: DeclSite {
+                decl_sites: vec![DeclSite {
                     module: "src/main.wado".to_string(),
+                    source: InvocationPath::normalize("./schema.proto"),
                     synthetic_id: "kiln-proto".to_string(),
-                },
+                }],
                 module: GeneratorModule::Spec("ns:proto@1.0.0".into()),
                 from: InvocationPath::normalize("schema.proto"),
-                source: InvocationPath::normalize("./schema.proto"),
                 inputs: vec![InvocationPath::normalize("dep.proto")],
                 output_dir: InvocationPath::normalize("build/kiln/proto"),
                 options: wado_compiler::kiln::CanonicalOptions::default(),
@@ -1724,13 +1735,13 @@ mod tests {
 
         fn sample_invocation() -> Invocation {
             Invocation {
-                decl_site: DeclSite {
+                decl_sites: vec![DeclSite {
                     module: "src/main.wado".to_string(),
+                    source: InvocationPath::normalize("./schema.proto"),
                     synthetic_id: "kiln-proto".to_string(),
-                },
+                }],
                 module: GeneratorModule::Spec("ns:proto@1.0.0".into()),
                 from: InvocationPath::normalize("schema.proto"),
-                source: InvocationPath::normalize("./schema.proto"),
                 inputs: vec![InvocationPath::normalize("dep.proto")],
                 output_dir: InvocationPath::normalize("build/kiln/proto"),
                 options: wado_compiler::kiln::CanonicalOptions::default(),

--- a/wado-cli/tests/integration/kiln_multi_file.rs
+++ b/wado-cli/tests/integration/kiln_multi_file.rs
@@ -2,7 +2,7 @@
 //!
 //! A path written in a `.wado` file (`from`, `generator.inputs`,
 //! `generator.output_dir`) must resolve relative to that file — the same rule
-//! every other Wado path follows. These tests pin two consequences:
+//! every other Wado path follows. These tests pin three consequences:
 //!
 //! 1. A consumer in a subdirectory reads *its own* sibling schema, not a
 //!    same-named file at the project root.
@@ -10,6 +10,8 @@
 //!    "./grammar.g4"` get distinct default `output_dir`s instead of clobbering
 //!    each other (the original collision the `output_dir` override worked
 //!    around).
+//! 3. Two consumers that do name one schema share its invocation, and each
+//!    still resolves its own import through it.
 
 use std::fs;
 
@@ -19,7 +21,8 @@ use predicates::prelude::*;
 /// A pass-through generator: it emits the primary schema's contents verbatim as
 /// the entry module, so the grammar file *is* the generated Wado source. This
 /// makes a cross-read (reading the wrong sibling) observable as a wrong return
-/// value.
+/// value. It cannot show a *missing* redirect, though: the loader then parses
+/// the grammar as Wado and gets the same result.
 const PASSTHROUGH_GENERATOR: &str = r#"use { Request, Response, OutputFile, Error } from "core:kiln";
 
 export fn generate(req: Request) -> Result<Response, Error> {
@@ -106,12 +109,11 @@ fn sibling_consumers_resolve_their_own_schema() {
 }
 
 /// Two modules declaring the same clause for the same schema collapse into one
-/// invocation — the generator runs once — but each of them still imports
-/// through it, so each needs its own redirect (WEP 2026-04-12 §"Use-site
-/// syntax").
+/// invocation, so the generator runs once. Each still imports through it, so
+/// each needs its own redirect (WEP 2026-04-12 §"Use-site syntax").
 ///
-/// The schema is not valid Wado on its own, so a module left unredirected fails
-/// to compile instead of accidentally parsing its schema as source.
+/// The schema here is not valid Wado, so a module left unredirected fails to
+/// compile rather than parsing its schema as source and passing by accident.
 #[test]
 fn two_modules_sharing_one_schema_both_redirect() {
     let tmp = tempfile::tempdir().unwrap();

--- a/wado-cli/tests/integration/kiln_multi_file.rs
+++ b/wado-cli/tests/integration/kiln_multi_file.rs
@@ -105,6 +105,78 @@ fn sibling_consumers_resolve_their_own_schema() {
     );
 }
 
+/// Two modules declaring the same clause for the same schema collapse into one
+/// invocation — the generator runs once — but each of them still imports
+/// through it, so each needs its own redirect (WEP 2026-04-12 §"Use-site
+/// syntax").
+///
+/// The schema is not valid Wado on its own, so a module left unredirected fails
+/// to compile instead of accidentally parsing its schema as source.
+#[test]
+fn two_modules_sharing_one_schema_both_redirect() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    fs::write(
+        root.join("wado.toml"),
+        "[package]\nname = \"shared\"\nversion = \"0.1.0\"\n\n[world]\n\"wasi:cli/command\" = \"src/main.wado\"\n",
+    )
+    .unwrap();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/gen.wado"),
+        r#"use { Request, Response, OutputFile, Error } from "core:kiln";
+
+export fn generate(req: Request) -> Result<Response, Error> {
+    return Result::Ok(Response {
+        files: [OutputFile {
+            path: "out.wado",
+            content: `pub fn hello() -> i32 { return ${req.primary.content.trim()}; }`,
+            is_entry: true,
+        }],
+    });
+}
+"#,
+    )
+    .unwrap();
+    fs::write(root.join("src/grammar.g4"), "1\n").unwrap();
+
+    let consumer = |name: &str| {
+        format!(
+            "use {{ hello }} from \"./grammar.g4\"\n    with {{ generator: {{ module: \"./gen.wado\" }} }};\n\npub fn {name}() -> i32 {{ return hello(); }}\n"
+        )
+    };
+    fs::write(root.join("src/first.wado"), consumer("v1")).unwrap();
+    fs::write(root.join("src/second.wado"), consumer("v2")).unwrap();
+    fs::write(
+        root.join("src/main.wado"),
+        r#"use { println, Stdout } from "core:cli";
+use { v1 } from "./first.wado";
+use { v2 } from "./second.wado";
+
+export fn run() with Stdout {
+    println(`${v1() + v2()}`);
+}
+"#,
+    )
+    .unwrap();
+
+    wado_in(root)
+        .args(["run", "src/main.wado"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("2"));
+
+    let out_files: Vec<_> = walk(&root.join("build/kiln"))
+        .into_iter()
+        .filter(|p| p.file_name().is_some_and(|n| n == "out.wado"))
+        .collect();
+    assert_eq!(
+        out_files.len(),
+        1,
+        "one schema, one clause: the generator runs once, got {out_files:?}"
+    );
+}
+
 #[test]
 fn explicit_output_dir_is_relative_to_declaring_file() {
     let tmp = tempfile::tempdir().unwrap();

--- a/wado-cli/tests/integration/kiln_pipeline.rs
+++ b/wado-cli/tests/integration/kiln_pipeline.rs
@@ -133,13 +133,13 @@ fn invocation(
     output_dir: &str,
 ) -> Invocation {
     Invocation {
-        decl_site: DeclSite {
+        decl_sites: vec![DeclSite {
             module: decl_file.to_string(),
+            source: InvocationPath::normalize(from),
             synthetic_id: synthetic_id.to_string(),
-        },
+        }],
         module,
         from: InvocationPath::normalize(from),
-        source: InvocationPath::normalize(from),
         inputs: vec![],
         output_dir: InvocationPath::normalize(output_dir),
         options: wado_compiler::kiln::CanonicalOptions::default(),
@@ -289,7 +289,7 @@ fn each_invocation_writes_its_own_metadata_file() {
     run(&m, tmp.path(), &host, &provider, invs.clone());
 
     for inv in &invs {
-        let id = inv.decl_site.synthetic_id.as_str();
+        let id = inv.decl_site().synthetic_id.as_str();
         let meta = kiln_metadata::load(tmp.path(), inv.output_dir.as_str(), inv.from.as_str())
             .unwrap()
             .unwrap_or_else(|| panic!("missing metadata for {id}"));
@@ -389,13 +389,13 @@ fn pipeline_invocations_feed_compiler_options_for_use_redirect() {
     let m = empty_manifest();
 
     let inline_inv = Invocation {
-        decl_site: DeclSite {
+        decl_sites: vec![DeclSite {
             module: "entry.wado".to_string(),
+            source: InvocationPath::normalize("./schema.proto"),
             synthetic_id: "kiln-abc12345".to_string(),
-        },
+        }],
         module: GeneratorModule::LocalPath(InvocationPath::normalize("../gen")),
         from: InvocationPath::normalize("./schema.proto"),
-        source: InvocationPath::normalize("./schema.proto"),
         inputs: vec![],
         output_dir: InvocationPath::normalize("build/kiln/kiln-abc12345"),
         options: wado_compiler::kiln::CanonicalOptions::default(),
@@ -452,13 +452,13 @@ fn inline_invocation_populates_invocation_index_for_redirect() {
     let m = empty_manifest();
 
     let inline_inv = Invocation {
-        decl_site: DeclSite {
+        decl_sites: vec![DeclSite {
             module: "entry.wado".to_string(),
+            source: InvocationPath::normalize("./sample.proto"),
             synthetic_id: "kiln-deadbeef".to_string(),
-        },
+        }],
         module: GeneratorModule::LocalPath(InvocationPath::normalize("../gen")),
         from: InvocationPath::normalize("./sample.proto"),
-        source: InvocationPath::normalize("./sample.proto"),
         inputs: vec![],
         output_dir: InvocationPath::normalize("build/kiln/kiln-deadbeef"),
         options: wado_compiler::kiln::CanonicalOptions::default(),

--- a/wado-compiler/src/kiln.rs
+++ b/wado-compiler/src/kiln.rs
@@ -5,6 +5,7 @@
 //! files and maintains `wado.lock` lives in `wado-cli` and consumes these.
 
 pub mod cache;
+pub mod harvest;
 pub mod header;
 pub mod import_check;
 pub mod inline;
@@ -19,6 +20,7 @@ pub use cache::{
     encode_options_canonical, file_hash, gather_file_hashes, generator_identity,
     hash_options_canonical, hex_digest,
 };
+pub use harvest::{Harvest, harvest_module_graph, remap_decl_files};
 pub use header::{GeneratedHeader, has_generated_marker, parse_header};
 pub use inline::{InvocationIndex, collect_inline_invocations};
 pub use invocation::{

--- a/wado-compiler/src/kiln/cache.rs
+++ b/wado-compiler/src/kiln/cache.rs
@@ -376,13 +376,13 @@ mod tests {
     #[test]
     fn gather_file_hashes_threads_errors() {
         let inv = Invocation {
-            decl_site: DeclSite {
+            decl_sites: vec![DeclSite {
                 module: "src/main.wado".to_string(),
+                source: InvocationPath::normalize("./schema.proto"),
                 synthetic_id: "kiln-proto".to_string(),
-            },
+            }],
             module: GeneratorModule::Spec("ns:p@1.0.0".into()),
             from: InvocationPath::normalize("schema.proto"),
-            source: InvocationPath::normalize("./schema.proto"),
             inputs: vec![InvocationPath::normalize("dep.proto")],
             output_dir: InvocationPath::normalize("build/kiln/proto"),
             options: crate::kiln::options_check::CanonicalOptions::default(),

--- a/wado-compiler/src/kiln/harvest.rs
+++ b/wado-compiler/src/kiln/harvest.rs
@@ -22,14 +22,18 @@ pub struct Harvest {
     pub identities: IndexMap<String, String>,
 }
 
-/// Walk the local module graph from `entry_key`, parsing every `./` / `../`
-/// `.wado` import reachable from it and reading each through `load`.
+/// Walk the local module graph from `entry_key` and `entry_ast`, parsing every
+/// `./` / `../` `.wado` import reachable from them.
 ///
-/// `entry_ast` supplies the entry's already-parsed tree (the LSP's editor
-/// buffer, which `load` cannot see); `None` loads it like any other module. A
-/// module that fails to load, or whose parse recovered from an error, is
+/// `load` receives the loader identity of a module, the key
+/// [`crate::loader`] reads it under, so a host that matches paths exactly
+/// serves this walk and the loader from one set of keys. The caller supplies
+/// the entry's tree because the loader does not read the entry through a host
+/// either.
+///
+/// A module that fails to load, or whose parse recovered from an error, is
 /// skipped: a mid-edit source must not trigger codegen side effects.
-pub async fn harvest_module_graph<L>(entry_key: &str, entry_ast: Option<Module>, load: L) -> Harvest
+pub async fn harvest_module_graph<L>(entry_key: &str, entry_ast: Module, load: L) -> Harvest
 where
     L: AsyncFn(&str) -> Option<String>,
 {
@@ -42,8 +46,11 @@ where
     // resolve time — do not normalize it here.
     identities.insert(entry_key.to_string(), entry_key.to_string());
 
-    let mut queue: VecDeque<(String, String, Option<Module>)> =
-        VecDeque::from([(entry_key.to_string(), entry_key.to_string(), entry_ast)]);
+    let mut queue: VecDeque<(String, String, Option<Module>)> = VecDeque::from([(
+        entry_key.to_string(),
+        entry_key.to_string(),
+        Some(entry_ast),
+    )]);
     while let Some((key, loader_id, ast)) = queue.pop_front() {
         if modules.contains_key(&key) {
             continue;
@@ -51,7 +58,7 @@ where
         let ast = if let Some(ast) = ast {
             ast
         } else {
-            let Some(source) = load(&key).await else {
+            let Some(source) = load(&loader_id).await else {
                 continue;
             };
             let Ok(parsed) = crate::parse(&source).into_fail_fast() else {
@@ -152,19 +159,37 @@ mod tests {
         futures::executor::block_on(future)
     }
 
-    #[test]
-    fn walks_past_the_entry_into_imported_modules() {
-        let sources = [
-            ("src/main.wado", "use { a } from \"./lib.wado\";\n"),
-            ("src/lib.wado", "use { b } from \"./deep/util.wado\";\n"),
-            ("src/deep/util.wado", "pub fn b() {}\n"),
-        ];
-        let harvest = block_on(harvest_module_graph("src/main.wado", None, async |path| {
-            sources
+    fn parse(source: &str) -> Module {
+        crate::parse(source).ast
+    }
+
+    /// A host that matches its keys exactly, as the in-memory hosts do.
+    /// `FilesystemCompilerHost` would answer either spelling, and would hide a
+    /// walk that asks under keys the loader never uses.
+    fn exact(
+        sources: &'static [(&'static str, &'static str)],
+    ) -> impl AsyncFn(&str) -> Option<String> {
+        move |path: &str| {
+            let hit = sources
                 .iter()
                 .find(|(p, _)| *p == path)
-                .map(|(_, s)| (*s).to_string())
-        }));
+                .map(|(_, s)| (*s).to_string());
+            async move { hit }
+        }
+    }
+
+    #[test]
+    fn walks_past_the_entry_into_imported_modules() {
+        // Keyed the way the loader reads them: entry-dir-relative identities.
+        let sources: &[(&str, &str)] = &[
+            ("./lib.wado", "use { b } from \"./deep/util.wado\";\n"),
+            ("./deep/util.wado", "pub fn b() {}\n"),
+        ];
+        let harvest = block_on(harvest_module_graph(
+            "src/main.wado",
+            parse("use { a } from \"./lib.wado\";\n"),
+            exact(sources),
+        ));
 
         assert_eq!(
             harvest.modules.keys().collect::<Vec<_>>(),
@@ -180,16 +205,12 @@ mod tests {
 
     #[test]
     fn a_cycle_terminates() {
-        let sources = [
-            ("src/a.wado", "use { x } from \"./b.wado\";\n"),
-            ("src/b.wado", "use { y } from \"./a.wado\";\n"),
-        ];
-        let harvest = block_on(harvest_module_graph("src/a.wado", None, async |path| {
-            sources
-                .iter()
-                .find(|(p, _)| *p == path)
-                .map(|(_, s)| (*s).to_string())
-        }));
+        let sources: &[(&str, &str)] = &[("./b.wado", "use { y } from \"./a.wado\";\n")];
+        let harvest = block_on(harvest_module_graph(
+            "src/a.wado",
+            parse("use { x } from \"./b.wado\";\n"),
+            exact(sources),
+        ));
 
         assert_eq!(harvest.modules.len(), 2);
         // The back-reference keeps the entry's pinned identity.
@@ -272,7 +293,7 @@ mod tests {
     fn an_unloadable_module_is_skipped_not_fatal() {
         let harvest = block_on(harvest_module_graph(
             "main.wado",
-            Some(crate::parse("use { a } from \"./missing.wado\";\n").ast),
+            parse("use { a } from \"./missing.wado\";\n"),
             async |_| None,
         ));
 

--- a/wado-compiler/src/kiln/harvest.rs
+++ b/wado-compiler/src/kiln/harvest.rs
@@ -1,0 +1,296 @@
+//! The module-graph walk that finds every inline `with { generator }` clause.
+//!
+//! Kiln's unit is the module, not the entry: a clause in an imported module
+//! produces a generated module for that module's own imports (WEP 2026-04-12
+//! §"The loader redirect"). One walk serves every host — the CLI reads through
+//! the filesystem, the LSP through `CompilerHost` — so the two cannot disagree
+//! about which clauses exist.
+
+use std::collections::VecDeque;
+
+use crate::ast::{Item, Module};
+use crate::compiler_host::{Code, Diagnostic, Severity};
+use crate::hashmap::IndexMap;
+use crate::kiln::inline::InvocationIndex;
+use crate::name::{
+    canonical_local_path, module_parent_dir, normalize_module_path, resolve_local_identity,
+    resolve_module_path,
+};
+
+/// Every module the walk reached, keyed by the path it was reached through,
+/// plus the loader identity each key resolves to.
+pub struct Harvest {
+    /// Module path (as the walk reached it) → parsed AST, entry first.
+    pub modules: IndexMap<String, Module>,
+    /// Module path → the identity the loader resolves that module under, which
+    /// is what an [`InvocationIndex`] key must be ([`remap_decl_files`]).
+    pub identities: IndexMap<String, String>,
+}
+
+/// Walk the local module graph from `entry_key`, parsing every `./` / `../`
+/// `.wado` import reachable from it.
+///
+/// `entry_ast` supplies the entry's already-parsed tree (the LSP's editor
+/// buffer, which `load` cannot see); `None` loads it like any other module.
+/// `load` reads a module by the path this walk resolved for it. A module that
+/// fails to load, or whose parse recovered from an error, is skipped: a
+/// mid-edit source must not trigger codegen side effects.
+pub async fn harvest_module_graph<L>(entry_key: &str, entry_ast: Option<Module>, load: L) -> Harvest
+where
+    L: AsyncFn(&str) -> Option<String>,
+{
+    let mut modules = IndexMap::<String, Module>::default();
+    let mut identities = IndexMap::<String, String>::default();
+
+    let entry_dir = module_parent_dir(entry_key).to_string();
+    // The entry's key must stay byte-identical to its `EntryPoint.filename`
+    // (interned verbatim by the loader), so the redirect it keys is found at
+    // resolve time — do not normalize it here.
+    identities.insert(entry_key.to_string(), entry_key.to_string());
+
+    // (key, loader identity, pre-parsed AST, is_entry)
+    let mut queue: VecDeque<(String, String, Option<Module>, bool)> = VecDeque::from([(
+        entry_key.to_string(),
+        entry_key.to_string(),
+        entry_ast,
+        true,
+    )]);
+    while let Some((key, loader_id, ast, is_entry)) = queue.pop_front() {
+        if modules.contains_key(&key) {
+            continue;
+        }
+        let ast = if let Some(ast) = ast {
+            ast
+        } else {
+            let Some(source) = load(&key).await else {
+                continue;
+            };
+            let Ok(parsed) = crate::parse(&source).into_fail_fast() else {
+                continue;
+            };
+            parsed.ast
+        };
+
+        for import in local_wado_imports(&ast) {
+            let child_key = resolve_module_path(&key, import);
+            // Must match the loader's identity derivation (entry vs deeper).
+            let child_loader_id = if is_entry {
+                canonical_local_path(&entry_dir, &normalize_module_path(import))
+            } else {
+                resolve_local_identity(&entry_dir, &loader_id, import)
+            };
+            // Don't overwrite the entry's pinned identity (back-refs fold to it).
+            if child_key != entry_key {
+                identities.insert(child_key.clone(), child_loader_id.clone());
+            }
+            if !modules.contains_key(&child_key) {
+                queue.push_back((child_key, child_loader_id, None, false));
+            }
+        }
+        modules.insert(key, ast);
+    }
+
+    Harvest {
+        modules,
+        identities,
+    }
+}
+
+/// The `./` / `../` `.wado` imports of `module`. Non-`.wado` sources are the
+/// Kiln schemas themselves, and `core:` / `wasi:` / dependency specifiers name
+/// no module in this graph.
+fn local_wado_imports(module: &Module) -> impl Iterator<Item = &str> {
+    module.items.iter().filter_map(|item| {
+        let Item::Use(use_decl) = item else {
+            return None;
+        };
+        let src = use_decl.source.as_str();
+        ((src.starts_with("./") || src.starts_with("../"))
+            && src.to_ascii_lowercase().ends_with(".wado"))
+        .then_some(src)
+    })
+}
+
+/// Rewrite `index`'s `decl_file` keys from harvest keys to loader identities
+/// (keys absent from `identities` pass through), so the loader's lookup —
+/// which asks under the identity it resolved the declaring module by — hits.
+///
+/// Returns a diagnostic for each *conflict* — two keys resolving to the same
+/// `(loader_identity, from)` but different targets — instead of silently
+/// dropping a redirect (last-write-wins); matching targets are a harmless
+/// duplicate. Unreachable with canonical identities; guards against a future
+/// identity-scheme regression.
+#[must_use]
+pub fn remap_decl_files(
+    index: &mut InvocationIndex,
+    identities: &IndexMap<String, String>,
+) -> Vec<Diagnostic> {
+    let rewritten: Vec<(String, String, String)> = index
+        .entries()
+        .map(|(decl, from, uri)| {
+            let decl = identities.get(decl).map_or(decl, String::as_str);
+            (decl.to_string(), from.to_string(), uri.to_string())
+        })
+        .collect();
+
+    let mut diagnostics = Vec::new();
+    let mut fresh = InvocationIndex::new();
+    for (decl, from, uri) in rewritten {
+        // `redirect` normalizes `from` identically to `insert`, so this sees
+        // the key `insert` would write.
+        if let Some(existing) = fresh.redirect(&decl, &from)
+            && existing != uri
+        {
+            diagnostics.push(Diagnostic {
+                severity: Severity::Error,
+                code: Code::KilnRedirectConflict,
+                message: format!(
+                    "kiln: two generator invocations for `use ... from {from:?}` in `{decl}` \
+                     redirect to different generated modules (`{existing}` and `{uri}`); \
+                     a module cannot resolve one import to two generated entries",
+                ),
+                span: None,
+            });
+            continue;
+        }
+        fresh.insert(&decl, &from, &uri);
+    }
+    *index = fresh;
+    diagnostics
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn block_on<F: Future>(future: F) -> F::Output {
+        futures::executor::block_on(future)
+    }
+
+    #[test]
+    fn walks_past_the_entry_into_imported_modules() {
+        let sources = [
+            ("src/main.wado", "use { a } from \"./lib.wado\";\n"),
+            ("src/lib.wado", "use { b } from \"./deep/util.wado\";\n"),
+            ("src/deep/util.wado", "pub fn b() {}\n"),
+        ];
+        let harvest = block_on(harvest_module_graph("src/main.wado", None, async |path| {
+            sources
+                .iter()
+                .find(|(p, _)| *p == path)
+                .map(|(_, s)| (*s).to_string())
+        }));
+
+        assert_eq!(
+            harvest.modules.keys().collect::<Vec<_>>(),
+            ["src/main.wado", "src/lib.wado", "src/deep/util.wado"],
+        );
+        // Identities are anchored on the entry's directory, which is what the
+        // loader names a local module by (`Loader::resolve_import`).
+        assert_eq!(
+            harvest.identities.get("src/deep/util.wado").unwrap(),
+            "./deep/util.wado",
+        );
+    }
+
+    #[test]
+    fn a_cycle_terminates() {
+        let sources = [
+            ("src/a.wado", "use { x } from \"./b.wado\";\n"),
+            ("src/b.wado", "use { y } from \"./a.wado\";\n"),
+        ];
+        let harvest = block_on(harvest_module_graph("src/a.wado", None, async |path| {
+            sources
+                .iter()
+                .find(|(p, _)| *p == path)
+                .map(|(_, s)| (*s).to_string())
+        }));
+
+        assert_eq!(harvest.modules.len(), 2);
+        // The back-reference keeps the entry's pinned identity.
+        assert_eq!(harvest.identities.get("src/a.wado").unwrap(), "src/a.wado");
+    }
+
+    #[test]
+    fn remap_swaps_a_harvest_key_for_its_loader_identity() {
+        let mut idx = InvocationIndex::new();
+        idx.insert(
+            "/abs/example/eval.wado",
+            "./Arith.g4",
+            "kiln:file:///g/arith.wado",
+        );
+
+        let mut identities = IndexMap::default();
+        identities.insert(
+            "/abs/example/eval.wado".to_string(),
+            "./eval.wado".to_string(),
+        );
+
+        let conflicts = remap_decl_files(&mut idx, &identities);
+        assert!(conflicts.is_empty(), "no conflict for a single mapping");
+
+        assert!(
+            idx.redirect("/abs/example/eval.wado", "./Arith.g4")
+                .is_none(),
+            "the harvest-key decl_file must no longer redirect"
+        );
+        assert_eq!(
+            idx.redirect("./eval.wado", "./Arith.g4"),
+            Some("kiln:file:///g/arith.wado"),
+            "the loader identity must redirect to the same URI"
+        );
+    }
+
+    // Two keys collapsing onto one `(identity, from)` with different targets
+    // must be reported, not silently resolved last-write-wins (#1423).
+    #[test]
+    fn remap_reports_a_conflict_on_identity_collision() {
+        let mut idx = InvocationIndex::new();
+        idx.insert("/abs/a.wado", "./G.g4", "kiln:file:///g/from_a.wado");
+        idx.insert("/abs/b.wado", "./G.g4", "kiln:file:///g/from_b.wado");
+
+        let mut identities = IndexMap::default();
+        identities.insert("/abs/a.wado".to_string(), "./shared.wado".to_string());
+        identities.insert("/abs/b.wado".to_string(), "./shared.wado".to_string());
+
+        let conflicts = remap_decl_files(&mut idx, &identities);
+        assert_eq!(conflicts.len(), 1, "the collision must be reported");
+        assert_eq!(conflicts[0].code, Code::KilnRedirectConflict);
+        assert_eq!(conflicts[0].severity, Severity::Error);
+        // The first redirect survives; the conflicting second is dropped.
+        assert_eq!(
+            idx.redirect("./shared.wado", "./G.g4"),
+            Some("kiln:file:///g/from_a.wado"),
+        );
+    }
+
+    // Same identity *and* target is a benign duplicate: no diagnostic.
+    #[test]
+    fn remap_allows_a_duplicate_with_an_identical_target() {
+        let mut idx = InvocationIndex::new();
+        idx.insert("/abs/a.wado", "./G.g4", "kiln:file:///g/shared.wado");
+        idx.insert("/abs/b.wado", "./G.g4", "kiln:file:///g/shared.wado");
+
+        let mut identities = IndexMap::default();
+        identities.insert("/abs/a.wado".to_string(), "./shared.wado".to_string());
+        identities.insert("/abs/b.wado".to_string(), "./shared.wado".to_string());
+
+        let conflicts = remap_decl_files(&mut idx, &identities);
+        assert!(conflicts.is_empty(), "identical target is not a conflict");
+        assert_eq!(
+            idx.redirect("./shared.wado", "./G.g4"),
+            Some("kiln:file:///g/shared.wado"),
+        );
+    }
+
+    #[test]
+    fn an_unloadable_module_is_skipped_not_fatal() {
+        let harvest = block_on(harvest_module_graph(
+            "main.wado",
+            Some(crate::parse("use { a } from \"./missing.wado\";\n").ast),
+            async |_| None,
+        ));
+
+        assert_eq!(harvest.modules.keys().collect::<Vec<_>>(), ["main.wado"]);
+    }
+}

--- a/wado-compiler/src/kiln/harvest.rs
+++ b/wado-compiler/src/kiln/harvest.rs
@@ -1,10 +1,5 @@
-//! The module-graph walk that finds every inline `with { generator }` clause.
-//!
-//! Kiln's unit is the module, not the entry: a clause in an imported module
-//! produces a generated module for that module's own imports (WEP 2026-04-12
-//! §"The loader redirect"). One walk serves every host — the CLI reads through
-//! the filesystem, the LSP through `CompilerHost` — so the two cannot disagree
-//! about which clauses exist.
+//! The module-graph walk behind every inline `with { generator }` clause.
+//! Kiln's unit is the module, not the entry, and one walk serves every host.
 
 use std::collections::VecDeque;
 
@@ -16,11 +11,11 @@ use crate::name::{
     canonical_local_path, module_parent_dir, normalize_module_path, resolve_local_identity,
     resolve_module_path,
 };
+use crate::path::is_cwd_relative;
 
-/// Every module the walk reached, keyed by the path it was reached through,
-/// plus the loader identity each key resolves to.
+/// Every module the walk reached, keyed by the path it was reached through.
 pub struct Harvest {
-    /// Module path (as the walk reached it) → parsed AST, entry first.
+    /// Module path → parsed AST, entry first.
     pub modules: IndexMap<String, Module>,
     /// Module path → the identity the loader resolves that module under, which
     /// is what an [`InvocationIndex`] key must be ([`remap_decl_files`]).
@@ -28,13 +23,12 @@ pub struct Harvest {
 }
 
 /// Walk the local module graph from `entry_key`, parsing every `./` / `../`
-/// `.wado` import reachable from it.
+/// `.wado` import reachable from it and reading each through `load`.
 ///
 /// `entry_ast` supplies the entry's already-parsed tree (the LSP's editor
-/// buffer, which `load` cannot see); `None` loads it like any other module.
-/// `load` reads a module by the path this walk resolved for it. A module that
-/// fails to load, or whose parse recovered from an error, is skipped: a
-/// mid-edit source must not trigger codegen side effects.
+/// buffer, which `load` cannot see); `None` loads it like any other module. A
+/// module that fails to load, or whose parse recovered from an error, is
+/// skipped: a mid-edit source must not trigger codegen side effects.
 pub async fn harvest_module_graph<L>(entry_key: &str, entry_ast: Option<Module>, load: L) -> Harvest
 where
     L: AsyncFn(&str) -> Option<String>,
@@ -48,14 +42,9 @@ where
     // resolve time — do not normalize it here.
     identities.insert(entry_key.to_string(), entry_key.to_string());
 
-    // (key, loader identity, pre-parsed AST, is_entry)
-    let mut queue: VecDeque<(String, String, Option<Module>, bool)> = VecDeque::from([(
-        entry_key.to_string(),
-        entry_key.to_string(),
-        entry_ast,
-        true,
-    )]);
-    while let Some((key, loader_id, ast, is_entry)) = queue.pop_front() {
+    let mut queue: VecDeque<(String, String, Option<Module>)> =
+        VecDeque::from([(entry_key.to_string(), entry_key.to_string(), entry_ast)]);
+    while let Some((key, loader_id, ast)) = queue.pop_front() {
         if modules.contains_key(&key) {
             continue;
         }
@@ -73,8 +62,10 @@ where
 
         for import in local_wado_imports(&ast) {
             let child_key = resolve_module_path(&key, import);
-            // Must match the loader's identity derivation (entry vs deeper).
-            let child_loader_id = if is_entry {
+            // Must match the loader's identity derivation, which anchors an
+            // entry import on the entry directory and a deeper one on the
+            // importing module.
+            let child_loader_id = if key == entry_key {
                 canonical_local_path(&entry_dir, &normalize_module_path(import))
             } else {
                 resolve_local_identity(&entry_dir, &loader_id, import)
@@ -83,9 +74,7 @@ where
             if child_key != entry_key {
                 identities.insert(child_key.clone(), child_loader_id.clone());
             }
-            if !modules.contains_key(&child_key) {
-                queue.push_back((child_key, child_loader_id, None, false));
-            }
+            queue.push_back((child_key, child_loader_id, None));
         }
         modules.insert(key, ast);
     }
@@ -96,30 +85,26 @@ where
     }
 }
 
-/// The `./` / `../` `.wado` imports of `module`. Non-`.wado` sources are the
-/// Kiln schemas themselves, and `core:` / `wasi:` / dependency specifiers name
-/// no module in this graph.
+/// The `./` / `../` `.wado` imports of `module`. A non-`.wado` source is a Kiln
+/// schema, and a `core:` / `wasi:` / dependency specifier names no module here.
 fn local_wado_imports(module: &Module) -> impl Iterator<Item = &str> {
     module.items.iter().filter_map(|item| {
         let Item::Use(use_decl) = item else {
             return None;
         };
         let src = use_decl.source.as_str();
-        ((src.starts_with("./") || src.starts_with("../"))
-            && src.to_ascii_lowercase().ends_with(".wado"))
-        .then_some(src)
+        (is_cwd_relative(src) && src.to_ascii_lowercase().ends_with(".wado")).then_some(src)
     })
 }
 
-/// Rewrite `index`'s `decl_file` keys from harvest keys to loader identities
-/// (keys absent from `identities` pass through), so the loader's lookup —
-/// which asks under the identity it resolved the declaring module by — hits.
+/// Rewrite `index`'s `decl_file` keys from harvest keys to loader identities,
+/// which is what the loader asks under. Keys absent from `identities` pass
+/// through.
 ///
-/// Returns a diagnostic for each *conflict* — two keys resolving to the same
-/// `(loader_identity, from)` but different targets — instead of silently
-/// dropping a redirect (last-write-wins); matching targets are a harmless
-/// duplicate. Unreachable with canonical identities; guards against a future
-/// identity-scheme regression.
+/// Two keys landing on one `(identity, from)` with different targets is
+/// reported rather than resolved last-write-wins; an identical target is a
+/// harmless duplicate. Canonical identities make the conflict unreachable, so
+/// this guards against a future identity-scheme regression.
 #[must_use]
 pub fn remap_decl_files(
     index: &mut InvocationIndex,

--- a/wado-compiler/src/kiln/inline.rs
+++ b/wado-compiler/src/kiln/inline.rs
@@ -395,7 +395,7 @@ fn resolve_or_reject(
     use_decl: &UseDecl,
     errors: &mut Vec<Diagnostic>,
 ) -> InvocationPath {
-    if raw.starts_with("./") || raw.starts_with("../") {
+    if crate::path::is_cwd_relative(raw) {
         return resolve_decl_relative(module_path, raw, manifest_root);
     }
     errors.push(Diagnostic {
@@ -457,7 +457,7 @@ fn lower_module_specifier(
     // resulting `LocalPath` is reliably reachable from the consuming
     // project — the provider resolves it as `manifest_root.join(path)`
     // when reading the file on disk and computing a stable cache key.
-    if spec.starts_with("./") || spec.starts_with("../") {
+    if crate::path::is_cwd_relative(spec) {
         return Some(GeneratorModule::LocalPath(resolve_decl_relative(
             module_path,
             spec,

--- a/wado-compiler/src/kiln/inline.rs
+++ b/wado-compiler/src/kiln/inline.rs
@@ -92,14 +92,14 @@ impl InvocationIndex {
 /// entry validates and encodes the clause's `options` through the typed
 /// pipeline; a missing one yields an empty canonical blob.
 ///
-/// # Errors
-/// Diagnostics are batched, so one malformed clause does not stop the rest of
-/// the tree. `Err` only when at least one was `Severity::Error`.
+/// Returns what lowered alongside the diagnostics, so one malformed clause
+/// costs its own invocation and no other. A batch build refuses to proceed on
+/// an `Error`; an editor keeps the redirects it has.
 pub fn collect_inline_invocations<'a, I>(
     modules: I,
     descriptors: &IndexMap<String, OptionsDescriptor>,
     manifest_root: &str,
-) -> Result<Vec<Invocation>, Vec<Diagnostic>>
+) -> (Vec<Invocation>, Vec<Diagnostic>)
 where
     I: IntoIterator<Item = (&'a str, &'a Module)>,
 {
@@ -119,8 +119,14 @@ where
             match lower_inline(module_path, use_decl, gen_cfg, descriptors, manifest_root) {
                 Ok(invocation) => {
                     let tuple_key = identity_key(&invocation);
-                    if let Some(existing) = by_tuple.get(&tuple_key) {
-                        let _ = existing;
+                    if let Some(existing) = by_tuple.get_mut(&tuple_key) {
+                        // One invocation, one generator run — but every module
+                        // that declared it imports through it, so each keeps a
+                        // site to key its redirect by.
+                        let site = invocation.decl_site().clone();
+                        if !existing.decl_sites.contains(&site) {
+                            existing.decl_sites.push(site);
+                        }
                         continue;
                     }
                     let from_key = invocation.from.as_str().to_string();
@@ -149,10 +155,7 @@ where
         }
     }
 
-    if diagnostics.iter().any(|d| d.severity == Severity::Error) {
-        return Err(diagnostics);
-    }
-    Ok(by_tuple.into_iter().map(|(_, v)| v).collect())
+    (by_tuple.into_iter().map(|(_, v)| v).collect(), diagnostics)
 }
 
 fn use_decls_of(module: &Module) -> impl Iterator<Item = &UseDecl> {
@@ -355,13 +358,13 @@ fn lower_inline(
     });
 
     Ok(Invocation {
-        decl_site: DeclSite {
+        decl_sites: vec![DeclSite {
             module: module_path.to_string(),
+            source,
             synthetic_id,
-        },
+        }],
         module,
         from,
-        source,
         inputs,
         output_dir,
         options,
@@ -588,6 +591,26 @@ mod tests {
         Span::new(0, 0, 1, 1)
     }
 
+    /// The invocations of a collect that was meant to succeed.
+    fn expect_ok(collected: (Vec<Invocation>, Vec<Diagnostic>)) -> Vec<Invocation> {
+        let (invocations, diagnostics) = collected;
+        assert!(
+            diagnostics.is_empty(),
+            "expected a clean collect, got {diagnostics:#?}",
+        );
+        invocations
+    }
+
+    /// The diagnostics of a collect that was meant to reject a clause.
+    fn expect_errors(collected: (Vec<Invocation>, Vec<Diagnostic>)) -> Vec<Diagnostic> {
+        let (_, diagnostics) = collected;
+        assert!(
+            diagnostics.iter().any(|d| d.severity == Severity::Error),
+            "expected an error diagnostic, got {diagnostics:#?}",
+        );
+        diagnostics
+    }
+
     fn module_with_use(source: &str, attrs: ImportAttributes) -> Module {
         let use_decl = UseDecl {
             id: AstId::fresh(),
@@ -631,19 +654,18 @@ mod tests {
         let mut mods: IndexMap<String, Module> = IndexMap::default();
         mods.insert("src/main.wado".to_string(), module);
 
-        let result = collect_inline_invocations(
+        let result = expect_ok(collect_inline_invocations(
             mods.iter().map(|(k, v)| (k.as_str(), v)),
             &IndexMap::default(),
             "",
-        )
-        .unwrap();
+        ));
         assert_eq!(result.len(), 1);
         // `from` is resolved relative to the declaring file (`src/main.wado`).
         assert_eq!(result[0].from.as_str(), "src/schema.proto");
         // The literal source string is preserved for the loader redirect key.
-        assert_eq!(result[0].source.as_str(), "schema.proto");
+        assert_eq!(result[0].decl_site().source.as_str(), "schema.proto");
         assert_matches!(&result[0].module, GeneratorModule::Spec(s) if s.spec == "ns:gen@1.0.0");
-        assert_eq!(result[0].decl_site.module, "src/main.wado");
+        assert_eq!(result[0].decl_site().module, "src/main.wado");
     }
 
     #[test]
@@ -655,12 +677,11 @@ mod tests {
         let mut mods: IndexMap<String, Module> = IndexMap::default();
         mods.insert("src/main.wado".to_string(), module);
 
-        let result = collect_inline_invocations(
+        let result = expect_ok(collect_inline_invocations(
             mods.iter().map(|(k, v)| (k.as_str(), v)),
             &IndexMap::default(),
             "",
-        )
-        .unwrap();
+        ));
         assert_matches!(&result[0].module, GeneratorModule::Spec(s) if s.spec == "lib:gen");
     }
 
@@ -673,12 +694,11 @@ mod tests {
         let mut mods: IndexMap<String, Module> = IndexMap::default();
         mods.insert("src/main.wado".to_string(), module);
 
-        let errs = collect_inline_invocations(
+        let errs = expect_errors(collect_inline_invocations(
             mods.iter().map(|(k, v)| (k.as_str(), v)),
             &IndexMap::default(),
             "",
-        )
-        .unwrap_err();
+        ));
         assert!(
             errs.iter()
                 .any(|d| d.message.contains("bare name is not allowed")),
@@ -699,12 +719,11 @@ mod tests {
         let mut mods: IndexMap<String, Module> = IndexMap::default();
         mods.insert("src/main.wado".to_string(), module);
 
-        let result = collect_inline_invocations(
+        let result = expect_ok(collect_inline_invocations(
             mods.iter().map(|(k, v)| (k.as_str(), v)),
             &IndexMap::default(),
             "",
-        )
-        .unwrap();
+        ));
         match &result[0].module {
             GeneratorModule::Spec(s) => {
                 assert_eq!(s.spec, "wado-lang:gale");
@@ -726,12 +745,11 @@ mod tests {
         let mut mods: IndexMap<String, Module> = IndexMap::default();
         mods.insert("src/main.wado".to_string(), module);
 
-        let errs = collect_inline_invocations(
+        let errs = expect_errors(collect_inline_invocations(
             mods.iter().map(|(k, v)| (k.as_str(), v)),
             &IndexMap::default(),
             "",
-        )
-        .unwrap_err();
+        ));
         assert!(
             errs.iter().any(|d| d
                 .message
@@ -747,12 +765,11 @@ mod tests {
         let mut mods: IndexMap<String, Module> = IndexMap::default();
         mods.insert("src/main.wado".to_string(), module);
 
-        let errs = collect_inline_invocations(
+        let errs = expect_errors(collect_inline_invocations(
             mods.iter().map(|(k, v)| (k.as_str(), v)),
             &IndexMap::default(),
             "",
-        )
-        .unwrap_err();
+        ));
         assert!(
             errs.iter()
                 .any(|d| d.message.contains("requires a `module` field"))
@@ -770,12 +787,11 @@ mod tests {
         mods.insert("src/a.wado".to_string(), mk());
         mods.insert("src/b.wado".to_string(), mk());
 
-        let result = collect_inline_invocations(
+        let result = expect_ok(collect_inline_invocations(
             mods.iter().map(|(k, v)| (k.as_str(), v)),
             &IndexMap::default(),
             "",
-        )
-        .unwrap();
+        ));
         assert_eq!(result.len(), 1);
     }
 
@@ -793,13 +809,82 @@ mod tests {
         mods.insert("src/a.wado".to_string(), a);
         mods.insert("src/b.wado".to_string(), b);
 
-        let errs = collect_inline_invocations(
+        let errs = expect_errors(collect_inline_invocations(
             mods.iter().map(|(k, v)| (k.as_str(), v)),
             &IndexMap::default(),
             "",
-        )
-        .unwrap_err();
+        ));
         assert!(errs.iter().any(|d| d.message.contains("disagree")));
+    }
+
+    /// A malformed clause costs its own invocation and no other, so an editor
+    /// keeps the redirects it can still resolve.
+    #[test]
+    fn a_malformed_clause_leaves_the_others_standing() {
+        let good = module_with_use(
+            "./ok.proto",
+            attr_with_generator(&[("module", AttrValue::String("ns:gen@1.0.0".to_string()))]),
+        );
+        let bad = module_with_use(
+            "./broken.proto",
+            attr_with_generator(&[("module", AttrValue::String("gen".to_string()))]),
+        );
+        let mut mods: IndexMap<String, Module> = IndexMap::default();
+        mods.insert("src/good.wado".to_string(), good);
+        mods.insert("src/bad.wado".to_string(), bad);
+
+        let (invocations, diagnostics) = collect_inline_invocations(
+            mods.iter().map(|(k, v)| (k.as_str(), v)),
+            &IndexMap::default(),
+            "",
+        );
+
+        assert_eq!(invocations.len(), 1, "the sound clause still lowers");
+        assert_eq!(invocations[0].decl_site().module, "src/good.wado");
+        assert!(
+            diagnostics
+                .iter()
+                .any(|d| d.message.contains("bare name is not allowed")),
+            "{diagnostics:#?}"
+        );
+    }
+
+    /// Clauses that agree collapse to one invocation, but each declaring module
+    /// keeps a site: the redirect index is keyed per module, and two modules may
+    /// spell the same schema differently.
+    #[test]
+    fn identical_clauses_in_two_modules_keep_both_sites() {
+        let attrs =
+            attr_with_generator(&[("module", AttrValue::String("ns:gen@1.0.0".to_string()))]);
+        let mut mods: IndexMap<String, Module> = IndexMap::default();
+        mods.insert(
+            "src/a.wado".to_string(),
+            module_with_use("./schema.proto", attrs.clone()),
+        );
+        mods.insert(
+            "src/sub/b.wado".to_string(),
+            module_with_use("../schema.proto", attrs),
+        );
+
+        let result = expect_ok(collect_inline_invocations(
+            mods.iter().map(|(k, v)| (k.as_str(), v)),
+            &IndexMap::default(),
+            "",
+        ));
+
+        assert_eq!(result.len(), 1, "one schema, one generator run");
+        let sites: Vec<(&str, &str)> = result[0]
+            .decl_sites
+            .iter()
+            .map(|s| (s.module.as_str(), s.source.as_str()))
+            .collect();
+        assert_eq!(
+            sites,
+            [
+                ("src/a.wado", "schema.proto"),
+                ("src/sub/b.wado", "../schema.proto"),
+            ],
+        );
     }
 
     #[test]
@@ -810,12 +895,11 @@ mod tests {
         let mut mods: IndexMap<String, Module> = IndexMap::default();
         mods.insert("src/main.wado".to_string(), module);
 
-        let result = collect_inline_invocations(
+        let result = expect_ok(collect_inline_invocations(
             mods.iter().map(|(k, v)| (k.as_str(), v)),
             &IndexMap::default(),
             "",
-        )
-        .unwrap();
+        ));
         assert_eq!(result.len(), 1);
         match &result[0].module {
             GeneratorModule::LocalPath(p) => assert_eq!(p.as_str(), "gen.wado"),
@@ -834,15 +918,14 @@ mod tests {
         let mut mods: IndexMap<String, Module> = IndexMap::default();
         mods.insert("src/main.wado".to_string(), module);
 
-        let result = collect_inline_invocations(
+        let result = expect_ok(collect_inline_invocations(
             mods.iter().map(|(k, v)| (k.as_str(), v)),
             &IndexMap::default(),
             "",
-        )
-        .unwrap();
+        ));
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].output_dir.as_str(), "src/generated");
-        assert_eq!(result[0].source.as_str(), "schema.proto");
+        assert_eq!(result[0].decl_site().source.as_str(), "schema.proto");
     }
 
     #[test]
@@ -860,12 +943,11 @@ mod tests {
         let mut mods: IndexMap<String, Module> = IndexMap::default();
         mods.insert("tests/deep/nested/calc_test.wado".to_string(), module);
 
-        let errs = collect_inline_invocations(
+        let errs = expect_errors(collect_inline_invocations(
             mods.iter().map(|(k, v)| (k.as_str(), v)),
             &IndexMap::default(),
             "",
-        )
-        .unwrap_err();
+        ));
         assert!(errs.iter().any(|d| {
             d.message.contains("generator.output_dir")
                 && d.message
@@ -882,12 +964,11 @@ mod tests {
         let mut mods: IndexMap<String, Module> = IndexMap::default();
         mods.insert("src/main.wado".to_string(), module);
 
-        let errs = collect_inline_invocations(
+        let errs = expect_errors(collect_inline_invocations(
             mods.iter().map(|(k, v)| (k.as_str(), v)),
             &IndexMap::default(),
             "",
-        )
-        .unwrap_err();
+        ));
         assert!(
             errs.iter()
                 .any(|d| d.message.contains("`from` must be a relative path"))
@@ -904,12 +985,11 @@ mod tests {
         let mut mods: IndexMap<String, Module> = IndexMap::default();
         mods.insert("src/main.wado".to_string(), module);
 
-        let errs = collect_inline_invocations(
+        let errs = expect_errors(collect_inline_invocations(
             mods.iter().map(|(k, v)| (k.as_str(), v)),
             &IndexMap::default(),
             "",
-        )
-        .unwrap_err();
+        ));
         assert!(errs.iter().any(|d| {
             d.message
                 .contains("`generator.output_dir` must be a string")
@@ -1013,12 +1093,11 @@ mod tests {
         let mut mods: IndexMap<String, Module> = IndexMap::default();
         mods.insert("main.wado".to_string(), module);
 
-        let result = collect_inline_invocations(
+        let result = expect_ok(collect_inline_invocations(
             mods.iter().map(|(k, v)| (k.as_str(), v)),
             &IndexMap::default(),
             ".",
-        )
-        .unwrap();
+        ));
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].output_dir.as_str(), "generated");
         assert_eq!(result[0].from.as_str(), "schema.g4");

--- a/wado-compiler/src/kiln/inline.rs
+++ b/wado-compiler/src/kiln/inline.rs
@@ -55,6 +55,14 @@ impl InvocationIndex {
             .insert((decl_file.to_string(), from), entry_uri.to_string());
     }
 
+    /// Record `entry_uri` for every module that declared `invocation`, each
+    /// under the literal that module wrote.
+    pub fn insert_invocation(&mut self, invocation: &Invocation, entry_uri: &str) {
+        for site in &invocation.decl_sites {
+            self.insert(&site.module, site.source.as_str(), entry_uri);
+        }
+    }
+
     /// Look up the entry URI for a `(decl_file, from)` pair. Returns the
     /// opaque URI of the entry module, or `None` if no invocation
     /// matches.
@@ -105,7 +113,9 @@ where
 {
     let mut diagnostics: Vec<Diagnostic> = Vec::new();
     let mut by_tuple: IndexMap<String, Invocation> = IndexMap::default();
-    let mut by_from: IndexMap<String, (Invocation, String)> = IndexMap::default();
+    // `from` path → the identity key it resolved to, and the module that
+    // claimed it first.
+    let mut by_from: IndexMap<String, (String, String)> = IndexMap::default();
 
     for (module_path, module) in modules {
         for use_decl in use_decls_of(module) {
@@ -120,9 +130,6 @@ where
                 Ok(invocation) => {
                     let tuple_key = identity_key(&invocation);
                     if let Some(existing) = by_tuple.get_mut(&tuple_key) {
-                        // One invocation, one generator run — but every module
-                        // that declared it imports through it, so each keeps a
-                        // site to key its redirect by.
                         let site = invocation.decl_site().clone();
                         if !existing.decl_sites.contains(&site) {
                             existing.decl_sites.push(site);
@@ -130,8 +137,8 @@ where
                         continue;
                     }
                     let from_key = invocation.from.as_str().to_string();
-                    if let Some((prior, prior_mod)) = by_from.get(&from_key)
-                        && identity_key(prior) != tuple_key
+                    if let Some((prior_key, prior_mod)) = by_from.get(&from_key)
+                        && *prior_key != tuple_key
                     {
                         diagnostics.push(Diagnostic {
                             severity: Severity::Error,
@@ -147,8 +154,8 @@ where
                         });
                         continue;
                     }
-                    by_tuple.insert(tuple_key.clone(), invocation.clone());
-                    by_from.insert(from_key, (invocation, module_path.to_string()));
+                    by_from.insert(from_key, (tuple_key.clone(), module_path.to_string()));
+                    by_tuple.insert(tuple_key, invocation);
                 }
                 Err(mut errs) => diagnostics.append(&mut errs),
             }

--- a/wado-compiler/src/kiln/invocation.rs
+++ b/wado-compiler/src/kiln/invocation.rs
@@ -83,11 +83,17 @@ impl fmt::Display for InvocationPath {
 
 /// Where a generator invocation was declared in the source tree.
 ///
-/// Used for diagnostics; never part of the cache key.
+/// Never part of the cache key. `(module, source)` is the redirect key the
+/// loader looks an import up by.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DeclSite {
     /// Relative path of the Wado file containing the inline `with` clause.
     pub module: String,
+    /// The literal `from "<source>"` path as this clause wrote it, only
+    /// normalized. The loader matches `(decl_file, import_source)` without
+    /// resolving, so it must stay frame-independent — two modules may reach one
+    /// schema by different spellings.
+    pub source: InvocationPath,
     /// Synthesized id derived from the canonical invocation tuple.
     pub synthetic_id: String,
 }
@@ -176,18 +182,15 @@ impl GeneratorSpec {
 /// and `options_canonical` are byte-equal.
 #[derive(Debug, Clone)]
 pub struct Invocation {
-    pub decl_site: DeclSite,
+    /// Every clause that declared this invocation: agreeing clauses collapse so
+    /// the generator runs once, and each keeps the site its own redirect is
+    /// keyed by. Non-empty; the first is what diagnostics name.
+    pub decl_sites: Vec<DeclSite>,
     pub module: GeneratorModule,
     /// Primary schema file, resolved relative to the declaring `.wado` file
     /// (project-root-relative). Drives input loading, the cache key, and the
     /// default `output_dir`.
     pub from: InvocationPath,
-    /// The literal `from "<source>"` path as written, only normalized (not
-    /// resolved against the declaring file). Used solely as the loader-redirect
-    /// key: the loader matches `(decl_file, import_source)` against it without
-    /// resolving, so it must stay frame-independent. Excluded from
-    /// [`Invocation::identity_tuple`].
-    pub source: InvocationPath,
     /// Supplementary schema files, resolved relative to the declaring `.wado`
     /// file, preserving declaration order.
     pub inputs: Vec<InvocationPath>,
@@ -216,6 +219,18 @@ pub struct Invocation {
 }
 
 impl Invocation {
+    /// The site diagnostics name. Every site shares the synthesized id, which
+    /// is derived from the identity tuple.
+    ///
+    /// # Panics
+    /// If `decl_sites` is empty, which construction forbids.
+    #[must_use]
+    pub fn decl_site(&self) -> &DeclSite {
+        self.decl_sites
+            .first()
+            .expect("an invocation has at least one declaring site")
+    }
+
     /// Canonical byte encoding of [`Self::options`], for the invocation cache
     /// key and dedup identity. Deterministic and injective; not an interchange
     /// format (nothing decodes it — see
@@ -227,8 +242,8 @@ impl Invocation {
 
     /// The tuple used for dedup and cycle detection.
     ///
-    /// Does not include `decl_site`: two clauses in the same file with
-    /// identical invocation tuples merge into one invocation.
+    /// Does not include `decl_sites`: clauses with identical invocation tuples
+    /// merge into one invocation, wherever they were written.
     #[must_use]
     pub fn identity_tuple(&self) -> (&GeneratorModule, &str, &[InvocationPath], &str, Vec<u8>) {
         (
@@ -295,6 +310,7 @@ mod tests {
     fn decl_site_display_inline() {
         let site = DeclSite {
             module: "main.wado".to_string(),
+            source: InvocationPath::normalize("./s.proto"),
             synthetic_id: "kiln-deadbeef".to_string(),
         };
         assert_eq!(format!("{site}"), "main.wado (inline: kiln-deadbeef)");
@@ -303,13 +319,13 @@ mod tests {
     #[test]
     fn identity_tuple_ignores_decl_site() {
         let inv_a = Invocation {
-            decl_site: DeclSite {
+            decl_sites: vec![DeclSite {
                 module: "a.wado".to_string(),
+                source: InvocationPath::normalize("./s.proto"),
                 synthetic_id: "kiln-aaaa".to_string(),
-            },
+            }],
             module: GeneratorModule::Spec("ns:x@1.0.0".into()),
             from: InvocationPath::normalize("s.proto"),
-            source: InvocationPath::normalize("./s.proto"),
             inputs: vec![],
             output_dir: InvocationPath::normalize("build/kiln/a"),
             options: crate::kiln::options_check::CanonicalOptions::default(),
@@ -317,10 +333,11 @@ mod tests {
             options_span: crate::token::Span::default(),
         };
         let inv_b = Invocation {
-            decl_site: DeclSite {
+            decl_sites: vec![DeclSite {
                 module: "b.wado".to_string(),
+                source: InvocationPath::normalize("./s.proto"),
                 synthetic_id: "kiln-bbbb".to_string(),
-            },
+            }],
             ..inv_a.clone()
         };
         assert_eq!(inv_a.identity_tuple(), inv_b.identity_tuple());

--- a/wado-compiler/src/kiln/invocation.rs
+++ b/wado-compiler/src/kiln/invocation.rs
@@ -89,10 +89,9 @@ impl fmt::Display for InvocationPath {
 pub struct DeclSite {
     /// Relative path of the Wado file containing the inline `with` clause.
     pub module: String,
-    /// The literal `from "<source>"` path as this clause wrote it, only
-    /// normalized. The loader matches `(decl_file, import_source)` without
-    /// resolving, so it must stay frame-independent — two modules may reach one
-    /// schema by different spellings.
+    /// The literal `from "<source>"` this clause wrote, only normalized. The
+    /// loader matches it unresolved, so it stays frame-independent: two modules
+    /// may reach one schema by different spellings.
     pub source: InvocationPath,
     /// Synthesized id derived from the canonical invocation tuple.
     pub synthetic_id: String,

--- a/wado-compiler/src/kiln/plan.rs
+++ b/wado-compiler/src/kiln/plan.rs
@@ -80,11 +80,11 @@ fn dedup_invocations(invocations: Vec<Invocation>) -> Result<Vec<Invocation>, Pl
             continue;
         }
         let first = &invocations[indices[0]];
-        let mut sites = vec![first.decl_site.clone()];
+        let mut sites = vec![first.decl_site().clone()];
         let mut all_equal = true;
         for &i in &indices[1..] {
             let other = &invocations[i];
-            sites.push(other.decl_site.clone());
+            sites.push(other.decl_site().clone());
             if other.identity_tuple() != first.identity_tuple() {
                 all_equal = false;
             }
@@ -156,7 +156,7 @@ fn topo_sort(invocations: Vec<Invocation>) -> Result<Plan, PlanError> {
         // real cycle report fires in practice.
         let participants: Vec<DeclSite> = (0..n)
             .filter(|&i| !processed[i])
-            .map(|i| invocations[i].decl_site.clone())
+            .map(|i| invocations[i].decl_site().clone())
             .collect();
         return Err(PlanError::Cycle { participants });
     }
@@ -210,13 +210,13 @@ mod tests {
 
     fn inv(name: &str, from: &str, inputs: &[&str], out: &str) -> Invocation {
         Invocation {
-            decl_site: DeclSite {
+            decl_sites: vec![DeclSite {
                 module: format!("src/{name}.wado"),
+                source: InvocationPath::normalize(from),
                 synthetic_id: format!("kiln-{name}"),
-            },
+            }],
             module: GeneratorModule::Spec(format!("ns:{name}@1.0.0").into()),
             from: InvocationPath::normalize(from),
-            source: InvocationPath::normalize(from),
             inputs: inputs
                 .iter()
                 .map(|p| InvocationPath::normalize(p))
@@ -291,7 +291,7 @@ mod tests {
         let positions: Vec<_> = plan
             .order
             .iter()
-            .map(|i| i.decl_site.synthetic_id.clone())
+            .map(|i| i.decl_site().synthetic_id.clone())
             .collect();
         let producer_pos = positions.iter().position(|s| s == "kiln-producer").unwrap();
         let consumer_pos = positions.iter().position(|s| s == "kiln-consumer").unwrap();
@@ -343,7 +343,7 @@ mod tests {
     fn names(plan: &Plan) -> Vec<String> {
         plan.order
             .iter()
-            .map(|i| i.decl_site.synthetic_id.clone())
+            .map(|i| i.decl_site().synthetic_id.clone())
             .collect()
     }
 

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -17,6 +17,7 @@ use crate::logger::Logger;
 use crate::module_source::{CmNamespace, ModuleSource, ModuleSourceInterner, WasmAssetKind};
 use crate::name::{normalize_module_path, resolve_module_path};
 use crate::parser::Parser;
+use crate::path::is_cwd_relative;
 use crate::stdlib;
 
 /// Error that can occur during module loading
@@ -2120,13 +2121,6 @@ fn resolve_include_path_impl(
     } else {
         stripped.to_string()
     }
-}
-
-/// Wado's relative-path notation matches gitignore / shell convention:
-/// `./` is "next to me" and `../` is "up one". Anything else is interpreted
-/// by the host (`core:`, `wasi:`, absolute, ...) and is not our concern.
-fn is_cwd_relative(path: &str) -> bool {
-    path.starts_with("./") || path.starts_with("../")
 }
 
 /// Whether an include path keeps its module's directory as a prefix, or collapses

--- a/wado-compiler/src/path.rs
+++ b/wado-compiler/src/path.rs
@@ -75,6 +75,14 @@ fn split_root(path: &str) -> (String, &str) {
     (String::new(), path)
 }
 
+/// Wado's relative-path notation matches gitignore / shell convention:
+/// `./` is "next to me" and `../` is "up one". Anything else is interpreted
+/// by the host (`core:`, `wasi:`, absolute, ...) and is not our concern.
+#[must_use]
+pub fn is_cwd_relative(path: &str) -> bool {
+    path.starts_with("./") || path.starts_with("../")
+}
+
 /// Express `target` as a path relative to the directory `base`, lexically: after
 /// [`normalize`]ing both, the minimal `./`- or `../`-prefixed path that rejoins
 /// with `base` to give `target` back. `base` and `target` must share rootedness;

--- a/wado-lsp/src/kiln.rs
+++ b/wado-lsp/src/kiln.rs
@@ -42,33 +42,27 @@ pub async fn prepare_invocations<H: CompilerHost>(
     };
 
     // The entry's tree comes from the editor buffer; every module it imports is
-    // read through the host, as the loader will read them.
-    let harvest = harvest_module_graph(entry_filename, Some(entry_ast.clone()), async |path| {
-        let bytes = host.load_source(path).await.ok()?;
+    // read through the host, under the identity the loader will read it by.
+    let harvest = harvest_module_graph(entry_filename, entry_ast.clone(), async |identity| {
+        let bytes = host.load_source(identity).await.ok()?;
         String::from_utf8(bytes).ok()
     })
     .await;
 
     let descriptors = wado_compiler::hashmap::IndexMap::default();
     let manifest_root_str = manifest_root.to_string_lossy();
-    let invocations = match collect_inline_invocations(
+    // A malformed clause costs its own redirect and no other. Its diagnostic is
+    // reported here because the semantics pass never re-runs this collector; no
+    // double-emit risk, since this is the sole `collect` call on the LSP path
+    // and each snapshot builds once.
+    let (invocations, diagnostics) = collect_inline_invocations(
         harvest.modules.iter().map(|(k, ast)| (k.as_str(), ast)),
         &descriptors,
         &manifest_root_str,
-    ) {
-        Ok(v) => v,
-        // A malformed inline clause (e.g. a bare, non-`./` path) is reported
-        // here: the semantics pass never re-runs this collector, so emitting
-        // the diagnostics through the host is the only way they reach the
-        // editor. No double-emit risk — this is the sole `collect` call on the
-        // LSP path, and each snapshot builds once.
-        Err(diags) => {
-            for d in diags {
-                host.emit_diagnostic(d);
-            }
-            return override_index.unwrap_or_default();
-        }
-    };
+    );
+    for diagnostic in diagnostics {
+        host.emit_diagnostic(diagnostic);
+    }
 
     options::check_all(&invocations, &manifest_root, host).await;
 
@@ -78,22 +72,24 @@ pub async fn prepare_invocations<H: CompilerHost>(
 
     let mut index = InvocationIndex::new();
     for invocation in &invocations {
-        let invocation_id = &invocation.decl_site.synthetic_id;
-        let decl_file = invocation.decl_site.module.as_str();
-        match resolve_invocation(&manifest_root, invocation, host).await {
-            Ok(entry_uri) => {
-                // Key by the literal `from "<source>"` string: the loader looks
-                // up redirects with the unresolved import path, while
-                // `invocation.from` is resolved relative to the declaring file.
-                index.insert(decl_file, invocation.source.as_str(), &entry_uri);
-            }
-            Err(reason) => {
-                let span = use_decl_span_for(
-                    harvest.modules.get(decl_file),
-                    &invocation.source,
-                    decl_file,
-                );
-                emit_stale(host, invocation_id, &reason, span);
+        let resolved = resolve_invocation(&manifest_root, invocation, host).await;
+        // One invocation, one generated module, but every module that declared
+        // it imports through it and needs its own redirect.
+        for site in &invocation.decl_sites {
+            let decl_file = site.module.as_str();
+            match &resolved {
+                Ok(entry_uri) => {
+                    // Key by the literal `from "<source>"` string this site
+                    // wrote: the loader looks up redirects with the unresolved
+                    // import path, while `invocation.from` is resolved relative
+                    // to the declaring file.
+                    index.insert(decl_file, site.source.as_str(), entry_uri);
+                }
+                Err(reason) => {
+                    let span =
+                        use_decl_span_for(harvest.modules.get(decl_file), &site.source, decl_file);
+                    emit_stale(host, &site.synthetic_id, reason, span);
+                }
             }
         }
     }

--- a/wado-lsp/src/kiln.rs
+++ b/wado-lsp/src/kiln.rs
@@ -1,6 +1,7 @@
-//! The Kiln pre-pass for one document: collect its inline `with { generator }`
-//! clauses, check their options ([`options`]), and resolve the consume-only
-//! invocation index (WEP 2026-04-12 §"Consume-only mode").
+//! The Kiln pre-pass for one document: collect the inline `with { generator }`
+//! clauses of the entry and every module it imports, check their options
+//! ([`options`]), and resolve the consume-only invocation index (WEP
+//! 2026-04-12 §"Consume-only mode").
 //!
 //! No LSP host can run a generator component, so it cannot re-derive the hashes
 //! `<output_dir>/<primary>.kiln.json` records. Redirects therefore trust that
@@ -12,7 +13,10 @@ use std::path::{Path, PathBuf};
 
 use wado_compiler::ast::{AstIdSpace, Item, Module};
 use wado_compiler::kiln::metadata::{METADATA_VERSION, Metadata, metadata_filename};
-use wado_compiler::kiln::{InvocationIndex, InvocationPath, collect_inline_invocations};
+use wado_compiler::kiln::{
+    InvocationIndex, InvocationPath, collect_inline_invocations, harvest_module_graph,
+    remap_decl_files,
+};
 use wado_compiler::{Code, CompilerHost, Diagnostic, DiagnosticSpan, Severity};
 
 /// The redirect index the loader resolves `use … from "<schema>"` through,
@@ -37,10 +41,19 @@ pub async fn prepare_invocations<H: CompilerHost>(
         return override_index.unwrap_or_default();
     };
 
+    // Kiln's unit is the module, so the clauses of every module the entry
+    // imports count too. The entry's tree comes from the editor buffer; the
+    // rest are read through the host, as the loader will read them.
+    let harvest = harvest_module_graph(entry_filename, Some(entry_ast.clone()), async |path| {
+        let bytes = host.load_source(path).await.ok()?;
+        String::from_utf8(bytes).ok()
+    })
+    .await;
+
     let descriptors = wado_compiler::hashmap::IndexMap::default();
     let manifest_root_str = manifest_root.to_string_lossy();
     let invocations = match collect_inline_invocations(
-        std::iter::once((entry_filename, entry_ast)),
+        harvest.modules.iter().map(|(k, ast)| (k.as_str(), ast)),
         &descriptors,
         &manifest_root_str,
     ) {
@@ -67,22 +80,28 @@ pub async fn prepare_invocations<H: CompilerHost>(
     let mut index = InvocationIndex::new();
     for invocation in &invocations {
         let invocation_id = &invocation.decl_site.synthetic_id;
+        let decl_file = invocation.decl_site.module.as_str();
         match resolve_invocation(&manifest_root, invocation, host).await {
             Ok(entry_uri) => {
                 // Key by the literal `from "<source>"` string: the loader looks
                 // up redirects with the unresolved import path, while
                 // `invocation.from` is resolved relative to the declaring file.
-                index.insert(
-                    &invocation.decl_site.module,
-                    invocation.source.as_str(),
-                    &entry_uri,
-                );
+                index.insert(decl_file, invocation.source.as_str(), &entry_uri);
             }
             Err(reason) => {
-                let span = use_decl_span_for(entry_ast, &invocation.source, entry_filename);
+                let span = use_decl_span_for(
+                    harvest.modules.get(decl_file),
+                    &invocation.source,
+                    decl_file,
+                );
                 emit_stale(host, invocation_id, &reason, span);
             }
         }
+    }
+    // The loader asks under the identity it resolved the declaring module by,
+    // which is the harvest key only for the entry.
+    for diagnostic in remap_decl_files(&mut index, &harvest.identities) {
+        host.emit_diagnostic(diagnostic);
     }
     index
 }
@@ -91,8 +110,12 @@ pub async fn prepare_invocations<H: CompilerHost>(
 /// `from` matches the given invocation path. Returns a synthetic
 /// file-anchored span when no match is found — every invocation came
 /// from a use clause, so a miss here is a defensive fallback only.
-fn use_decl_span_for(module: &Module, from: &InvocationPath, filename: &str) -> DiagnosticSpan {
-    for item in &module.items {
+fn use_decl_span_for(
+    module: Option<&Module>,
+    from: &InvocationPath,
+    filename: &str,
+) -> DiagnosticSpan {
+    for item in module.iter().flat_map(|m| &m.items) {
         if let Item::Use(use_decl) = item
             && InvocationPath::normalize(&use_decl.source).as_str() == from.as_str()
         {

--- a/wado-lsp/src/kiln.rs
+++ b/wado-lsp/src/kiln.rs
@@ -41,9 +41,8 @@ pub async fn prepare_invocations<H: CompilerHost>(
         return override_index.unwrap_or_default();
     };
 
-    // Kiln's unit is the module, so the clauses of every module the entry
-    // imports count too. The entry's tree comes from the editor buffer; the
-    // rest are read through the host, as the loader will read them.
+    // The entry's tree comes from the editor buffer; every module it imports is
+    // read through the host, as the loader will read them.
     let harvest = harvest_module_graph(entry_filename, Some(entry_ast.clone()), async |path| {
         let bytes = host.load_source(path).await.ok()?;
         String::from_utf8(bytes).ok()

--- a/wado-lsp/src/kiln.rs
+++ b/wado-lsp/src/kiln.rs
@@ -51,10 +51,8 @@ pub async fn prepare_invocations<H: CompilerHost>(
 
     let descriptors = wado_compiler::hashmap::IndexMap::default();
     let manifest_root_str = manifest_root.to_string_lossy();
-    // A malformed clause costs its own redirect and no other. Its diagnostic is
-    // reported here because the semantics pass never re-runs this collector; no
-    // double-emit risk, since this is the sole `collect` call on the LSP path
-    // and each snapshot builds once.
+    // Emitting the clause diagnostics here is what reaches the editor: no later
+    // phase re-runs this collector, and each snapshot builds once.
     let (invocations, diagnostics) = collect_inline_invocations(
         harvest.modules.iter().map(|(k, ast)| (k.as_str(), ast)),
         &descriptors,
@@ -72,23 +70,14 @@ pub async fn prepare_invocations<H: CompilerHost>(
 
     let mut index = InvocationIndex::new();
     for invocation in &invocations {
-        let resolved = resolve_invocation(&manifest_root, invocation, host).await;
-        // One invocation, one generated module, but every module that declared
-        // it imports through it and needs its own redirect.
-        for site in &invocation.decl_sites {
-            let decl_file = site.module.as_str();
-            match &resolved {
-                Ok(entry_uri) => {
-                    // Key by the literal `from "<source>"` string this site
-                    // wrote: the loader looks up redirects with the unresolved
-                    // import path, while `invocation.from` is resolved relative
-                    // to the declaring file.
-                    index.insert(decl_file, site.source.as_str(), entry_uri);
-                }
-                Err(reason) => {
+        match resolve_invocation(&manifest_root, invocation, host).await {
+            Ok(entry_uri) => index.insert_invocation(invocation, &entry_uri),
+            Err(reason) => {
+                for site in &invocation.decl_sites {
+                    let decl_file = site.module.as_str();
                     let span =
                         use_decl_span_for(harvest.modules.get(decl_file), &site.source, decl_file);
-                    emit_stale(host, &site.synthetic_id, reason, span);
+                    emit_stale(host, &site.synthetic_id, &reason, span);
                 }
             }
         }

--- a/wado-lsp/src/kiln/options.rs
+++ b/wado-lsp/src/kiln/options.rs
@@ -39,7 +39,7 @@ pub(super) async fn check_all<H: CompilerHost>(
             continue;
         };
         let anchor = OptionsAnchor {
-            file: &invocation.decl_site.module,
+            file: &invocation.decl_site().module,
             span: invocation.options_span,
         };
         if let Err(diagnostics) =

--- a/wado-lsp/tests/kiln_consume_only.rs
+++ b/wado-lsp/tests/kiln_consume_only.rs
@@ -39,16 +39,27 @@ const SCHEMA_BODY: &str = "// dummy calc grammar — body content is irrelevant\
 const GENERATED_BODY: &str = "#![generated(by = \"fake:gen@0.1\", sources = [\"grammars/calc.g4\"])]\n\
      pub fn parse() -> i32 { return 42; }\n";
 
-fn entry_source() -> &'static str {
-    "use { parse } from \"./grammars/calc.g4\" with {\n    \
+/// The `use … with { generator }` clause, as written wherever it lives.
+const CLAUSE: &str = "use { parse } from \"./grammars/calc.g4\" with {\n    \
      generator: {\n        \
      module: \"fake:gen@0.1\",\n        \
      output_dir: \"./tests/generated\",\n    \
      },\n\
-     };\n\
-     fn run() {\n    \
-     let _x = parse();\n\
-     }\n"
+     };\n";
+
+fn entry_source() -> String {
+    format!("{CLAUSE}fn run() {{\n    let _x = parse();\n}}\n")
+}
+
+/// The entry when the clause lives one module deeper: it imports the
+/// re-export instead of declaring the clause itself.
+fn importer_entry_source() -> String {
+    "use { parse } from \"./lib.wado\";\nfn run() {\n    let _x = parse();\n}\n".to_string()
+}
+
+/// The imported module that declares the clause and re-exports its symbol.
+fn clause_module_source() -> String {
+    format!("pub {CLAUSE}")
 }
 
 fn hex_sha256(bytes: &[u8]) -> String {
@@ -58,6 +69,7 @@ fn hex_sha256(bytes: &[u8]) -> String {
 struct Fixture {
     root: tempfile::TempDir,
     entry_uri: String,
+    entry_text: String,
 }
 
 /// Knobs the builder consults to materialize the workspace state. Each
@@ -75,6 +87,10 @@ struct FixtureSpec<'a> {
     /// Defaults to `"fake:gen@0.1"` so it matches what
     /// `generator_identity` derives for the inline `module:`.
     metadata_generator: Option<&'a str>,
+    /// Put the clause in `lib.wado`, which the entry imports, instead of
+    /// in the entry itself. Kiln's unit is the module, not the entry:
+    /// a clause anywhere in the graph must redirect.
+    clause_in_imported_module: bool,
 }
 
 impl Default for FixtureSpec<'_> {
@@ -83,6 +99,7 @@ impl Default for FixtureSpec<'_> {
             schema_on_disk: SCHEMA_BODY,
             generated_on_disk: GENERATED_BODY,
             metadata_generator: None,
+            clause_in_imported_module: false,
         }
     }
 }
@@ -134,19 +151,26 @@ fn build_fixture(spec: FixtureSpec<'_>) -> Fixture {
     )
     .unwrap();
 
+    let entry_text = if spec.clause_in_imported_module {
+        std::fs::write(root.join("lib.wado"), clause_module_source()).unwrap();
+        importer_entry_source()
+    } else {
+        entry_source()
+    };
     let entry_path = root.join("main.wado");
-    std::fs::write(&entry_path, entry_source()).unwrap();
+    std::fs::write(&entry_path, &entry_text).unwrap();
 
     Fixture {
         root: tmp,
         entry_uri: format!("file://{}", entry_path.display()),
+        entry_text,
     }
 }
 
 fn engine_with(fixture: &Fixture) -> (Engine, FilesystemCompilerHost) {
     let host = FilesystemCompilerHost::new(fixture.root.path().to_path_buf());
     let mut engine = Engine::new();
-    engine.open_document(&fixture.entry_uri, entry_source().to_string());
+    engine.open_document(&fixture.entry_uri, fixture.entry_text.clone());
     (engine, host)
 }
 
@@ -182,6 +206,24 @@ fn assert_redirected_clean(diags: &[wado_lsp::Diagnostic]) {
 fn artifact_present_redirects_without_warning() {
     futures::executor::block_on(async {
         let fixture = build_fixture(FixtureSpec::default());
+        let (engine, host) = engine_with(&fixture);
+
+        let diags = engine.diagnostics(&fixture.entry_uri, &host).await;
+
+        assert_redirected_clean(&diags);
+    });
+}
+
+#[test]
+fn clause_in_an_imported_module_redirects() {
+    futures::executor::block_on(async {
+        // Kiln's unit is the module, not the entry: a `with` clause in an
+        // imported module produces a generated module for *that* module's
+        // imports (WEP 2026-04-12 §"The loader redirect").
+        let fixture = build_fixture(FixtureSpec {
+            clause_in_imported_module: true,
+            ..FixtureSpec::default()
+        });
         let (engine, host) = engine_with(&fixture);
 
         let diags = engine.diagnostics(&fixture.entry_uri, &host).await;

--- a/wado-lsp/tests/kiln_consume_only.rs
+++ b/wado-lsp/tests/kiln_consume_only.rs
@@ -47,19 +47,13 @@ const CLAUSE: &str = "use { parse } from \"./grammars/calc.g4\" with {\n    \
      },\n\
      };\n";
 
-fn entry_source() -> String {
-    format!("{CLAUSE}fn run() {{\n    let _x = parse();\n}}\n")
-}
-
 /// The entry when the clause lives one module deeper: it imports the
 /// re-export instead of declaring the clause itself.
-fn importer_entry_source() -> String {
-    "use { parse } from \"./lib.wado\";\nfn run() {\n    let _x = parse();\n}\n".to_string()
-}
+const IMPORTER_ENTRY: &str =
+    "use { parse } from \"./lib.wado\";\nfn run() {\n    let _x = parse();\n}\n";
 
-/// The imported module that declares the clause and re-exports its symbol.
-fn clause_module_source() -> String {
-    format!("pub {CLAUSE}")
+fn entry_source() -> String {
+    format!("{CLAUSE}fn run() {{\n    let _x = parse();\n}}\n")
 }
 
 fn hex_sha256(bytes: &[u8]) -> String {
@@ -88,8 +82,7 @@ struct FixtureSpec<'a> {
     /// `generator_identity` derives for the inline `module:`.
     metadata_generator: Option<&'a str>,
     /// Put the clause in `lib.wado`, which the entry imports, instead of
-    /// in the entry itself. Kiln's unit is the module, not the entry:
-    /// a clause anywhere in the graph must redirect.
+    /// in the entry itself.
     clause_in_imported_module: bool,
 }
 
@@ -152,8 +145,8 @@ fn build_fixture(spec: FixtureSpec<'_>) -> Fixture {
     .unwrap();
 
     let entry_text = if spec.clause_in_imported_module {
-        std::fs::write(root.join("lib.wado"), clause_module_source()).unwrap();
-        importer_entry_source()
+        std::fs::write(root.join("lib.wado"), format!("pub {CLAUSE}")).unwrap();
+        IMPORTER_ENTRY.to_string()
     } else {
         entry_source()
     };


### PR DESCRIPTION
Kiln's unit is the module, not the entry. This branch makes the clause harvest hold that everywhere, and records the design for naming a dependency's files.

## Clause harvesting

`kiln::harvest_module_graph` is the one walk over the local module graph, used by `wado compile` / `check` and by the LSP's consume-only path, so the two cannot disagree about which clauses exist. A `use ... with { generator }` clause in any module reachable from the entry declares an invocation, and the redirect it produces is keyed by the identity the loader resolves its module under.

The walk reads a module through `load` under that same loader identity, so a host matching keys exactly — the in-memory hosts the browser playground and the LSP tests use — serves the walk and the loader from one set of keys. The caller supplies the entry's tree, since the loader does not read the entry through a host either.

An `Invocation` carries every `DeclSite` that declared it. Clauses agreeing on the identity tuple collapse into one invocation, so the generator runs once, and each declaring module still resolves its own import: `DeclSite` holds the literal `from` that module wrote, which is what the loader looks up, and two modules may reach one schema by different spellings. `InvocationIndex::insert_invocation` records the entry URI for all of them.

`collect_inline_invocations` returns the invocations it lowered alongside the diagnostics. A malformed clause costs its own invocation and no other: a batch build refuses to proceed on an `Error`, and an editor keeps the redirects it can still resolve.

`path::is_cwd_relative` is the single predicate for the `./` / `../` notation.

## Design record

`docs/wep-2026-09-06-package-file-exports.md` specifies how a package offers files to its consumers, with `wep-2026-04-12-kiln`, `-02-14-package-manifest`, `-06-17-package-module-syntax`, `-03-02-include-str` and `-07-26-provider-metadata` revised to match. Nothing in it is implemented here; the WEP carries the roadmap.

- `[package].exports` is an allowlist covering assets and `.wado` submodules alike. A file it does not name does not exist to a consumer, and the refusal names the package rather than the path.
- A file is named `<coordinate>/<path.ext>`, extension required — that is what separates it from a specifier naming the package's `lib` entry. The same reference works at a `use`, at Kiln's `from` / `inputs`, and in `#include_str`.
- An invocation's identity records the logical reference (`ns:pkg@ver/path`), never where the file sits on this machine, and outputs land in the consuming project's tree.
- A dependency's own invocations follow Kiln's cache rule: a recorded output travels with the package and is used as-is, and without one the consuming build runs the generator through the dependency's own `[build-dependencies]`.
- An exported submodule offers its `pub` items. Paths compare after NFC with case matched exactly. Reserved namespaces export nothing, and glob patterns are refused in the allowlist as much as at a use site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EFjLXjeXP6KBkPpT3wf6f1

---
_Generated by [Claude Code](https://claude.ai/code/session_01EFjLXjeXP6KBkPpT3wf6f1)_