### PR TITLE
docs(skill): a PR title and opening paragraph carry the value, not the edit list

### DIFF
--- a/.claude/skills/pull-request/SKILL.md
+++ b/.claude/skills/pull-request/SKILL.md
@@ -30,8 +30,8 @@ a list of PRs is deciding whether to care.
 
 `<type>(<scope>): <the value>`
 
-Where the value is a number, the number is the title. Name two things if two are
-worth it, still on one line. If five are, name the largest and leave the rest to
+If the value is a number, put the number in. Name two things if two are worth
+it, on the same line. If there are more, name the largest and leave the rest to
 the description.
 
 `type` is `feat`, `fix`, `docs`, `perf`, `refactor` or `chore`, with `!` for a
@@ -42,8 +42,8 @@ breaking change. The scope is optional.
 Open with the outcome, in a paragraph a reader can stop after: what holds once
 this is merged, and what it is worth. Mechanism comes after, under headings.
 
-Do not include trial-and-error history in the branch; the commit history is the
-SSoT. That is any sentence which only parses against the pre-branch state:
+Do not include trial-and-error history in the description; the commit history is
+the SSoT. That is any sentence which only parses against the pre-branch state:
 "previously X, now Y", "an earlier approach", "X was replaced by Y", a count
 given as a delta ("2 -> 0"). Read each sentence back and ask whether it works
 for someone who sees only the merged tree. If it needs the old state, cut it.
@@ -61,7 +61,7 @@ No need to include a test section. CI runs the full test suite.
 
 Angle brackets need nothing but a code span: `` `t_<Name>` `` renders as
 written. The GitHub MCP server drops them and HTML-escapes quotes in the text it
-reads back, so check the web UI before believing the description is broken, and
+reads back. Check the web UI before believing the description is broken, and
 never rewrite prose to work around it.
 
 Cut the draft before posting. A first draft follows the shape of the work: a

--- a/.claude/skills/pull-request/SKILL.md
+++ b/.claude/skills/pull-request/SKILL.md
@@ -25,9 +25,8 @@ If conflicting, resolve with the `git-upstream-sync` skill.
 
 ## Title
 
-One line saying what the branch is worth. Not what was edited — a reader
-scanning a list of PRs is deciding whether to care, and an inventory of the
-change does not help them decide.
+One line saying what the branch is worth, not what was edited. A reader scanning
+a list of PRs is deciding whether to care.
 
 `<type>(<scope>): <the value>`
 
@@ -36,19 +35,17 @@ change does not help them decide.
 - No: `fix(elaborator): add an arity check to impl resolution`
 - Yes: `fix(elaborator): an impl on [] no longer matches ()`
 
-Where the value is a number, the number is the title. Where it is a behaviour,
-name the behaviour. Where a branch does two unrelated things worth naming, name
-both and keep it to one line; where it does five, the title names the largest
-and the description carries the rest.
+Where the value is a number, the number is the title. Name two things if two are
+worth it, still on one line. If five are, name the largest and leave the rest to
+the description.
 
 `type` is `feat`, `fix`, `docs`, `perf`, `refactor` or `chore`, with `!` for a
-breaking change (`feat!`, `fix!`). The scope is optional.
+breaking change. The scope is optional.
 
 ## Description
 
-Open with the outcome, in a paragraph a reader can stop after. What holds once
-this is merged, and what it is worth — the numbers if the value is a number, the
-behaviour if it is a behaviour. Mechanism comes after, under headings.
+Open with the outcome, in a paragraph a reader can stop after: what holds once
+this is merged, and what it is worth. Mechanism comes after, under headings.
 
 Do not include trial-and-error history in the branch; the commit history is the
 SSoT. That is any sentence which only parses against the pre-branch state:
@@ -59,8 +56,8 @@ for someone who sees only the merged tree. If it needs the old state, cut it.
 - No: "Codegen looked the global up by name; it now compares the read's type."
 - Yes: "Codegen compares the read site's `result_ty` against the slot's type."
 
-The same test applies to the opening paragraph, and it is where the temptation
-is worst: a speedup is worth stating, the struggle to find it is not.
+The opening paragraph is the hardest place to hold that line: a speedup is worth
+stating, the struggle to find it is not.
 
 If the branch obviously closes a known issue, add a closing keyword
 (`Closes #N`). Do not go looking for one to attach.
@@ -68,17 +65,21 @@ If the branch obviously closes a known issue, add a closing keyword
 No need to include a test section. CI runs the full test suite.
 
 Angle brackets need nothing but a code span: `` `t_<Name>` `` renders as
-written. The GitHub MCP server mangles the text it reads back — it drops the
-brackets and HTML-escapes quotes — so check the web UI before believing the
-description is broken, and never rewrite prose to work around it.
+written. The GitHub MCP server drops them and HTML-escapes quotes in the text it
+reads back, so check the web UI before believing the description is broken, and
+never rewrite prose to work around it.
 
-## After opening & Periodic status checks
+Cut the draft before posting. A first draft follows the shape of the work: a
+heading for each thing that happened, at the length it took to do. Read it back
+and cut every sentence a reader would skip.
+
+## After opening
 
 Subscribe to the PR with `subscribe_pr_activity`. Handle every event it
 delivers; skipping one is a decision you state. If the tool is unavailable, say
 so when reporting the PR rather than implying you are watching it.
 
-Check mergeability (`mergeable_state`). If conflicting, resolve it with the
-`git-upstream-sync` skill.
+Keep checking mergeability (`mergeable_state`). If conflicting, resolve it with
+the `git-upstream-sync` skill.
 
 Answer a review, human or bot, with the `code-review-response` skill.

--- a/.claude/skills/pull-request/SKILL.md
+++ b/.claude/skills/pull-request/SKILL.md
@@ -5,8 +5,8 @@ description: The rules for opening a PR you must read before creating or editing
 
 ## Before writing
 
-Read `git diff origin/main...HEAD` (three dots). The description comes from that
-diff, not from the session that produced it.
+Read `git diff origin/main...HEAD` (three dots). The title and description come
+from that diff, not from the session that produced it.
 
 Revise the branch while you are there: clean up comments and docs according to
 the project rules.
@@ -23,24 +23,32 @@ touches neither the worktree nor the index.
 
 If conflicting, resolve with the `git-upstream-sync` skill.
 
-## PR Title
+## Title
 
-Use the Conventional Commits style for pull request titles:
+One line saying what the branch is worth. Not what was edited — a reader
+scanning a list of PRs is deciding whether to care, and an inventory of the
+change does not help them decide.
 
-- `feat`: add a new feature
-- `feat!`: add a new feature with a breaking change
-- `fix`: bug fix
-- `fix!`: bug fix with a breaking change
-- `docs`: documentation-only changes
-- `perf`: code change that improves performance
-- `refactor`: code change that neither fixes a bug nor adds a feature
-- `chore`: anything else (e.g. CI, build process, dependencies)
+`<type>(<scope>): <the value>`
 
-It may include a scope, e.g. `feat(optimizer)`.
+- No: `refactor(nir): thread a frame stack through the arena visitors`
+- Yes: `perf(nir): 7 % off a debug compile of the SQLite parser`
+- No: `fix(elaborator): add an arity check to impl resolution`
+- Yes: `fix(elaborator): an impl on [] no longer matches ()`
 
-## PR Description
+Where the value is a number, the number is the title. Where it is a behaviour,
+name the behaviour. Where a branch does two unrelated things worth naming, name
+both and keep it to one line; where it does five, the title names the largest
+and the description carries the rest.
 
-Describe the outcome of the whole branch — what holds once it is merged.
+`type` is `feat`, `fix`, `docs`, `perf`, `refactor` or `chore`, with `!` for a
+breaking change (`feat!`, `fix!`). The scope is optional.
+
+## Description
+
+Open with the outcome, in a paragraph a reader can stop after. What holds once
+this is merged, and what it is worth — the numbers if the value is a number, the
+behaviour if it is a behaviour. Mechanism comes after, under headings.
 
 Do not include trial-and-error history in the branch; the commit history is the
 SSoT. That is any sentence which only parses against the pre-branch state:
@@ -51,21 +59,24 @@ for someone who sees only the merged tree. If it needs the old state, cut it.
 - No: "Codegen looked the global up by name; it now compares the read's type."
 - Yes: "Codegen compares the read site's `result_ty` against the slot's type."
 
+The same test applies to the opening paragraph, and it is where the temptation
+is worst: a speedup is worth stating, the struggle to find it is not.
+
 If the branch obviously closes a known issue, add a closing keyword
 (`Closes #N`). Do not go looking for one to attach.
 
 No need to include a test section. CI runs the full test suite.
 
-Angle brackets need nothing but a code span: `` `t_<Name>` `` renders as written.
-Reading the body back through the GitHub MCP server shows it as `t_` — that path
-mangles the text it returns (it HTML-escapes quotes in the same response), so
-what it hands back is not what GitHub stored. Check the web UI before believing
-the description is broken, and never rewrite prose to work around it.
+Angle brackets need nothing but a code span: `` `t_<Name>` `` renders as
+written. The GitHub MCP server mangles the text it reads back — it drops the
+brackets and HTML-escapes quotes — so check the web UI before believing the
+description is broken, and never rewrite prose to work around it.
 
 ## After opening & Periodic status checks
 
 Subscribe to the PR with `subscribe_pr_activity`. Handle every event it
-delivers; skipping one is a decision you state.
+delivers; skipping one is a decision you state. If the tool is unavailable, say
+so when reporting the PR rather than implying you are watching it.
 
 Check mergeability (`mergeable_state`). If conflicting, resolve it with the
 `git-upstream-sync` skill.

--- a/.claude/skills/pull-request/SKILL.md
+++ b/.claude/skills/pull-request/SKILL.md
@@ -30,11 +30,6 @@ a list of PRs is deciding whether to care.
 
 `<type>(<scope>): <the value>`
 
-- No: `refactor(nir): thread a frame stack through the arena visitors`
-- Yes: `perf(nir): 7 % off a debug compile of the SQLite parser`
-- No: `fix(elaborator): add an arity check to impl resolution`
-- Yes: `fix(elaborator): an impl on [] no longer matches ()`
-
 Where the value is a number, the number is the title. Name two things if two are
 worth it, still on one line. If five are, name the largest and leave the rest to
 the description.


### PR DESCRIPTION
The `pull-request` skill judges a PR by what a reader gets from it: the title states what the branch is worth rather than what was edited, the description opens with a paragraph a reader can stop after, and the draft is cut before it is posted.

## Title

`<type>(<scope>): <the value>`. Where the value is a number, the number is the title; where several are worth naming, the largest goes in the title and the rest in the description. The type stays Conventional Commits, stated in one line.

## Description

The opening paragraph carries the outcome and its worth; mechanism follows under headings. The rule against trial-and-error prose names that paragraph as the hardest place to hold the line — a speedup is worth stating, the struggle to find it is not. Reading the draft back and cutting every sentence a reader would skip is a step, not an aspiration.

## After opening

If `subscribe_pr_activity` is unavailable, say so when reporting the PR rather than implying the PR is being watched. Mergeability is checked for as long as the PR is open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)