### PR TITLE
chore(ci): test the stdlib at every optimization level

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,8 +80,12 @@ jobs:
           save-if: false
       - run: cargo test --locked --all -- --skip fixture_test_
 
+  # One job per optimization level runs the whole compiler over the same level:
+  # the e2e fixtures, then the stdlib's own `test` blocks. Before this the
+  # stdlib was only ever tested at -O2, so an optimizer bug reachable from
+  # `core:*` at another level had nothing to catch it.
   test-e2e-o0:
-    name: Test (E2E O0)
+    name: Test (E2E+stdlib O0)
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
@@ -94,10 +98,18 @@ jobs:
         with:
           shared-key: ci
           save-if: false
+      - uses: jdx/mise-action@v4.3.0
+        with:
+          cache: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          MISE_VERBOSE: ${{ runner.debug }}
+
       - run: cargo test --locked -p wado-compiler --test e2e -- fixture_test_o0
+      - run: mise run test-stdlib O0
 
   test-e2e-o1:
-    name: Test (E2E O1)
+    name: Test (E2E+stdlib O1)
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
@@ -110,10 +122,18 @@ jobs:
         with:
           shared-key: ci
           save-if: false
+      - uses: jdx/mise-action@v4.3.0
+        with:
+          cache: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          MISE_VERBOSE: ${{ runner.debug }}
+
       - run: cargo test --locked -p wado-compiler --test e2e -- fixture_test_o1
+      - run: mise run test-stdlib O1
 
   test-e2e-o2:
-    name: Test (E2E O2)
+    name: Test (E2E+stdlib O2)
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
@@ -126,10 +146,18 @@ jobs:
         with:
           shared-key: ci
           save-if: false
+      - uses: jdx/mise-action@v4.3.0
+        with:
+          cache: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          MISE_VERBOSE: ${{ runner.debug }}
+
       - run: cargo test --locked -p wado-compiler --test e2e -- fixture_test_o2
+      - run: mise run test-stdlib O2
 
   test-e2e-o3:
-    name: Test (E2E O3)
+    name: Test (E2E+stdlib O3)
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
@@ -142,10 +170,18 @@ jobs:
         with:
           shared-key: ci
           save-if: false
+      - uses: jdx/mise-action@v4.3.0
+        with:
+          cache: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          MISE_VERBOSE: ${{ runner.debug }}
+
       - run: cargo test --locked -p wado-compiler --test e2e -- fixture_test_o3
+      - run: mise run test-stdlib O3
 
   test-e2e-os:
-    name: Test (E2E Os)
+    name: Test (E2E+stdlib Os)
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
@@ -158,7 +194,15 @@ jobs:
         with:
           shared-key: ci
           save-if: false
+      - uses: jdx/mise-action@v4.3.0
+        with:
+          cache: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          MISE_VERBOSE: ${{ runner.debug }}
+
       - run: cargo test --locked -p wado-compiler --test e2e -- fixture_test_os
+      - run: mise run test-stdlib Os
 
   test-wado:
     name: Test (Wado)
@@ -198,8 +242,8 @@ jobs:
       # component) without pushing, so no wkg or credentials are needed.
       - run: cargo run --locked -p wado-cli -- publish --dry-run
 
-  test-gale-o3:
-    name: Test (Gale O3)
+  test-gale-o2:
+    name: Test (Gale O2)
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
@@ -219,7 +263,7 @@ jobs:
         env:
           MISE_VERBOSE: ${{ runner.debug }}
 
-      - run: mise run test-gale-o3
+      - run: mise run test-gale-o2
 
   # Build-light static gates folded into one sub-minute job. Neither needs the
   # shared `ci` build cache: `check-deps` is a pure `cargo tree -d` resolution,
@@ -265,7 +309,7 @@ jobs:
         changes,
         test-core,
         test-wado,
-        test-gale-o3,
+        test-gale-o2,
         test-e2e-o0,
         test-e2e-o1,
         test-e2e-o2,
@@ -290,7 +334,7 @@ jobs:
             echo "Docs-only change: test jobs skipped, reporting success."
             exit 0
           fi
-          results="${{ needs.test-core.result }} ${{ needs.test-wado.result }} ${{ needs.test-gale-o3.result }} ${{ needs.test-e2e-o0.result }} ${{ needs.test-e2e-o1.result }} ${{ needs.test-e2e-o2.result }} ${{ needs.test-e2e-o3.result }} ${{ needs.test-e2e-os.result }} ${{ needs.check.result }}"
+          results="${{ needs.test-core.result }} ${{ needs.test-wado.result }} ${{ needs.test-gale-o2.result }} ${{ needs.test-e2e-o0.result }} ${{ needs.test-e2e-o1.result }} ${{ needs.test-e2e-o2.result }} ${{ needs.test-e2e-o3.result }} ${{ needs.test-e2e-os.result }} ${{ needs.check.result }}"
           for result in $results; do
             if [ "$result" != "success" ]; then
               echo "One or more jobs failed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,18 +80,25 @@ jobs:
           save-if: false
       - run: cargo test --locked --all -- --skip fixture_test_
 
-  # One job per optimization level runs the whole compiler over the same level:
-  # the e2e fixtures, then the stdlib's own `test` blocks. Before this the
-  # stdlib was only ever tested at -O2, so an optimizer bug reachable from
-  # `core:*` at another level had nothing to catch it.
-  test-e2e-o0:
-    name: Test (E2E+stdlib O0)
+  # One job per optimization level runs the compiler's full test at that level:
+  # the e2e fixtures, then the stdlib. Before this the stdlib ran at -O2 only,
+  # so an optimizer bug reachable from `core:*` at another level had nothing to
+  # catch it. `fail-fast: false` keeps the other levels running, because which
+  # levels break says where the bug is.
+  test-level:
+    name: Test (E2E+stdlib ${{ matrix.level }})
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        level: [O0, O1, O2, O3, Os]
+    env:
+      LEVEL: ${{ matrix.level }}
     steps:
       - uses: actions/checkout@v7
       - uses: Swatinem/rust-cache@v2
@@ -105,104 +112,9 @@ jobs:
         env:
           MISE_VERBOSE: ${{ runner.debug }}
 
-      - run: cargo test --locked -p wado-compiler --test e2e -- fixture_test_o0
-      - run: mise run test-stdlib O0
-
-  test-e2e-o1:
-    name: Test (E2E+stdlib O1)
-    needs: changes
-    if: needs.changes.outputs.code == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v7
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: ci
-          save-if: false
-      - uses: jdx/mise-action@v4.3.0
-        with:
-          cache: true
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-        env:
-          MISE_VERBOSE: ${{ runner.debug }}
-
-      - run: cargo test --locked -p wado-compiler --test e2e -- fixture_test_o1
-      - run: mise run test-stdlib O1
-
-  test-e2e-o2:
-    name: Test (E2E+stdlib O2)
-    needs: changes
-    if: needs.changes.outputs.code == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v7
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: ci
-          save-if: false
-      - uses: jdx/mise-action@v4.3.0
-        with:
-          cache: true
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-        env:
-          MISE_VERBOSE: ${{ runner.debug }}
-
-      - run: cargo test --locked -p wado-compiler --test e2e -- fixture_test_o2
-      - run: mise run test-stdlib O2
-
-  test-e2e-o3:
-    name: Test (E2E+stdlib O3)
-    needs: changes
-    if: needs.changes.outputs.code == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v7
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: ci
-          save-if: false
-      - uses: jdx/mise-action@v4.3.0
-        with:
-          cache: true
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-        env:
-          MISE_VERBOSE: ${{ runner.debug }}
-
-      - run: cargo test --locked -p wado-compiler --test e2e -- fixture_test_o3
-      - run: mise run test-stdlib O3
-
-  test-e2e-os:
-    name: Test (E2E+stdlib Os)
-    needs: changes
-    if: needs.changes.outputs.code == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v7
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: ci
-          save-if: false
-      - uses: jdx/mise-action@v4.3.0
-        with:
-          cache: true
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-        env:
-          MISE_VERBOSE: ${{ runner.debug }}
-
-      - run: cargo test --locked -p wado-compiler --test e2e -- fixture_test_os
-      - run: mise run test-stdlib Os
+      # The e2e test names are lower case.
+      - run: cargo test --locked -p wado-compiler --test e2e -- "fixture_test_${LEVEL,,}"
+      - run: mise run test-stdlib "$LEVEL"
 
   test-wado:
     name: Test (Wado)
@@ -310,11 +222,7 @@ jobs:
         test-core,
         test-wado,
         test-gale-o2,
-        test-e2e-o0,
-        test-e2e-o1,
-        test-e2e-o2,
-        test-e2e-o3,
-        test-e2e-os,
+        test-level,
         check,
       ]
     runs-on: ubuntu-latest
@@ -334,7 +242,9 @@ jobs:
             echo "Docs-only change: test jobs skipped, reporting success."
             exit 0
           fi
-          results="${{ needs.test-core.result }} ${{ needs.test-wado.result }} ${{ needs.test-gale-o2.result }} ${{ needs.test-e2e-o0.result }} ${{ needs.test-e2e-o1.result }} ${{ needs.test-e2e-o2.result }} ${{ needs.test-e2e-o3.result }} ${{ needs.test-e2e-os.result }} ${{ needs.check.result }}"
+          # `test-level` is one matrix job. Its result is success only if
+          # every level succeeded.
+          results="${{ needs.test-core.result }} ${{ needs.test-wado.result }} ${{ needs.test-gale-o2.result }} ${{ needs.test-level.result }} ${{ needs.check.result }}"
           for result in $results; do
             if [ "$result" != "success" ]; then
               echo "One or more jobs failed"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,9 +33,10 @@ mise run on-task-started   # install project tools
 ### Common Development Tasks
 
 ```sh
-mise run test        # test Rust crates
-mise run test-wado   # test Wado modules
-mise run format      # format Rust, Markdown, and Wado files
+mise run test            # test Rust crates
+mise run test-wado       # test Wado modules
+mise run test-stdlib O3  # test the stdlib at one optimization level (CI runs each)
+mise run format          # format Rust, Markdown, and Wado files
 
 mise run benchmark-all     # runs all benchmarks and reports the results
 mise run report-wasm-size  # measures the size of the generated Wasm files and reports the results
@@ -45,7 +46,7 @@ mise run report-wasm-size  # measures the size of the generated Wasm files and r
 
 - Make every edit with the editing tools. They refuse a match that is not unique and a file the session has not read, and the harness tracks what they wrote, so each edit is checkable. Scripts — Node.js included — measure, extract, and generate data to read.
 - Run a long job (`mise run test`, `test-wado`, `update-golden-fixtures`) in the background, one per invocation: the harness announces the end of a job it owns. Chaining one behind a slow step puts both under a single timeout.
-- `test`, `test-wado` and `test-gale-o3` refuse to start while another of the same is running, naming the holder's pid — where `flock` exists; `scripts/exclusive.sh` says so on stderr and runs unlocked where it does not. Abandoning a job does not stop it, so restarting after an edit means killing that pid first.
+- `test`, `test-wado`, `test-stdlib` and `test-gale-o2` refuse to start while another of the same is running, naming the holder's pid — where `flock` exists; `scripts/exclusive.sh` says so on stderr and runs unlocked where it does not. Abandoning a job does not stop it, so restarting after an edit means killing that pid first.
 - Redirect a job's output to a file and read the file, so what you did not anticipate is still there.
 - Have the job record its own completion — `cmd > run.log 2>&1 && s=0 || s=$?; echo "exit=$s" >> run.log` — and wait for it with `until grep -q "^exit=" run.log; do sleep 30; done`. The `&&`/`||` is what writes the marker on a failure too, which `set -e` would otherwise exit before.
 - Let a `wado test` run finish before editing sources: it pins each Kiln generator at its first resolve, and its verdict then describes neither tree.

--- a/mise.toml
+++ b/mise.toml
@@ -187,25 +187,51 @@ description = "Run Wado module tests"
 run = """
 #!/usr/bin/env bash
 set -xe -o pipefail
-# package-gale is excluded in CI only, where test-gale-o3 covers it; locally
-# one run walks every nested package. benchmark/* test blocks need no `--dir`:
-# their file reads sit in `export fn run()`, which the test world never calls.
-# Same batch-compilation shape as `test-gale-o3`, whose comment explains the
-# purge and what holding the pages costs in RSS.
+# package-gale and the stdlib are excluded in CI only, where test-gale-o2 and
+# `test-stdlib` (once per optimization level) cover them; locally one run walks
+# every nested package. benchmark/* test blocks need no `--dir`: their file
+# reads sit in `export fn run()`, which the test world never calls. Same
+# batch-compilation shape as `test-gale-o2`, whose comment explains the purge
+# and what holding the pages costs in RSS.
 export MIMALLOC_PURGE_DELAY=-1
 extra_args=()
 if [ -n "${CI:-}" ]; then
-    extra_args+=(--exclude 'package-gale/**' --format tap)
+    extra_args+=(--exclude 'package-gale/**' --exclude 'wado-compiler/**' --format tap)
 fi
 ./scripts/exclusive.sh test-wado cargo run -p wado-cli -- test -O2 "${extra_args[@]}"
+"""
+
+[tasks.test-stdlib]
+description = "Run the stdlib (wado-compiler/lib) tests at one optimization level: O0, O1, O2, O3 or Os (default O2)"
+run = """
+#!/usr/bin/env bash
+set -xe -o pipefail
+# The level is spelled without its dash so mise does not read it as a flag of
+# its own. `wado-compiler`'s [test] include/exclude is what narrows the package
+# to the stdlib's `*_test.wado` files. Same batch-compilation shape as
+# `test-gale-o2`, whose comment explains the purge.
+level="${1:-O2}"
+case "${level}" in
+    O0 | O1 | O2 | O3 | Os) ;;
+    *)
+        echo "error: unknown optimization level '${level}' (expected O0, O1, O2, O3 or Os)" >&2
+        exit 1
+        ;;
+esac
+export MIMALLOC_PURGE_DELAY=-1
+extra_args=()
+if [ -n "${CI:-}" ]; then
+    extra_args+=(--format tap)
+fi
+./scripts/exclusive.sh test-stdlib cargo run -p wado-cli -- test "-${level}" wado-compiler "${extra_args[@]}"
 """
 
 [tasks.test-hooks]
 description = "Run the Claude Code hook and repo script tests"
 run = "node --test .claude/hooks/*.test.mts scripts/*.test.mjs"
 
-[tasks.test-gale-o3]
-description = "Run package-gale tests with -O3"
+[tasks.test-gale-o2]
+description = "Run package-gale tests with -O2"
 run = """
 #!/usr/bin/env bash
 set -xe -o pipefail
@@ -213,12 +239,12 @@ set -xe -o pipefail
 # the file is done, so the heap empties once per file. mimalloc's 10ms purge
 # timer then returns those pages to the OS just before the next file asks for
 # them again, and taking them back costs a fault and a free-list rebuild each:
-# 7.0 GiB purged over 24.8K calls to compile four fixtures. Holding them runs
-# this suite in 828s against 931s (-11%, compile CPU 3081s against 3442s) for a
-# peak RSS of 5941 MiB against 4798, which is comfortable on a 16 GiB runner and
-# the first thing to revisit on a smaller one. Serializing the compiles (`-p 1`)
-# leaves the page traffic where it was, so it is the per-file heap that costs,
-# not the threads. Batch compilation only: `wado serve` is long-running, and
+# 7.0 GiB purged over 24.8K calls to compile four fixtures. Holding them ran
+# this suite (measured at -O3) in 828s against 931s (-11%, compile CPU 3081s
+# against 3442s) for a peak RSS of 5941 MiB against 4798, which is comfortable
+# on a 16 GiB runner and the first thing to revisit on a smaller one.
+# Serializing the compiles (`-p 1`) leaves the page traffic where it was, so it
+# is the per-file heap that costs, not the threads. Batch compilation only: `wado serve` is long-running, and
 # reclaiming after a spike is what the purge is for. The standing fix is the
 # allocation volume itself — ~31% of a compile's CPU is in the allocator.
 export MIMALLOC_PURGE_DELAY=-1
@@ -226,7 +252,7 @@ extra_args=()
 if [ -n "${CI:-}" ]; then
     extra_args+=(--format tap)
 fi
-./scripts/exclusive.sh test-gale-o3 cargo run -p wado-cli -- test -O3 package-gale "${extra_args[@]}"
+./scripts/exclusive.sh test-gale-o2 cargo run -p wado-cli -- test -O2 package-gale "${extra_args[@]}"
 """
 
 [tasks.test-cov]

--- a/mise.toml
+++ b/mise.toml
@@ -244,9 +244,10 @@ set -xe -o pipefail
 # against 3442s) for a peak RSS of 5941 MiB against 4798, which is comfortable
 # on a 16 GiB runner and the first thing to revisit on a smaller one.
 # Serializing the compiles (`-p 1`) leaves the page traffic where it was, so it
-# is the per-file heap that costs, not the threads. Batch compilation only: `wado serve` is long-running, and
-# reclaiming after a spike is what the purge is for. The standing fix is the
-# allocation volume itself — ~31% of a compile's CPU is in the allocator.
+# is the per-file heap that costs, not the threads. Batch compilation only:
+# `wado serve` is long-running, and reclaiming after a spike is what the purge
+# is for. The standing fix is the allocation volume itself — ~31% of a
+# compile's CPU is in the allocator.
 export MIMALLOC_PURGE_DELAY=-1
 extra_args=()
 if [ -n "${CI:-}" ]; then

--- a/mise.toml
+++ b/mise.toml
@@ -207,9 +207,9 @@ run = """
 #!/usr/bin/env bash
 set -xe -o pipefail
 # The level is spelled without its dash so mise does not read it as a flag of
-# its own. `wado-compiler`'s [test] include/exclude is what narrows the package
-# to the stdlib's `*_test.wado` files. Same batch-compilation shape as
-# `test-gale-o2`, whose comment explains the purge.
+# its own. `wado-compiler` is the stdlib package; its [test] filters pick the
+# `lib/` modules and the `*_test.wado` siblings holding the prelude's. Same
+# batch-compilation shape as `test-gale-o2`, whose comment explains the purge.
 level="${1:-O2}"
 case "${level}" in
     O0 | O1 | O2 | O3 | Os) ;;


### PR DESCRIPTION
One CI job per optimization level runs the compiler's full test at that level: the e2e fixtures, then the stdlib's own `test` blocks. `(e2e + stdlib) x level` is what the toolchain is tested by.

The five levels are one matrix job (`test-level`, `O0 O1 O2 O3 Os`) with `fail-fast: false`, so which levels break says where a bug is. The aggregating `Test` check reads its single result, which is success only when every level succeeded.

`mise run test-stdlib <level>` runs the stdlib at one level, and is what a level job calls. The level is spelled without its dash (`test-stdlib O3`) so mise does not read it as a flag of its own; anything but `O0`, `O1`, `O2`, `O3` or `Os` is refused before a compile starts.

`test-wado` covers the rest of the Wado corpus at -O2. In CI it excludes the stdlib and `package-gale`, which have jobs of their own; locally one run still walks every nested package.

`test-gale-o2` runs `package-gale` at -O2, as its own job.

The stdlib passes 1830 tests at every level (local, 4 cores): O0 101s, O1 53s, Os 49s, O2 83s, O3 104s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ltm4L6AG8vs5E7GYGZGida


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ltm4L6AG8vs5E7GYGZGida)_