### PR TITLE
fix: the empty tuple is not unit, on either side of the compiler

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1954,12 +1954,11 @@ let unit: () = ();    // Unit type/value
 let empty: [] = [];   // Empty tuple (rarely used)
 ```
 
-Being distinct types, they take separate `impl`s: a method defined on one is not
-found on the other.
+They take separate `impl`s, so a method defined on one is not found on the other.
 
-`[]` has no Component Model representation — a `tuple` carries at least one type,
-and `()` is the type that carries none — so it cannot cross a component boundary.
-An export naming one is rejected at compile time.
+`[]` cannot cross a component boundary. It has no Component Model representation:
+a `tuple` carries at least one type, and `()` is the type that carries none. An
+export naming one is rejected at compile time.
 
 ##### The `never` type (`!`) — bottom type
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1954,6 +1954,13 @@ let unit: () = ();    // Unit type/value
 let empty: [] = [];   // Empty tuple (rarely used)
 ```
 
+Being distinct types, they take separate `impl`s: a method defined on one is not
+found on the other.
+
+`[]` has no Component Model representation — a `tuple` carries at least one type,
+and `()` is the type that carries none — so it cannot cross a component boundary.
+An export naming one is rejected at compile time.
+
 ##### The `never` type (`!`) — bottom type
 
 `never` is the bottom type: it is a subtype of every type. An expression of type `never` never returns — it always diverges (traps). `panic()` and `unreachable()` both return `!`.

--- a/wado-compiler/src/codegen/component.rs
+++ b/wado-compiler/src/codegen/component.rs
@@ -539,9 +539,7 @@ fn emit_cm_val_type(
                 None
             } else {
                 let ok = &g.args[0];
-                if let Type::Named(named) = ok
-                    && named.name == "()"
-                {
+                if ok.is_unit() {
                     None
                 } else if let Type::Named(named) = ok
                     && own_resource_type_indices.contains_key(&named.name)

--- a/wado-compiler/src/component_model.rs
+++ b/wado-compiler/src/component_model.rs
@@ -4225,10 +4225,8 @@ impl CmTypeGen {
                     ComponentValType::Type(idx)
                 }
                 "Result" => {
-                    let is_ok_unit = matches!(&generic.args[0], Type::Tuple(t) if t.is_empty())
-                        || matches!(&generic.args[0], Type::Named(n) if n.name == "()");
-                    let is_err_unit = matches!(&generic.args[1], Type::Tuple(t) if t.is_empty())
-                        || matches!(&generic.args[1], Type::Named(n) if n.name == "()");
+                    let is_ok_unit = generic.args[0].is_unit();
+                    let is_err_unit = generic.args[1].is_unit();
                     let ok_type = if is_ok_unit {
                         None
                     } else {

--- a/wado-compiler/src/component_model.rs
+++ b/wado-compiler/src/component_model.rs
@@ -4455,7 +4455,7 @@ fn is_param_type_supported_with_types(
             matches!(
                 generic.name.as_str(),
                 "Stream" | "Result" | "Future" | "Option" | "List"
-            )
+            ) && !generic.args.iter().any(mentions_empty_tuple)
         }
         Type::Reference(inner) | Type::MutReference(inner) => {
             // borrow<resource> - passed as i32 handle at CM boundary
@@ -4468,6 +4468,18 @@ fn is_param_type_supported_with_types(
         Type::Tuple(elems) if !elems.is_empty() => elems
             .iter()
             .all(|e| is_param_type_supported_with_types(e, enums, resources, structs)),
+        _ => false,
+    }
+}
+
+/// Whether `ty` names the empty tuple anywhere, including under a generic. The
+/// shape predicates ask this where they accept a generic without judging its
+/// arguments, so a payload of `[]` cannot ride in past them.
+fn mentions_empty_tuple(ty: &Type) -> bool {
+    match ty {
+        Type::Tuple(elems) => elems.is_empty() || elems.iter().any(mentions_empty_tuple),
+        Type::Generic(generic) => generic.args.iter().any(mentions_empty_tuple),
+        Type::Reference(inner) | Type::MutReference(inner) => mentions_empty_tuple(inner),
         _ => false,
     }
 }
@@ -4509,7 +4521,7 @@ fn is_return_type_supported_with_types(
         }
         Type::Generic(generic) => {
             match generic.name.as_str() {
-                "Stream" | "Future" => true,
+                "Stream" | "Future" => !generic.args.iter().any(mentions_empty_tuple),
                 "AsyncCall" if generic.args.len() == 1 => {
                     // `AsyncCall<T>` is the Wado-level wrapper for async CM imports;
                     // the CM ABI return is the inner `T`. Support depends on `T`.

--- a/wado-compiler/src/component_model.rs
+++ b/wado-compiler/src/component_model.rs
@@ -4467,7 +4467,9 @@ fn is_param_type_supported_with_types(
                 false
             }
         }
-        Type::Tuple(elems) => elems
+        // `[]` falls to the catch-all: a `tuple` carries at least one type, and
+        // unit is the named `()` matched above.
+        Type::Tuple(elems) if !elems.is_empty() => elems
             .iter()
             .all(|e| is_param_type_supported_with_types(e, enums, resources, structs)),
         _ => false,
@@ -4533,15 +4535,9 @@ fn is_return_type_supported_with_types(
                 _ => false,
             }
         }
-        Type::Tuple(elements) => {
-            // Empty tuple () is the unit type, which is always supported
-            if elements.is_empty() {
-                return true;
-            }
-            elements
-                .iter()
-                .all(|el| is_return_type_supported_with_types(el, enums, resources, structs))
-        }
+        Type::Tuple(elements) if !elements.is_empty() => elements
+            .iter()
+            .all(|el| is_return_type_supported_with_types(el, enums, resources, structs)),
         _ => false,
     }
 }

--- a/wado-compiler/src/component_model.rs
+++ b/wado-compiler/src/component_model.rs
@@ -4310,9 +4310,7 @@ impl CmTypeGen {
                 }
                 _ => panic!("unsupported generic type for CM instance: {}", generic.name),
             },
-            Type::Tuple(elems) if elems.is_empty() => {
-                unreachable!("{EMPTY_TUPLE_AT_BOUNDARY}")
-            }
+            Type::Tuple(elems) if elems.is_empty() => unreachable!("{EMPTY_TUPLE_AT_BOUNDARY}"),
             Type::Tuple(elems) => {
                 let cm_elems: Vec<ComponentValType> = elems
                     .iter()
@@ -4467,8 +4465,6 @@ fn is_param_type_supported_with_types(
                 false
             }
         }
-        // `[]` falls to the catch-all: a `tuple` carries at least one type, and
-        // unit is the named `()` matched above.
         Type::Tuple(elems) if !elems.is_empty() => elems
             .iter()
             .all(|e| is_param_type_supported_with_types(e, enums, resources, structs)),
@@ -4583,9 +4579,8 @@ pub fn is_cm_function_supported(func: &CmFunctionInfo) -> bool {
 /// Canonical ABI maximum flat results before a return must use an outptr.
 pub const MAX_FLAT_RESULTS: usize = 1;
 
-/// Why no boundary path carries the empty tuple. `check_cm_boundary_representable`
-/// rejects one, and unit arrives as the named `()`, so neither spelling reaches
-/// the arms that state this.
+/// What every boundary path says when it meets the empty tuple, which none of
+/// them does.
 pub const EMPTY_TUPLE_AT_BOUNDARY: &str = "the empty tuple `[]` has no Component Model \
      representation, and the boundary rejects one before synthesis";
 

--- a/wado-compiler/src/component_model.rs
+++ b/wado-compiler/src/component_model.rs
@@ -4311,7 +4311,7 @@ impl CmTypeGen {
                 _ => panic!("unsupported generic type for CM instance: {}", generic.name),
             },
             Type::Tuple(elems) if elems.is_empty() => {
-                panic!("unit type should be handled at Result level, not directly")
+                unreachable!("{EMPTY_TUPLE_AT_BOUNDARY}")
             }
             Type::Tuple(elems) => {
                 let cm_elems: Vec<ComponentValType> = elems
@@ -4586,6 +4586,12 @@ pub fn is_cm_function_supported(func: &CmFunctionInfo) -> bool {
 
 /// Canonical ABI maximum flat results before a return must use an outptr.
 pub const MAX_FLAT_RESULTS: usize = 1;
+
+/// Why no boundary path carries the empty tuple. `check_cm_boundary_representable`
+/// rejects one, and unit arrives as the named `()`, so neither spelling reaches
+/// the arms that state this.
+pub const EMPTY_TUPLE_AT_BOUNDARY: &str = "the empty tuple `[]` has no Component Model \
+     representation, and the boundary rejects one before synthesis";
 
 /// Whether a return type must use an outptr rather than flat core results. The
 /// flat count is the single rule: a type returns via the outptr iff it flattens

--- a/wado-compiler/src/elaborator/method_lookup.rs
+++ b/wado-compiler/src/elaborator/method_lookup.rs
@@ -190,7 +190,6 @@ impl TypeSystem {
                 ResolvedType::MutRef(target) => self.arg_matches(inner, target),
                 _ => false,
             },
-            Type::Tuple(elems) if elems.is_empty() => matches!(resolved, ResolvedType::Unit),
             Type::Tuple(elems) => {
                 let tt = self.type_table.borrow();
                 let is_tuple = matches!(

--- a/wado-compiler/src/elaborator/module.rs
+++ b/wado-compiler/src/elaborator/module.rs
@@ -563,7 +563,6 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
     pub(super) fn get_type_name(&self, ty: &Type) -> String {
         match ty {
-            Type::Named(named) if named.name == "()" => TypeTable::UNIT_TYPE_NAME.to_string(),
             Type::Named(named) => named.name.clone(),
             Type::Generic(generic) => generic.name.clone(),
             // The `ns$Name` alias a namespace import registers, which is the

--- a/wado-compiler/src/elaborator/solver_bridge.rs
+++ b/wado-compiler/src/elaborator/solver_bridge.rs
@@ -210,10 +210,6 @@ impl Lowering {
                     .collect::<Option<Vec<_>>>()?;
                 Some(SolverType::Decl(head, args))
             }
-            Type::Tuple(elems) if elems.is_empty() => Some(SolverType::Decl(
-                self.builtin(TypeTable::UNIT_TYPE_NAME),
-                Vec::new(),
-            )),
             Type::Tuple(elems) => elems
                 .iter()
                 .map(|elem| self.ast_type(elem, param, resolutions, self_type))

--- a/wado-compiler/src/elaborator/trait_env.rs
+++ b/wado-compiler/src/elaborator/trait_env.rs
@@ -2634,9 +2634,6 @@ pub(super) fn written_type_arg(
         ast::Type::MutReference(inner) => {
             written_type_arg(inner, resolutions).with_reference(name::RefKind::Mut)
         }
-        ast::Type::Tuple(elems) if elems.is_empty() => {
-            name::FqTypeName::builtin(TypeTable::UNIT_TYPE_NAME)
-        }
         ast::Type::Tuple(elems) => name::FqTypeName::tuple(nested(elems)),
         // Spelled by the whole shape, matching the resolved form: the two
         // sides of a lookup have to render one type one way.

--- a/wado-compiler/src/elaborator/trait_env.rs
+++ b/wado-compiler/src/elaborator/trait_env.rs
@@ -2725,7 +2725,6 @@ fn written_type_source(ty: &ast::Type) -> String {
 
 pub(super) fn get_type_name_static(ty: &ast::Type) -> String {
     match ty {
-        ast::Type::Named(named) if named.name == "()" => TypeTable::UNIT_TYPE_NAME.to_string(),
         ast::Type::Named(named) => named.name.clone(),
         ast::Type::Generic(generic) => generic.name.clone(),
         ast::Type::Reference(_) | ast::Type::MutReference(_) => name::RefKind::from_ast(ty)

--- a/wado-compiler/src/synthesis/cm_binding/cm_free.rs
+++ b/wado-compiler/src/synthesis/cm_binding/cm_free.rs
@@ -9,7 +9,8 @@ use std::cell::RefCell;
 use crate::ast::{NamedType, Type};
 use crate::cm_abi;
 use crate::component_model::{
-    CmInterfaceRegistry, cm_align_with_registry_scoped, cm_size_with_registry_scoped,
+    CmInterfaceRegistry, EMPTY_TUPLE_AT_BOUNDARY, cm_align_with_registry_scoped,
+    cm_size_with_registry_scoped,
 };
 use crate::hashmap::IndexMap;
 use crate::module_source::ModuleSource;
@@ -95,7 +96,7 @@ pub(super) fn cm_shape(ty: &Type, ctx: &CmShapeContext<'_>) -> CmShape {
     match &resolved {
         Type::Named(named) if named.name == names.string => CmShape::Str,
         Type::Named(named) => named_shape(named, ctx),
-        Type::Tuple(elems) if elems.is_empty() => CmShape::Scalar,
+        Type::Tuple(elems) if elems.is_empty() => unreachable!("{EMPTY_TUPLE_AT_BOUNDARY}"),
         Type::Tuple(elems) => CmShape::Record(field_list(elems, ctx)),
         Type::Generic(g) if g.name == names.array && g.args.len() == 1 => {
             CmShape::List(Box::new(field_of(&g.args[0], 0, ctx)))

--- a/wado-compiler/src/synthesis/cm_binding/export_adapter.rs
+++ b/wado-compiler/src/synthesis/cm_binding/export_adapter.rs
@@ -10,7 +10,7 @@ use std::rc::Rc;
 use crate::ast::Type;
 use crate::canonical::CanonicalIntrinsic;
 use crate::cm_abi;
-use crate::component_model::CmInterfaceRegistry;
+use crate::component_model::{CmInterfaceRegistry, EMPTY_TUPLE_AT_BOUNDARY};
 use crate::hashmap::IndexMap;
 use crate::module_source::{ModuleSource, ModuleSourceInterner};
 use crate::name::LocalMethodName;
@@ -1070,10 +1070,7 @@ pub(super) fn synthesize_lift_from_flat_params(
             // Stream<T>, Future<T>, Own<T>, Borrow<T> — i32 handles
             _ => (local_ref(flat_param_locals[0], "__p", TypeTable::I32), 1),
         },
-        Type::Tuple(elems) if elems.is_empty() => {
-            let unit = TirExpr::new(TirExprKind::Unit, TypeTable::UNIT, synth_span());
-            (unit, 0)
-        }
+        Type::Tuple(elems) if elems.is_empty() => unreachable!("{EMPTY_TUPLE_AT_BOUNDARY}"),
         Type::Tuple(elems) => {
             // Tuple: lift each element from consecutive flat params
             let mut total_consumed = 0;

--- a/wado-compiler/src/synthesis/cm_binding/import_adapter.rs
+++ b/wado-compiler/src/synthesis/cm_binding/import_adapter.rs
@@ -8,7 +8,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use crate::ast::{NamedType, Type};
-use crate::component_model::{CmFunctionInfo, CmInterfaceRegistry};
+use crate::component_model::{CmFunctionInfo, CmInterfaceRegistry, EMPTY_TUPLE_AT_BOUNDARY};
 use crate::hashmap::IndexSet;
 use crate::module_source::{ModuleSource, ModuleSourceInterner};
 use crate::name::LocalMethodName;
@@ -725,7 +725,7 @@ fn classify_param<'t>(
         Type::Generic(g) if matches!(g.name.as_str(), "Stream" | "Future" | "Own" | "Borrow") => {
             ParamLowering::Direct
         }
-        Type::Tuple(elems) if elems.is_empty() => ParamLowering::Direct,
+        Type::Tuple(elems) if elems.is_empty() => unreachable!("{EMPTY_TUPLE_AT_BOUNDARY}"),
         other => panic!("unsupported param type shape for CM import lowering: {other:?}"),
     }
 }

--- a/wado-compiler/src/synthesis/cm_binding/lift.rs
+++ b/wado-compiler/src/synthesis/cm_binding/lift.rs
@@ -9,7 +9,7 @@
 
 use crate::ast::{NamedType, Type};
 use crate::cm_abi;
-use crate::component_model::CmVariantCase;
+use crate::component_model::{CmVariantCase, EMPTY_TUPLE_AT_BOUNDARY};
 use crate::module_source::ModuleSource;
 use crate::tir::{
     TirBinaryOp, TirBlock, TirExpr, TirExprKind, TirLocal, TirStmt, TirStructField, TypeId,
@@ -234,9 +234,7 @@ fn synthesize_lift_inner(
                 panic!("unsupported generic type for CM lift: {gname}")
             }
         }
-        Type::Tuple(elems) if elems.is_empty() => {
-            TirExpr::new(TirExprKind::Unit, TypeTable::UNIT, synth_span())
-        }
+        Type::Tuple(elems) if elems.is_empty() => unreachable!("{EMPTY_TUPLE_AT_BOUNDARY}"),
         Type::Tuple(elems) => synthesize_lift_tuple(elems, addr, next_local, stmts, locals, ctx),
         Type::Reference(_) | Type::MutReference(_) => {
             builtin_call("i32_load", vec![addr], TypeTable::I32)

--- a/wado-compiler/src/synthesis/cm_binding/lift.rs
+++ b/wado-compiler/src/synthesis/cm_binding/lift.rs
@@ -152,6 +152,10 @@ fn synthesize_lift_inner(
                     binary(TirBinaryOp::NotEq, raw, i32_const(0), TypeTable::BOOL)
                 }
                 "char" => builtin_call("i32_load", vec![addr], TypeTable::CHAR),
+                // Unit occupies no memory, so there is nothing to load.
+                TypeTable::UNIT_TYPE_NAME => {
+                    TirExpr::new(TirExprKind::Unit, TypeTable::UNIT, synth_span())
+                }
                 _ => {
                     // CM named types arrive with `source_interface` populated
                     // either by stdlib bootstrap or by `resolve_cm_source_for`

--- a/wado-compiler/src/synthesis/cm_binding/lower.rs
+++ b/wado-compiler/src/synthesis/cm_binding/lower.rs
@@ -6,6 +6,7 @@
 
 use crate::ast::{NamedType, Type};
 use crate::cm_abi;
+use crate::component_model::EMPTY_TUPLE_AT_BOUNDARY;
 use crate::module_source::ModuleSource;
 use crate::name::LocalMethodName;
 use crate::tir::{
@@ -157,7 +158,7 @@ pub fn synthesize_lower(
              which handles aggregate layout; synthesize_lower covers primitives only",
             g.name
         ),
-        Type::Tuple(elems) if elems.is_empty() => vec![],
+        Type::Tuple(elems) if elems.is_empty() => unreachable!("{EMPTY_TUPLE_AT_BOUNDARY}"),
         Type::Tuple(_) => panic!(
             "tuples must lower via synthesize_lower_tuple, \
              which computes element offsets; synthesize_lower covers primitives only"

--- a/wado-compiler/src/synthesis/cm_binding/lower.rs
+++ b/wado-compiler/src/synthesis/cm_binding/lower.rs
@@ -89,6 +89,8 @@ pub fn synthesize_lower(
             stmts
         }
         Type::Named(named) => match named.name.as_str() {
+            // Unit occupies no memory, so there is nothing to store.
+            TypeTable::UNIT_TYPE_NAME => vec![],
             "i32" | "u32" => vec![expr_stmt(builtin_call(
                 "i32_store",
                 vec![addr, value],

--- a/wado-compiler/src/synthesis/cm_binding/types.rs
+++ b/wado-compiler/src/synthesis/cm_binding/types.rs
@@ -1383,7 +1383,7 @@ pub(super) fn type_id_to_ast_type(
     };
     match resolved {
         ResolvedType::Primitive(p) => named_no_source(p.as_str()),
-        ResolvedType::Unit => Type::Tuple(Vec::new()),
+        ResolvedType::Unit => named_no_source(TypeTable::UNIT_TYPE_NAME),
         // `Flags` joins them: its own CM type, 1 byte at <=8 labels, not a
         // four-byte `i32`.
         ResolvedType::Struct { .. }
@@ -1549,5 +1549,17 @@ mod tests {
             Some((None, "kiln/types.wado".into()))
         );
         assert_eq!(cm_interface_module("my:pkg/iface"), None);
+    }
+
+    /// The bridge back to the AST has to spell unit the way the parser does.
+    /// Every AST-level predicate asks [`Type::is_unit`], which the empty tuple
+    /// does not answer — a manufactured `[]` reads as a tuple of no elements,
+    /// and a `Result<(), E>` then lowers an `Ok` payload it does not have.
+    #[test]
+    fn the_unit_type_id_spells_the_unit_type() {
+        let (registry, _) = CmInterfaceRegistry::build_from_stdlib();
+        let type_table = TypeTable::new();
+        let unit = type_id_to_ast_type(TypeTable::UNIT, &type_table, &registry);
+        assert!(unit.is_unit(), "unit spelled as {unit:?}");
     }
 }

--- a/wado-compiler/src/synthesis/cm_binding/types.rs
+++ b/wado-compiler/src/synthesis/cm_binding/types.rs
@@ -1551,10 +1551,8 @@ mod tests {
         assert_eq!(cm_interface_module("my:pkg/iface"), None);
     }
 
-    /// The bridge back to the AST has to spell unit the way the parser does.
-    /// Every AST-level predicate asks [`Type::is_unit`], which the empty tuple
-    /// does not answer — a manufactured `[]` reads as a tuple of no elements,
-    /// and a `Result<(), E>` then lowers an `Ok` payload it does not have.
+    /// The bridge back to the AST spells unit the way the parser does, since
+    /// [`Type::is_unit`] is what every AST-level predicate asks.
     #[test]
     fn the_unit_type_id_spells_the_unit_type() {
         let (registry, _) = CmInterfaceRegistry::build_from_stdlib();

--- a/wado-compiler/src/wit_emit.rs
+++ b/wado-compiler/src/wit_emit.rs
@@ -709,7 +709,7 @@ impl<'a> Emitter<'a> {
         };
         match inner {
             None => Ok(None),
-            Some(t) if is_ast_unit(t) => Ok(None),
+            Some(t) if t.is_unit() => Ok(None),
             Some(t) => Ok(Some(self.map_ast_type(t, fq, uses)?)),
         }
     }
@@ -1088,11 +1088,7 @@ fn classify_ast(ty: &crate::ast::Type) -> CmShape<crate::ast::Type> {
 
 /// A `Result` arm in AST form: a unit arm is absent (`_`).
 fn non_unit_ast(ty: &crate::ast::Type) -> Option<crate::ast::Type> {
-    if is_ast_unit(ty) {
-        None
-    } else {
-        Some(ty.clone())
-    }
+    if ty.is_unit() { None } else { Some(ty.clone()) }
 }
 
 fn map_primitive(p: PrimitiveType) -> Result<Type, WitEmitError> {
@@ -1229,15 +1225,6 @@ fn primitive_by_name(name: &str) -> Option<Type> {
         _ => return None,
     };
     Some(ty)
-}
-
-/// Whether an AST type is the unit type `()`.
-fn is_ast_unit(ty: &crate::ast::Type) -> bool {
-    match ty {
-        crate::ast::Type::Tuple(elems) => elems.is_empty(),
-        crate::ast::Type::Named(named) => named.name == "()",
-        _ => false,
-    }
 }
 
 /// Collect the source-interface FQs of every CM-defined named type referenced

--- a/wado-compiler/tests/fixtures/error_impl_on_empty_tuple_is_not_unit.wado
+++ b/wado-compiler/tests/fixtures/error_impl_on_empty_tuple_is_not_unit.wado
@@ -1,0 +1,21 @@
+// `[]` is a type of its own, not unit. An `impl` on one is not an `impl` on
+// the other, so a `()` receiver has no method the empty tuple's impl defines.
+
+trait Marker {
+    fn tag(&self) -> i32;
+}
+
+impl Marker for [] {
+    fn tag(&self) -> i32 {
+        return 7;
+    }
+}
+
+export fn run() {
+    let u: () = ();
+    let n: i32 = u.tag();
+    assert n == 7;
+}
+
+__DATA__
+{"compile_error": "no method 'tag' found on type '()'"}

--- a/wado-compiler/tests/fixtures/error_impl_on_empty_tuple_is_not_unit.wado
+++ b/wado-compiler/tests/fixtures/error_impl_on_empty_tuple_is_not_unit.wado
@@ -1,5 +1,5 @@
 // `[]` is a type of its own, not unit. An `impl` on one is not an `impl` on
-// the other, so a `()` receiver has no method the empty tuple's impl defines.
+// the other, so a `()` receiver does not find the empty tuple's method.
 
 trait Marker {
     fn tag(&self) -> i32;

--- a/wado-compiler/tests/generated/fixtures/opt_ctor_forward_slice.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/opt_ctor_forward_slice.wir.wado
@@ -177,7 +177,7 @@ fn "opt_ctor_forward_slice.wado/__cm_future_read_core:prelude/types.wado/Result<
         __disc = builtin::load_u8(ptr);
         __result_val = ref.null none;
         if __disc == 0 {
-            __result_val = struct.new "core:prelude/types.wado//Result<(),wasi:cli/types.wado/ErrorCode>" { 0, nop };
+            __result_val = struct.new "core:prelude/types.wado//Result<(),wasi:cli/types.wado/ErrorCode>" { 0 };
         } else {
             __edisc = builtin::load_u8(ptr + 1);
             __eresult = 0;

--- a/wado-compiler/tests/generated/fixtures/stream_cm_stderr_write.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/stream_cm_stderr_write.wir.wado
@@ -192,7 +192,7 @@ fn "stream_cm_stderr_write.wado/__cm_future_read_core:prelude/types.wado/Result<
         __disc = builtin::load_u8(ptr);
         __result_val = ref.null none;
         if __disc == 0 {
-            __result_val = struct.new "core:prelude/types.wado//Result<(),wasi:cli/types.wado/ErrorCode>" { 0, nop };
+            __result_val = struct.new "core:prelude/types.wado//Result<(),wasi:cli/types.wado/ErrorCode>" { 0 };
         } else {
             __edisc = builtin::load_u8(ptr + 1);
             __eresult = 0;

--- a/wado-compiler/tests/generated/fixtures/stream_cm_stdin_pipe.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/stream_cm_stdin_pipe.wir.wado
@@ -125,7 +125,7 @@ fn "stream_cm_stdin_pipe.wado/__cm_future_read_core:prelude/types.wado/Result<()
         __disc = builtin::load_u8(ptr);
         __result_val = ref.null none;
         if __disc == 0 {
-            __result_val = struct.new "core:prelude/types.wado//Result<(),wasi:cli/types.wado/ErrorCode>" { 0, nop };
+            __result_val = struct.new "core:prelude/types.wado//Result<(),wasi:cli/types.wado/ErrorCode>" { 0 };
         } else {
             __edisc = builtin::load_u8(ptr + 1);
             __eresult = 0;

--- a/wado-compiler/tests/generated/fixtures/stream_write_raw_offset.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/stream_write_raw_offset.wir.wado
@@ -253,7 +253,7 @@ fn "stream_write_raw_offset.wado/__cm_future_read_core:prelude/types.wado/Result
         __disc = builtin::load_u8(ptr);
         __result_val = ref.null none;
         if __disc == 0 {
-            __result_val = struct.new "core:prelude/types.wado//Result<(),wasi:cli/types.wado/ErrorCode>" { 0, nop };
+            __result_val = struct.new "core:prelude/types.wado//Result<(),wasi:cli/types.wado/ErrorCode>" { 0 };
         } else {
             __edisc = builtin::load_u8(ptr + 1);
             __eresult = 0;


### PR DESCRIPTION
`()` and `[]` are distinct types, and the compiler treats them as two throughout: in the spelling it manufactures for its own unit, in the impls it registers, and in the boundary paths that carry neither.

## The compiler spells its own unit `()`

`type_id_to_ast_type` is the bridge from a `TypeId` back to the AST, and it renders `ResolvedType::Unit` as the named `()`. Every AST-level predicate asks `Type::is_unit`, which only that spelling answers, so the compiler's own unit reads as unit wherever it lands.

`cm_payload_type_from_ast` therefore classifies `Result<(), E>` as carrying no `Ok` payload, and its future lift materializes no slot for one:

```
__result_val = struct.new "…Result<(),…ErrorCode>" { 0 };
```

`lift.rs` and `lower.rs` each name unit among the types they load and store: it occupies no memory, so there is nothing to read from an address and nothing to write to one. Without that, the catch-all `Type::Named` arm takes `()` for a resource handle.

## An `impl` on `[]` is not an `impl` on `()`

```wado
impl Marker for [] {
    fn tag(&self) -> i32 { return 7; }
}

export fn run() {
    let u: () = ();
    let n: i32 = u.tag();   // error: no method 'tag' found on type '()'
}
```

A written `[]` keys its impl by the tuple head, as `FqTypeName::builtin`'s doc requires — "one spelling, whichever side asks". The general tuple path serves an empty element list: lengths of zero match, an empty zip satisfies `all`, and `SolverType::Tuple` and `FqTypeName::tuple` each carry an empty argument list. `resolve_type` makes `[]` an empty tuple, and the type check, method lookup and impl key now agree on that.

## No boundary path carries the empty tuple

`check_cm_boundary_representable` rejects a written `[]` at an export, and unit reaches synthesis spelled `()`. The import side follows from the same fact by another route: an import adapter runs only for a registry-known CM interface, and those come from WIT, which has no `tuple<>`.

Six paths state this with `unreachable!` against one shared message, so a path that does reach the empty tuple announces itself rather than lowering it as something it is not.

## One predicate

`Type::is_unit` is the only place the question is answered. `wit_emit` and codegen ask it rather than matching a name, and the name-to-string arms spell `()` the way every other named type is spelled.

The spec records what follows from `()` and `[]` being distinct: separate `impl`s, and no Component Model representation, so `[]` cannot cross a component boundary.

## Known gap

A `#[cm]` attribute naming an interface the registry does not know panics in WIR translation (`[WIR] unresolved Call`) rather than reporting a diagnostic. Unrelated to the empty tuple — the same panic occurs with an `i32` parameter — and found while probing the import path here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ePhqkD7uCobpVaFu4z1Ci