### PR TITLE
fix(nir): a census that walks the body sees the value pool's extraction sources

### DIFF
--- a/docs/wep-2026-06-05-nir-optimizer-architecture.md
+++ b/docs/wep-2026-06-05-nir-optimizer-architecture.md
@@ -225,6 +225,13 @@ These are settled by measurement and re-derived at a cost.
   local is unused, or rewrites every read of one, must count the pool's reads as
   well. The count is scoped to the operands the skeleton still carries, since the
   pool is append-only and also holds reads that folded away.
+- A whole-body walk is `for_each_reachable_node`, which covers the skeleton and
+  what a promoted operand names as its extraction source. `for_each_node_under`
+  walks a subtree and asserts it is not handed the root block. Reaching for the
+  skeleton walk over a whole body is the shape every bridge miscompile took, and
+  the name is what invites it. The pool records whether an extraction source
+  exists at all, so a body with none takes the plain skeleton walk and the
+  coverage costs nothing.
 - That census is session-scoped, never per-application. It walks the whole
   body, so recomputing it per rule application is quadratic. It is memoized, and
   the memo is maintained across edits rather than dropped: an operand becoming

--- a/docs/wep-2026-06-05-nir-optimizer-architecture.md
+++ b/docs/wep-2026-06-05-nir-optimizer-architecture.md
@@ -227,11 +227,11 @@ These are settled by measurement and re-derived at a cost.
   pool is append-only and also holds reads that folded away.
 - A whole-body walk is `for_each_reachable_node`, which covers the skeleton and
   what a promoted operand names as its extraction source. `for_each_node_under`
-  walks a subtree and asserts it is not handed the root block. Reaching for the
-  skeleton walk over a whole body is the shape every bridge miscompile took, and
-  the name is what invites it. The pool records whether an extraction source
-  exists at all, so a body with none takes the plain skeleton walk and the
-  coverage costs nothing.
+  walks a subtree, and asserts it is not handed the root block: every bridge
+  miscompile came from a census reaching for the skeleton walk because its name
+  is the obvious one. The pool records whether an extraction source exists at
+  all, so a body with none takes the plain skeleton walk and the coverage costs
+  nothing.
 - That census is session-scoped, never per-application. It walks the whole
   body, so recomputing it per rule application is quadratic. It is memoized, and
   the memo is maintained across edits rather than dropped: an operand becoming

--- a/wado-compiler/src/nir_arena.rs
+++ b/wado-compiler/src/nir_arena.rs
@@ -1141,21 +1141,12 @@ impl Body {
         }
         let mut pool_seen: IndexSet<ValueId> = IndexSet::default();
         let mut sourced: Vec<ExprId> = Vec::new();
-        self.for_each_skeleton_node(root, |node| {
-            f(node);
-            self.for_each_operand(node, |op| {
-                if let Some(v) = op.as_value() {
-                    self.values
-                        .for_each_opaque_expr(v, &mut pool_seen, |e| sourced.push(e));
-                }
-            });
-        });
-        // Not collected during the first walk: an insert per node costs more
-        // than this second one, which a body with no source never reaches.
-        #[cfg(debug_assertions)]
+        self.walk_sourcing(root, &mut f, &mut pool_seen, &mut sourced, None);
+        // Only the assertion reads this, and only a body that named a source can
+        // fail it, so nothing else pays the scan or the per-node insert.
         let mut covered: IndexSet<ExprId> = IndexSet::default();
-        #[cfg(debug_assertions)]
-        if !sourced.is_empty() {
+        let checking = cfg!(debug_assertions) && !sourced.is_empty();
+        if checking {
             self.for_each_skeleton_node(root, |node| {
                 if let NodeRef::Expr(e) = node {
                     covered.insert(e);
@@ -1170,20 +1161,40 @@ impl Body {
                 "[NIR] {e:?} is an extraction source this walk already covered, so \
                  `reachable_operand_values` counts its slots twice"
             );
-            self.for_each_skeleton_node(NodeRef::Expr(e), |node| {
-                f(node);
-                #[cfg(debug_assertions)]
-                if let NodeRef::Expr(inner) = node {
-                    covered.insert(inner);
-                }
-                self.for_each_operand(node, |op| {
-                    if let Some(v) = op.as_value() {
-                        self.values
-                            .for_each_opaque_expr(v, &mut pool_seen, |e| sourced.push(e));
-                    }
-                });
-            });
+            self.walk_sourcing(
+                NodeRef::Expr(e),
+                &mut f,
+                &mut pool_seen,
+                &mut sourced,
+                checking.then_some(&mut covered),
+            );
         }
+    }
+
+    /// Walk `root`'s skeleton subtree into `f`, pushing the extraction sources
+    /// its operands name onto `sourced`. `covered` records what `f` was handed.
+    fn walk_sourcing(
+        &self,
+        root: NodeRef,
+        f: &mut impl FnMut(NodeRef),
+        pool_seen: &mut IndexSet<ValueId>,
+        sourced: &mut Vec<ExprId>,
+        mut covered: Option<&mut IndexSet<ExprId>>,
+    ) {
+        self.for_each_skeleton_node(root, |node| {
+            f(node);
+            if let Some(covered) = covered.as_deref_mut()
+                && let NodeRef::Expr(e) = node
+            {
+                covered.insert(e);
+            }
+            self.for_each_operand(node, |op| {
+                if let Some(v) = op.as_value() {
+                    self.values
+                        .for_each_opaque_expr(v, pool_seen, |e| sourced.push(e));
+                }
+            });
+        });
     }
 
     /// The first value `f` gives for `root` or a node beneath it, parents before
@@ -1269,19 +1280,9 @@ impl Body {
         self.for_each_live_node_under(NodeRef::Block(self.root), f);
     }
 
-    /// The first value `f` gives for a reachable node. [`Body::find_in_nodes_under`]
-    /// is the skeleton form, and stops at the first hit; this one walks on.
-    pub fn find_in_reachable_node<T>(&self, mut f: impl FnMut(NodeRef) -> Option<T>) -> Option<T> {
-        let mut found = None;
-        self.for_each_reachable_node(|node| {
-            if found.is_none() {
-                found = f(node);
-            }
-        });
-        found
-    }
-
-    /// [`Body::find_in_reachable_node`] over one subtree.
+    /// The first value `f` gives for `root` or a live node beneath it.
+    /// [`Body::find_in_nodes_under`] is the skeleton form and stops at the first
+    /// hit; this one walks on.
     pub fn find_in_live_node_under<T>(
         &self,
         root: NodeRef,

--- a/wado-compiler/src/nir_arena.rs
+++ b/wado-compiler/src/nir_arena.rs
@@ -1097,7 +1097,7 @@ impl Body {
     /// go stale after `inline` / `ref_elim` copy reference nodes, so
     /// alias-sensitive consumers union this scan in.
     pub fn collect_address_taken_locals(&self, out: &mut crate::hashmap::IndexSet<u32>) {
-        self.for_each_node_under(NodeRef::Block(self.root), |node| {
+        self.for_each_reachable_node(|node| {
             if let NodeRef::Expr(id) = node
                 && let ExprKind::Unary {
                     op: crate::nir::NirUnaryOp::Ref | crate::nir::NirUnaryOp::MutRef,
@@ -1112,7 +1112,19 @@ impl Body {
     }
 
     /// Invoke `f` on `root` and every node beneath it, parents before children.
-    pub fn for_each_node_under(&self, root: NodeRef, mut f: impl FnMut(NodeRef)) {
+    /// A subtree walk: the whole body is [`Body::for_each_reachable_node`].
+    pub fn for_each_node_under(&self, root: NodeRef, f: impl FnMut(NodeRef)) {
+        debug_assert!(
+            self.blocks.is_empty() || root != NodeRef::Block(self.root),
+            "[NIR] a whole-body walk is `for_each_reachable_node`, which also covers what a \
+             promoted operand names as its extraction source"
+        );
+        self.for_each_skeleton_node(root, f);
+    }
+
+    /// [`Body::for_each_node_under`] without its whole-body check, for the two
+    /// walks [`Body::for_each_live_node_under`] is itself made of.
+    fn for_each_skeleton_node(&self, root: NodeRef, mut f: impl FnMut(NodeRef)) {
         self.walk_nodes_under::<()>(root, |node| {
             f(node);
             ControlFlow::Continue(true)
@@ -1124,9 +1136,13 @@ impl Body {
     /// took only skeleton children would call them orphans — and a rewrite that
     /// trusted the walk would pass them by.
     pub fn for_each_live_node_under(&self, root: NodeRef, mut f: impl FnMut(NodeRef)) {
+        if !self.values.has_expr_source() {
+            self.for_each_skeleton_node(root, f);
+            return;
+        }
         let mut pool_seen: IndexSet<ValueId> = IndexSet::default();
         let mut sourced: Vec<ExprId> = Vec::new();
-        self.for_each_node_under(root, |node| {
+        self.for_each_skeleton_node(root, |node| {
             f(node);
             self.for_each_operand(node, |op| {
                 if let Some(v) = op.as_value() {
@@ -1140,7 +1156,7 @@ impl Body {
         let mut covered: IndexSet<ExprId> = IndexSet::default();
         #[cfg(debug_assertions)]
         if !sourced.is_empty() {
-            self.for_each_node_under(root, |node| {
+            self.for_each_skeleton_node(root, |node| {
                 if let NodeRef::Expr(e) = node {
                     covered.insert(e);
                 }
@@ -1154,7 +1170,7 @@ impl Body {
                 "[NIR] {e:?} is an extraction source this walk already covered, so \
                  `reachable_operand_values` counts its slots twice"
             );
-            self.for_each_node_under(NodeRef::Expr(e), |node| {
+            self.for_each_skeleton_node(NodeRef::Expr(e), |node| {
                 f(node);
                 #[cfg(debug_assertions)]
                 if let NodeRef::Expr(inner) = node {
@@ -1251,6 +1267,33 @@ impl Body {
             return;
         }
         self.for_each_live_node_under(NodeRef::Block(self.root), f);
+    }
+
+    /// The first value `f` gives for a reachable node. [`Body::find_in_nodes_under`]
+    /// is the skeleton form, and stops at the first hit; this one walks on.
+    pub fn find_in_reachable_node<T>(&self, mut f: impl FnMut(NodeRef) -> Option<T>) -> Option<T> {
+        let mut found = None;
+        self.for_each_reachable_node(|node| {
+            if found.is_none() {
+                found = f(node);
+            }
+        });
+        found
+    }
+
+    /// [`Body::find_in_reachable_node`] over one subtree.
+    pub fn find_in_live_node_under<T>(
+        &self,
+        root: NodeRef,
+        mut f: impl FnMut(NodeRef) -> Option<T>,
+    ) -> Option<T> {
+        let mut found = None;
+        self.for_each_live_node_under(root, |node| {
+            if found.is_none() {
+                found = f(node);
+            }
+        });
+        found
     }
 
     /// The distinct promoted values the reachable skeleton carries, and how many

--- a/wado-compiler/src/nir_arena.rs
+++ b/wado-compiler/src/nir_arena.rs
@@ -1122,8 +1122,8 @@ impl Body {
         self.for_each_skeleton_node(root, f);
     }
 
-    /// [`Body::for_each_node_under`] without its whole-body check, for the two
-    /// walks [`Body::for_each_live_node_under`] is itself made of.
+    /// [`Body::for_each_node_under`] without its whole-body check, for the walks
+    /// [`Body::for_each_live_node_under`] is itself made of.
     fn for_each_skeleton_node(&self, root: NodeRef, mut f: impl FnMut(NodeRef)) {
         self.walk_nodes_under::<()>(root, |node| {
             f(node);
@@ -1132,9 +1132,8 @@ impl Body {
     }
 
     /// [`Body::for_each_node_under`] plus the nodes a promoted operand names as
-    /// its extraction source. Those produce the operand's code, so a walk that
-    /// took only skeleton children would call them orphans — and a rewrite that
-    /// trusted the walk would pass them by.
+    /// its extraction source. Those produce the operand's code, so a walk
+    /// without them calls a live node an orphan.
     pub fn for_each_live_node_under(&self, root: NodeRef, mut f: impl FnMut(NodeRef)) {
         if !self.values.has_expr_source() {
             self.for_each_skeleton_node(root, f);
@@ -1151,7 +1150,8 @@ impl Body {
                 }
             });
         });
-        // Built only once a source exists, so a body with none pays nothing.
+        // Not collected during the first walk: an insert per node costs more
+        // than this second one, which a body with no source never reaches.
         #[cfg(debug_assertions)]
         let mut covered: IndexSet<ExprId> = IndexSet::default();
         #[cfg(debug_assertions)]

--- a/wado-compiler/src/nir_arena.rs
+++ b/wado-compiler/src/nir_arena.rs
@@ -1092,10 +1092,9 @@ impl Body {
 
 /// Structural navigation used by the rewrite engine (parent map + worklist).
 impl Body {
-    /// Collect every local with a live `&local` / `&mut local` in the body.
-    /// The canonical `address_taken_locals` / `stores_aliased_locals` sets
-    /// go stale after `inline` / `ref_elim` copy reference nodes, so
-    /// alias-sensitive consumers union this scan in.
+    /// Every local with a live `&local` / `&mut local`. The canonical
+    /// `address_taken_locals` / `stores_aliased_locals` go stale once `inline` /
+    /// `ref_elim` copy reference nodes, so alias-sensitive consumers union this in.
     pub fn collect_address_taken_locals(&self, out: &mut crate::hashmap::IndexSet<u32>) {
         self.for_each_reachable_node(|node| {
             if let NodeRef::Expr(id) = node
@@ -1210,6 +1209,22 @@ impl Body {
         })
     }
 
+    /// The first value `f` gives for `root` or a live node beneath it.
+    /// [`Body::find_in_nodes_under`] stops at the first hit; this one walks on.
+    pub fn find_in_live_node_under<T>(
+        &self,
+        root: NodeRef,
+        mut f: impl FnMut(NodeRef) -> Option<T>,
+    ) -> Option<T> {
+        let mut found = None;
+        self.for_each_live_node_under(root, |node| {
+            if found.is_none() {
+                found = f(node);
+            }
+        });
+        found
+    }
+
     /// Walk `root` and the nodes beneath it, parents before children. `f`
     /// answers `Continue(true)` to descend into a node's children,
     /// `Continue(false)` to skip them, or `Break(value)` to stop the walk.
@@ -1278,23 +1293,6 @@ impl Body {
             return;
         }
         self.for_each_live_node_under(NodeRef::Block(self.root), f);
-    }
-
-    /// The first value `f` gives for `root` or a live node beneath it.
-    /// [`Body::find_in_nodes_under`] is the skeleton form and stops at the first
-    /// hit; this one walks on.
-    pub fn find_in_live_node_under<T>(
-        &self,
-        root: NodeRef,
-        mut f: impl FnMut(NodeRef) -> Option<T>,
-    ) -> Option<T> {
-        let mut found = None;
-        self.for_each_live_node_under(root, |node| {
-            if found.is_none() {
-                found = f(node);
-            }
-        });
-        found
     }
 
     /// The distinct promoted values the reachable skeleton carries, and how many

--- a/wado-compiler/src/nir_value_graph.rs
+++ b/wado-compiler/src/nir_value_graph.rs
@@ -515,6 +515,9 @@ pub struct ValuePool {
     /// scheduled skeleton expression (a call result kept in the skeleton).
     /// Empty for opaques minted without a recorded source.
     opaque_sources: IndexMap<OpaqueId, OpaqueSource>,
+    /// Whether any [`OpaqueSource::Expr`] has ever been recorded. Sticky, so it
+    /// over-estimates rather than reporting a source the walks would then skip.
+    expr_sources: bool,
     /// One stable `Opaque(Local idx)` per local, memoized so repeated requests
     /// (e.g. a loop-stability re-seed of a local's reads after maintenance
     /// dropped them) share a single identity — the precondition for matching the
@@ -650,8 +653,16 @@ impl ValuePool {
     pub fn fresh_opaque_with_source(&mut self, source: OpaqueSource) -> ValueId {
         let opaque = OpaqueId(self.next_opaque);
         self.next_opaque += 1;
+        self.expr_sources |= matches!(source, OpaqueSource::Expr(_));
         self.opaque_sources.insert(opaque, source);
         self.intern(ValueKind::Opaque(opaque))
+    }
+
+    /// Whether any operand can name a skeleton-external extraction source. False
+    /// lets a reachability walk stay on the skeleton.
+    #[inline]
+    pub fn has_expr_source(&self) -> bool {
+        self.expr_sources
     }
 
     /// The recorded extraction source of an `Opaque`, if any.

--- a/wado-compiler/src/nir_value_graph.rs
+++ b/wado-compiler/src/nir_value_graph.rs
@@ -515,8 +515,8 @@ pub struct ValuePool {
     /// scheduled skeleton expression (a call result kept in the skeleton).
     /// Empty for opaques minted without a recorded source.
     opaque_sources: IndexMap<OpaqueId, OpaqueSource>,
-    /// Whether any [`OpaqueSource::Expr`] has ever been recorded. Sticky, so it
-    /// over-estimates rather than reporting a source the walks would then skip.
+    /// Whether any [`OpaqueSource::Expr`] has ever been recorded. Sticky: an
+    /// over-estimate costs a walk, a stale `false` would skip a live node.
     expr_sources: bool,
     /// One stable `Opaque(Local idx)` per local, memoized so repeated requests
     /// (e.g. a loop-stability re-seed of a local's reads after maintenance

--- a/wado-compiler/src/niri.rs
+++ b/wado-compiler/src/niri.rs
@@ -400,7 +400,7 @@ pub fn region_queries(
         shapes: None,
     };
     let mut out = Vec::new();
-    body.for_each_node_under(NodeRef::Block(body.root), |node| {
+    body.for_each_reachable_node(|node| {
         if let NodeRef::Expr(e) = node
             && let Some((block, _)) = region::region_shape(body, e, type_table)
         {

--- a/wado-compiler/src/niri/region.rs
+++ b/wado-compiler/src/niri/region.rs
@@ -191,7 +191,7 @@ pub(super) fn region_needs(
     let mut seen = LocalSet::default();
     let mut mentioned: Vec<(u32, Option<TypeId>)> = Vec::new();
     let mut written = LocalSet::default();
-    body.for_each_node_under(NodeRef::Block(block), |node| {
+    body.for_each_live_node_under(NodeRef::Block(block), |node| {
         match node {
             NodeRef::Stmt(s) => {
                 if let StmtKind::Let { local_index, .. } = &body.stmts[s].kind {

--- a/wado-compiler/src/niri/rewrite.rs
+++ b/wado-compiler/src/niri/rewrite.rs
@@ -1325,7 +1325,7 @@ fn existing_fields(
 /// Whether anything inside `block` binds `local` — storage the block opened, as
 /// against a local it read from outside.
 fn block_binds_local(body: &Body, block: BlockId, local: u32) -> bool {
-    body.find_in_nodes_under(NodeRef::Block(block), |node| {
+    body.find_in_live_node_under(NodeRef::Block(block), |node| {
         body.binds_local(node, local).then_some(())
     })
     .is_some()

--- a/wado-compiler/src/niri/trackability.rs
+++ b/wado-compiler/src/niri/trackability.rs
@@ -42,14 +42,10 @@ fn performed_exprs(body: &Body) -> IndexSet<ExprId> {
     performed
 }
 
-/// Every statement id reachable from the body root, in walk order — or every
-/// statement, for a bare-expression body with no block structure.
+/// Every reachable statement id, in walk order.
 fn reachable_stmts(body: &Body) -> Vec<StmtId> {
-    if body.blocks.is_empty() {
-        return body.stmts.iter().map(|(s, _)| s).collect();
-    }
     let mut stmts = Vec::new();
-    body.for_each_node_under(NodeRef::Block(body.root), |node| {
+    body.for_each_reachable_node(|node| {
         if let NodeRef::Stmt(s) = node {
             stmts.push(s);
         }

--- a/wado-compiler/src/optimize/arena_query.rs
+++ b/wado-compiler/src/optimize/arena_query.rs
@@ -17,9 +17,7 @@ use crate::nir_engine::Engine;
 use crate::nir_value_graph::{OpaqueSource, ValueId, ValueKind};
 use crate::tir::TypeTable;
 
-/// Every block reachable from the body root, in DFS pop order (a block precedes
-/// the blocks nested under it). The NIR block graph is a tree, so no visited set
-/// is needed.
+/// Every reachable block, each before the blocks nested under it.
 pub(super) fn reachable_blocks(body: &Body) -> Vec<BlockId> {
     let mut out = Vec::new();
     body.for_each_reachable_node(|node| {

--- a/wado-compiler/src/optimize/arena_query.rs
+++ b/wado-compiler/src/optimize/arena_query.rs
@@ -22,7 +22,7 @@ use crate::tir::TypeTable;
 /// is needed.
 pub(super) fn reachable_blocks(body: &Body) -> Vec<BlockId> {
     let mut out = Vec::new();
-    body.for_each_node_under(NodeRef::Block(body.root), |node| {
+    body.for_each_reachable_node(|node| {
         if let NodeRef::Block(b) = node {
             out.push(b);
         }
@@ -352,7 +352,7 @@ fn node_mentions_local(body: &Body, node: NodeRef, idx: u32) -> bool {
 /// nesting. Shared by the inliner (cold-cost) and labeled-block fusion
 /// (unlabeled-break capture guard).
 pub(super) fn block_contains_loop(body: &Body, block: BlockId) -> bool {
-    body.find_in_nodes_under(NodeRef::Block(block), |n| {
+    body.find_in_live_node_under(NodeRef::Block(block), |n| {
         matches!(n, NodeRef::Stmt(s) if matches!(body.stmts[s].kind, StmtKind::Loop { .. }))
             .then_some(())
     })

--- a/wado-compiler/src/optimize/clone_forward.rs
+++ b/wado-compiler/src/optimize/clone_forward.rs
@@ -116,7 +116,7 @@ fn root_local(body: &Body, expr: ExprId) -> Option<u32> {
 
 /// Accumulate whole-function usage for every local.
 fn collect_usage(body: &Body, usage: &mut IndexMap<u32, Usage>) {
-    body.for_each_node_under(NodeRef::Block(body.root), |node| {
+    body.for_each_reachable_node(|node| {
         if let NodeRef::Expr(id) = node {
             match &body.exprs[id].kind {
                 ExprKind::Local { index, .. } => {
@@ -183,7 +183,7 @@ fn stmt_disturbs_place(
     let mut disturbs = false;
     // A node the walk stops at disturbs the place on its own; `disturbs`
     // accumulates the rest.
-    let stopped = body.find_in_nodes_under(NodeRef::Stmt(stmt), |node| {
+    let stopped = body.find_in_live_node_under(NodeRef::Stmt(stmt), |node| {
         if let NodeRef::Expr(id) = node {
             match &body.exprs[id].kind {
                 ExprKind::GlobalVarSet { .. } => return Some(()),
@@ -258,7 +258,7 @@ fn mut_arg_hits_root(
 /// Locals whose address is taken by a `&mut` borrow anywhere in the function:
 /// a write through such a reference can reach the local without naming it.
 fn collect_address_taken(body: &Body, out: &mut IndexSet<u32>) {
-    body.for_each_node_under(NodeRef::Block(body.root), |node| {
+    body.for_each_reachable_node(|node| {
         if let NodeRef::Expr(id) = node
             && let ExprKind::Unary {
                 op: NirUnaryOp::MutRef,
@@ -282,7 +282,7 @@ fn find_clone_referent_use(
     index: u32,
     descriptors: &[FunctionRef],
 ) -> Option<ExprId> {
-    body.find_in_nodes_under(NodeRef::Stmt(stmt), |node| {
+    body.find_in_live_node_under(NodeRef::Stmt(stmt), |node| {
         if let NodeRef::Expr(id) = node
             && let ExprKind::Call { func_id, args, .. } = &body.exprs[id].kind
             && is_consuming_clone(*func_id, descriptors)

--- a/wado-compiler/src/optimize/condition_implication.rs
+++ b/wado-compiler/src/optimize/condition_implication.rs
@@ -139,7 +139,7 @@ pub(super) type Binds = crate::hashmap::IndexMap<u32, Operand>;
 /// so resolving through it can never read a stale value.
 pub(super) fn build_copy_bindings(body: &crate::nir_arena::Body) -> Binds {
     let mut reassigned = crate::hashmap::IndexSet::default();
-    body.for_each_node_under(NodeRef::Block(body.root), |n| {
+    body.for_each_reachable_node(|n| {
         if let Some(r) = local_written_by(body, n) {
             reassigned.insert(r);
         }
@@ -679,7 +679,7 @@ pub(super) fn node_modifies(engine: &Engine, node: NodeRef, var: u32, bound: Bou
             }
         }
     };
-    engine.body.for_each_node_under(node, visit);
+    engine.body.for_each_live_node_under(node, visit);
     hit
 }
 
@@ -745,7 +745,7 @@ fn refute_panic_checks(
     refute: impl Fn(&Engine, &Binds, Operand) -> bool,
 ) -> bool {
     let mut holders: Vec<(NodeRef, Operand)> = Vec::new();
-    engine.body.for_each_node_under(node, |n| {
+    engine.body.for_each_live_node_under(node, |n| {
         if let Some(cond) = panic_guard_check(engine, n)
             && refute(engine, binds, cond)
         {

--- a/wado-compiler/src/optimize/const_folding.rs
+++ b/wado-compiler/src/optimize/const_folding.rs
@@ -491,7 +491,7 @@ struct GlobalStoreCollector<'a> {
 
 impl GlobalStoreCollector<'_> {
     fn visit_body(&mut self, body: &Body) {
-        body.for_each_node_under(NodeRef::Block(body.root), |node| match node {
+        body.for_each_reachable_node(|node| match node {
             NodeRef::Expr(e) => self.visit_expr(body, e),
             NodeRef::Stmt(s) => self.visit_stmt(body, s),
             NodeRef::Block(_) | NodeRef::Pat(_) => {}
@@ -972,7 +972,7 @@ impl ConstFoldVisitor<'_> {
             // drop the stale entry for every local the pattern binds; otherwise a
             // reused index keeps the earlier `let`'s constant.
             StmtKind::LetDestructure { pattern, .. } => {
-                body.for_each_node_under(NodeRef::Pat(*pattern), |node| {
+                body.for_each_live_node_under(NodeRef::Pat(*pattern), |node| {
                     if let NodeRef::Pat(p) = node
                         && let PatKind::Binding { local_index, .. } = &body.pats[p].kind
                     {

--- a/wado-compiler/src/optimize/const_object_globalization.rs
+++ b/wado-compiler/src/optimize/const_object_globalization.rs
@@ -769,7 +769,7 @@ fn set_then_get_block(
 fn locals_declared_once(body: &Body) -> IndexSet<u32> {
     let mut seen: IndexSet<u32> = IndexSet::default();
     let mut dupes: IndexSet<u32> = IndexSet::default();
-    body.for_each_node_under(NodeRef::Block(body.root), |node| {
+    body.for_each_reachable_node(|node| {
         if let NodeRef::Stmt(s) = node
             && let StmtKind::Let { local_index, .. } = &body.stmts[s].kind
             && !seen.insert(*local_index)
@@ -1025,7 +1025,7 @@ fn detach_stmts(body: &mut Body, stmts: &[StmtId]) {
 /// The `GlobalVarSet` a hoist just planted, which every sibling rewrite folds
 /// its moved definitions into.
 fn find_global_var_set(body: &Body, module_source: &ModuleSource, name: &str) -> ExprId {
-    if let Some(e) = body.find_in_nodes_under(NodeRef::Block(body.root), |node| {
+    if let Some(e) = body.find_in_reachable_node(|node| {
         if let NodeRef::Expr(e) = node
             && let ExprKind::GlobalVarSet {
                 name: n,
@@ -1052,7 +1052,7 @@ fn stmts_within_operand(body: &Body, value: Operand) -> IndexSet<StmtId> {
     let Some(e) = value.as_expr() else {
         return out;
     };
-    body.for_each_node_under(NodeRef::Expr(e), |node| {
+    body.for_each_live_node_under(NodeRef::Expr(e), |node| {
         if let NodeRef::Stmt(s) = node {
             out.insert(s);
         }
@@ -1080,7 +1080,7 @@ fn sibling_const_locals(
     let mut sc = SiblingConsts::default();
     loop {
         let mut changed = false;
-        body.for_each_node_under(NodeRef::Block(body.root), |node| {
+        body.for_each_reachable_node(|node| {
             if let NodeRef::Stmt(s) = node
                 && let StmtKind::Let {
                     local_index,
@@ -1126,7 +1126,7 @@ fn mutated_locals(body: &Body, gate: &Gate<'_>) -> IndexSet<u32> {
         }
     };
     let mut out: IndexSet<u32> = IndexSet::default();
-    body.for_each_node_under(NodeRef::Block(body.root), |node| {
+    body.for_each_reachable_node(|node| {
         if let NodeRef::Expr(id) = node {
             match &body.exprs[id].kind {
                 ExprKind::Assign { target, .. } => {
@@ -1178,7 +1178,7 @@ fn seeded_locals_read(body: &Body, value: Operand, siblings: &SiblingConsts) -> 
     while let Some(op) = pending.pop() {
         let Some(e) = op.as_expr() else { continue };
         let mut found = IndexSet::default();
-        body.for_each_node_under(NodeRef::Expr(e), |node| {
+        body.for_each_live_node_under(NodeRef::Expr(e), |node| {
             if let NodeRef::Expr(id) = node
                 && let ExprKind::Local { index, .. } = &body.exprs[id].kind
                 && siblings.set.contains(index)
@@ -1207,7 +1207,7 @@ fn seeded_locals_read(body: &Body, value: Operand, siblings: &SiblingConsts) -> 
 /// unseen.
 fn count_reads_of(body: &Body, node: NodeRef, wanted: &IndexSet<u32>) -> IndexMap<u32, usize> {
     let mut counts: IndexMap<u32, usize> = IndexMap::default();
-    body.for_each_node_under(node, |node| {
+    body.for_each_live_node_under(node, |node| {
         if let NodeRef::Expr(id) = node
             && let ExprKind::Local { index, .. } = &body.exprs[id].kind
             && wanted.contains(index)
@@ -1820,7 +1820,7 @@ fn written_through(body: &Body, idx: u32, gate: &Gate<'_>) -> bool {
 fn param_storage_escapes(body: &Body, idx: u32, gate: &Gate<'_>) -> bool {
     let roots = projection_alias_roots(body, idx, gate, AliasRoots::WithReassigned);
     let escapes = |op: Operand| delivers_projection_operand(body, op, &roots, gate);
-    body.find_in_nodes_under(NodeRef::Block(body.root), |node| {
+    body.find_in_reachable_node(|node| {
         match node {
             NodeRef::Stmt(s) => match &body.stmts[s].kind {
                 StmtKind::Return { value } | StmtKind::Break { value, .. } => {
@@ -1938,7 +1938,7 @@ fn projection_alias_roots(body: &Body, idx: u32, gate: &Gate<'_>, which: AliasRo
             sites.push(AliasSite { yields, binds });
         }
     };
-    body.for_each_node_under(NodeRef::Block(body.root), |node| {
+    body.for_each_reachable_node(|node| {
         match node {
             NodeRef::Stmt(s) => match &body.stmts[s].kind {
                 StmtKind::Let {
@@ -2060,7 +2060,7 @@ fn block_tail_delivers(body: &Body, block: BlockId, roots: &[u32], gate: &Gate<'
 
 /// Every local a pattern binds, appended to `out` if not already there.
 fn collect_pattern_bindings(body: &Body, pattern: crate::nir_arena::PatId, out: &mut Vec<u32>) {
-    body.for_each_node_under(NodeRef::Pat(pattern), |node| {
+    body.for_each_live_node_under(NodeRef::Pat(pattern), |node| {
         if let NodeRef::Pat(p) = node
             && let crate::nir_arena::PatKind::Binding { local_index, .. } = &body.pats[p].kind
             && !out.contains(local_index)
@@ -2078,7 +2078,7 @@ fn yielded_roots(body: &Body, op: Operand, gate: &Gate<'_>) -> Vec<u32> {
     let Some(expr) = op.as_expr() else {
         return out;
     };
-    body.for_each_node_under(NodeRef::Expr(expr), |node| {
+    body.for_each_live_node_under(NodeRef::Expr(expr), |node| {
         if let NodeRef::Expr(e) = node
             && gate.is_reference_type(body.exprs[e].type_id)
             && let Some(root) = projection_root_of(body, e, gate)
@@ -2379,7 +2379,7 @@ fn rewrite_reads(
     ty: TypeId,
 ) {
     let mut targets = Vec::new();
-    body.for_each_node_under(NodeRef::Block(body.root), |node| {
+    body.for_each_reachable_node(|node| {
         if let NodeRef::Expr(id) = node
             && matches!(&body.exprs[id].kind, ExprKind::Local { index, .. } if *index == local_index)
         {
@@ -2509,7 +2509,7 @@ fn inline_sibling_lets(
 /// past `ARRAY_NEW_FIXED_LIMIT`, which becomes a build sequence; and one
 /// `promote_constant_arrays_to_data` will rewrite to `array.new_data`.
 fn needs_lazy_guard(body: &Body, expr: ExprId, gate: &Gate<'_>, prefer_fixed: bool) -> bool {
-    body.find_in_nodes_under(NodeRef::Expr(expr), |node| {
+    body.find_in_live_node_under(NodeRef::Expr(expr), |node| {
         let NodeRef::Expr(id) = node else { return None };
         match &body.exprs[id].kind {
             ExprKind::Call { .. } | ExprKind::IndirectCall { .. } | ExprKind::CmRawCall { .. } => {

--- a/wado-compiler/src/optimize/const_object_globalization.rs
+++ b/wado-compiler/src/optimize/const_object_globalization.rs
@@ -1025,7 +1025,7 @@ fn detach_stmts(body: &mut Body, stmts: &[StmtId]) {
 /// The `GlobalVarSet` a hoist just planted, which every sibling rewrite folds
 /// its moved definitions into.
 fn find_global_var_set(body: &Body, module_source: &ModuleSource, name: &str) -> ExprId {
-    if let Some(e) = body.find_in_reachable_node(|node| {
+    if let Some(e) = body.find_in_live_node_under(NodeRef::Block(body.root), |node| {
         if let NodeRef::Expr(e) = node
             && let ExprKind::GlobalVarSet {
                 name: n,
@@ -1820,7 +1820,7 @@ fn written_through(body: &Body, idx: u32, gate: &Gate<'_>) -> bool {
 fn param_storage_escapes(body: &Body, idx: u32, gate: &Gate<'_>) -> bool {
     let roots = projection_alias_roots(body, idx, gate, AliasRoots::WithReassigned);
     let escapes = |op: Operand| delivers_projection_operand(body, op, &roots, gate);
-    body.find_in_reachable_node(|node| {
+    body.find_in_live_node_under(NodeRef::Block(body.root), |node| {
         match node {
             NodeRef::Stmt(s) => match &body.stmts[s].kind {
                 StmtKind::Return { value } | StmtKind::Break { value, .. } => {

--- a/wado-compiler/src/optimize/dae.rs
+++ b/wado-compiler/src/optimize/dae.rs
@@ -228,7 +228,7 @@ fn validate_in_body(
     rejected: &mut IndexSet<FnKey>,
     type_table: &crate::tir::TypeTable,
 ) {
-    body.for_each_node_under(NodeRef::Block(body.root), |node| {
+    body.for_each_reachable_node(|node| {
         if let NodeRef::Expr(id) = node {
             validate_call(body, id, candidates, rejected, type_table);
         }
@@ -310,7 +310,7 @@ fn apply_dae(project: &mut NirPackage, confirmed: &IndexMap<FnKey, Vec<bool>>) -
 /// arguments, clearing `has_receiver` when the receiver itself is dropped.
 fn rewrite_calls_in_body(body: &mut Body, confirmed: &IndexMap<FnKey, Vec<bool>>) -> bool {
     let mut calls = Vec::new();
-    body.for_each_node_under(NodeRef::Block(body.root), |node| {
+    body.for_each_reachable_node(|node| {
         if let NodeRef::Expr(id) = node
             && matches!(&body.exprs[id].kind, ExprKind::Call { .. })
         {
@@ -439,7 +439,7 @@ fn remap_locals(body: &mut Body, remap: &[Option<u32>]) {
     let mut exprs = Vec::new();
     let mut stmts = Vec::new();
     let mut pats = Vec::new();
-    body.for_each_node_under(NodeRef::Block(body.root), |node| match node {
+    body.for_each_reachable_node(|node| match node {
         NodeRef::Expr(id) => exprs.push(id),
         NodeRef::Stmt(id) => stmts.push(id),
         NodeRef::Pat(id) => pats.push(id),

--- a/wado-compiler/src/optimize/dce.rs
+++ b/wado-compiler/src/optimize/dce.rs
@@ -440,7 +440,7 @@ fn has_short_push_str_candidate(project: &NirPackage, push_str_id: crate::nir::F
 const SHORT_PUSH_STR_MAX_LEN: usize = 8;
 
 fn body_has_short_push_str(body: &Body, push_str_id: crate::nir::FuncId) -> bool {
-    body.find_in_nodes_under(NodeRef::Block(body.root), |node| {
+    body.find_in_reachable_node(|node| {
         if let NodeRef::Expr(e) = node
             && let Some((_, func_id, args)) = body.exprs[e].kind.as_method_call()
             && func_id == push_str_id
@@ -478,7 +478,7 @@ fn collect_array_clone_element_types(
     descriptors: &[FunctionRef],
     out: &mut IndexSet<crate::tir::TypeId>,
 ) {
-    body.for_each_node_under(NodeRef::Block(body.root), |node| {
+    body.for_each_reachable_node(|node| {
         if let NodeRef::Expr(e) = node
             && let ExprKind::Call {
                 func_id, type_args, ..
@@ -932,7 +932,7 @@ fn scan_inspect_signatures_block(
     inspect_name: &str,
     sigs: &mut InspectableSignatures,
 ) {
-    body.for_each_node_under(NodeRef::Block(body.root), |node| {
+    body.for_each_reachable_node(|node| {
         if let NodeRef::Expr(e) = node
             && let Some((receiver, func_id, _)) = body.exprs[e].kind.as_method_call()
             && let Some(info) = &callee_descriptor(descriptors, func_id).method_info
@@ -2041,7 +2041,7 @@ pub(super) fn deletable_value(
     let Some(root) = value.as_expr() else {
         return false;
     };
-    body.find_in_nodes_under(NodeRef::Expr(root), |node| match node {
+    body.find_in_live_node_under(NodeRef::Expr(root), |node| match node {
         NodeRef::Expr(id) => match &body.exprs[id].kind {
             ExprKind::Call { func_id, .. } => {
                 let effect = effects

--- a/wado-compiler/src/optimize/dce.rs
+++ b/wado-compiler/src/optimize/dce.rs
@@ -440,7 +440,7 @@ fn has_short_push_str_candidate(project: &NirPackage, push_str_id: crate::nir::F
 const SHORT_PUSH_STR_MAX_LEN: usize = 8;
 
 fn body_has_short_push_str(body: &Body, push_str_id: crate::nir::FuncId) -> bool {
-    body.find_in_reachable_node(|node| {
+    body.find_in_live_node_under(NodeRef::Block(body.root), |node| {
         if let NodeRef::Expr(e) = node
             && let Some((_, func_id, args)) = body.exprs[e].kind.as_method_call()
             && func_id == push_str_id

--- a/wado-compiler/src/optimize/drve.rs
+++ b/wado-compiler/src/optimize/drve.rs
@@ -128,7 +128,7 @@ fn has_only_pure_returns_with_explicit_tail(body: &Body, type_table: &TypeTable)
     // Every return reachable in the body must carry a pure value — a
     // `Return { value: None }` would mean a void exit path, structurally
     // inconsistent for a non-void signature.
-    body.find_in_reachable_node(|node| {
+    body.find_in_live_node_under(NodeRef::Block(root), |node| {
         let NodeRef::Stmt(s) = node else { return None };
         match &body.stmts[s].kind {
             StmtKind::Return { value: None } => Some(()),

--- a/wado-compiler/src/optimize/drve.rs
+++ b/wado-compiler/src/optimize/drve.rs
@@ -128,7 +128,7 @@ fn has_only_pure_returns_with_explicit_tail(body: &Body, type_table: &TypeTable)
     // Every return reachable in the body must carry a pure value — a
     // `Return { value: None }` would mean a void exit path, structurally
     // inconsistent for a non-void signature.
-    body.find_in_nodes_under(NodeRef::Block(root), |node| {
+    body.find_in_reachable_node(|node| {
         let NodeRef::Stmt(s) = node else { return None };
         match &body.stmts[s].kind {
             StmtKind::Return { value: None } => Some(()),
@@ -289,7 +289,7 @@ fn apply_drve(project: &mut NirPackage, confirmed: &IndexSet<FnKey>) -> Vec<usiz
 /// Rewrite every reachable `Return { value: Some(_) }` to `Return { value: None }`.
 fn void_returns(body: &mut Body) {
     let mut returns = Vec::new();
-    body.for_each_node_under(NodeRef::Block(body.root), |node| {
+    body.for_each_reachable_node(|node| {
         if let NodeRef::Stmt(s) = node
             && matches!(&body.stmts[s].kind, StmtKind::Return { value: Some(_) })
         {
@@ -304,7 +304,7 @@ fn void_returns(body: &mut Body) {
 /// Set `type_id` to `Unit` at every call of a confirmed function in the body.
 fn retype_calls(body: &mut Body, confirmed: &IndexSet<FnKey>) -> bool {
     let mut targets = Vec::new();
-    body.for_each_node_under(NodeRef::Block(body.root), |node| {
+    body.for_each_reachable_node(|node| {
         if let NodeRef::Expr(id) = node
             && let ExprKind::Call { func_id, .. } = &body.exprs[id].kind
             && confirmed.contains(func_id)

--- a/wado-compiler/src/optimize/inline.rs
+++ b/wado-compiler/src/optimize/inline.rs
@@ -1262,7 +1262,7 @@ fn recursive_scc_members(call_graph: &[Vec<usize>]) -> Vec<bool> {
 /// graph). Each stamped `func_id` is total and resolves to a position in
 /// `project.functions`, which is exactly the call-graph node index.
 fn collect_callees(body: &Body, callees: &mut IndexSet<usize>) {
-    body.for_each_node_under(NodeRef::Block(body.root), |node| {
+    body.for_each_reachable_node(|node| {
         if let NodeRef::Expr(id) = node
             && let ExprKind::Call { func_id, .. } = &body.exprs[id].kind
         {
@@ -1282,7 +1282,7 @@ fn call_site_counts(project: &NirPackage) -> Vec<usize> {
         let Some(body) = func.body.as_ref() else {
             continue;
         };
-        body.for_each_node_under(NodeRef::Block(body.root), |node| {
+        body.for_each_reachable_node(|node| {
             if let NodeRef::Expr(id) = node
                 && let ExprKind::Call { func_id, .. } = &body.exprs[id].kind
                 && let Some(slot) = counts.get_mut(func_id.index())

--- a/wado-compiler/src/optimize/loop_version_bce.rs
+++ b/wado-compiler/src/optimize/loop_version_bce.rs
@@ -523,7 +523,7 @@ fn operand_reads_local(engine: &Engine, op: Operand, var: u32) -> bool {
 fn subtree_redefines(engine: &Engine, block: BlockId, locals: &[u32]) -> bool {
     engine
         .body
-        .find_in_nodes_under(NodeRef::Block(block), |n| {
+        .find_in_live_node_under(NodeRef::Block(block), |n| {
             let NodeRef::Stmt(s) = n else { return None };
             match &engine.body.stmts[s].kind {
                 StmtKind::Let { local_index, .. } => locals.contains(local_index).then_some(()),

--- a/wado-compiler/src/optimize/ref_elim.rs
+++ b/wado-compiler/src/optimize/ref_elim.rs
@@ -241,7 +241,7 @@ fn is_valid_referent(body: &Body, id: ExprId) -> bool {
 fn find_rebound_locals(body: &Body) -> IndexSet<u32> {
     let mut seen: IndexSet<u32> = IndexSet::default();
     let mut rebound: IndexSet<u32> = IndexSet::default();
-    body.for_each_node_under(NodeRef::Block(body.root), |node| {
+    body.for_each_reachable_node(|node| {
         if let NodeRef::Stmt(s) = node
             && let StmtKind::Let { local_index, .. } = &body.stmts[s].kind
             && !seen.insert(*local_index)

--- a/wado-compiler/src/optimize/scalar_forward.rs
+++ b/wado-compiler/src/optimize/scalar_forward.rs
@@ -227,7 +227,7 @@ fn is_forwardable_value(body: &Body, root: ExprId) -> bool {
     if !is_pure_expr(body, root) {
         return false;
     }
-    body.find_in_nodes_under(NodeRef::Expr(root), |node| {
+    body.find_in_live_node_under(NodeRef::Expr(root), |node| {
         let NodeRef::Expr(id) = node else { return None };
         match &body.exprs[id].kind {
             ExprKind::Index { .. } | ExprKind::GlobalVarGet { .. } => Some(()),

--- a/wado-compiler/src/optimize/sroa.rs
+++ b/wado-compiler/src/optimize/sroa.rs
@@ -294,7 +294,7 @@ struct ReconstructInfo {
 
 fn collect_candidates(body: &Body) -> Vec<SroaCandidate> {
     let mut candidates = Vec::new();
-    body.for_each_node_under(NodeRef::Block(body.root), |node| {
+    body.for_each_reachable_node(|node| {
         if let NodeRef::Stmt(s) = node {
             candidate_from_stmt(body, s, &mut candidates);
         }

--- a/wado-compiler/src/remarks.rs
+++ b/wado-compiler/src/remarks.rs
@@ -308,7 +308,7 @@ struct ParamOrigin {
 /// and the operand it writes there.
 fn global_assignments(body: &Body) -> Vec<(GlobalKey, crate::nir_arena::Operand)> {
     let mut out = Vec::new();
-    body.for_each_node_under(NodeRef::Block(body.root), |node| {
+    body.for_each_reachable_node(|node| {
         if let NodeRef::Expr(e) = node
             && let ExprKind::GlobalVarSet {
                 module_source,
@@ -328,7 +328,7 @@ fn reads_decided_global(
     op: crate::nir_arena::Operand,
     decided: &IndexMap<GlobalKey, ParamOrigin>,
 ) -> Option<String> {
-    body.find_in_nodes_under(NodeRef::Expr(op.as_expr()?), |node| {
+    body.find_in_live_node_under(NodeRef::Expr(op.as_expr()?), |node| {
         if let NodeRef::Expr(e) = node
             && let ExprKind::GlobalVarGet {
                 module_source,


### PR DESCRIPTION
A pass asking a question about a whole body now gets an answer that covers the nodes a promoted operand names as its extraction source, not just the skeleton. Those nodes are emitted, so a walk without them answers "no use", "not disturbed" or "does not trap" for code that runs — the shape of every miscompile the operand bridge has produced. The coverage is free: a body whose pool holds no extraction source takes the plain skeleton walk, and a debug `-O2` compile of the Gale-generated SQLite parser comes out at 5.42–5.54 s against 5.50–5.68 s.

## Merge this to un-red main

`wado-compiler` compiles with `debug_assertions` off. The live walk's coverage set is declared unconditionally, because `debug_assert!` expands to `if cfg!(debug_assertions) { assert!(…) }` and still type-checks its body in a build that will never run it.

main is currently failing `wado-vscode` on all three runners for exactly this — `error[E0425]: cannot find value 'covered' in this scope`, building `wado-lsp.wasm` for `wasm32-wasip1`. Every other job passes because they build with assertions on. If a smaller hotfix is wanted ahead of this branch, the one-line form is to drop the `#[cfg(debug_assertions)]` from that `let`.

## The walks

`for_each_reachable_node` and `find_in_live_node_under` answer over the skeleton and the pool together. Forty call sites use them: every whole-body census, every rewrite that must reach each node once, and every subtree gate whose miss is the unsafe direction.

The ones that decide correctness:

- `dae::remap_locals` — a `Local` under a source keeps its old index while every other reference is renumbered.
- `const_object_globalization::mutated_locals` and `count_reads_of` — a missed write or read leaves a mutated local looking constant.
- `clone_forward::stmt_disturbs_place` — a missed write says the place survives the statement.
- `scalar_forward::is_forwardable_value` — a missed `Index` or trapping divide says the value is forwardable.
- `param_spec` — `mark_unclassified_opaque` marks a local opaque only for nodes it visits, so a use out of reach leaves the local looking cleanly classified.

`loop_version_bce::collect_checks_in_node` stays on the skeleton walk. It gathers refutation candidates, so a miss costs an optimization; the two scans that decide whether refuting is sound, `subtree_redefines` and `node_modifies`, take the live walk.

## Not reaching for the skeleton walk again

`for_each_node_under` walks a subtree and asserts it is not handed the root block, because its name is the obvious one to reach for and the whole body is what it answers wrongly about.

## What it costs

`ValuePool` records whether an `OpaqueSource::Expr` was ever minted. False — the common case — means no operand can name a node outside the skeleton, so the live walk is the skeleton walk and drops its per-node operand scan. That gate also serves the `for_each_reachable_node` callers that predate this branch, which is why the compile comes out slightly faster than it went in.

The live walk's own coverage assertion is a set built on the one body that named a source, rather than a body walk per source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)