### PR TITLE
docs(skill): how to build against a locally patched wasmtime

### DIFF
--- a/.claude/skills/profiling-wado-compiler/SKILL.md
+++ b/.claude/skills/profiling-wado-compiler/SKILL.md
@@ -44,6 +44,12 @@ kill -TERM "$(pgrep -P "$SAMPLY_PID" | head -1)"; wait "$SAMPLY_PID"
 node .claude/skills/profiling-wado-compiler/scripts/analyze_native_profile.ts /tmp/prof.json
 ```
 
+Symbols resolve against the path the profile recorded, not the binary that
+produced it. Rebuilding over `target/profiling/wado` makes every earlier profile
+symbolicate against the new build, and its output still looks normal. When you
+A/B, give each arm its own path: copy the first build aside and profile it
+there.
+
 For one-shot commands (`wado compile foo.wado`, `wado test foo.wado`)
 there is nothing to drive — samply records until the child exits, so
 just invoke it directly:

--- a/.claude/skills/vendor-submodules/SKILL.md
+++ b/.claude/skills/vendor-submodules/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vendor-submodules
-description: Locate and sync the vendored reference specs and runtimes under vendor/ (Wasm, WASI P3, and Component Model specs; wasm-tools, wasmtime sources). Use when you need to read a Wasm/WASI/CM spec or wasmtime/wasm-tools source, or when vendor/ submodules are missing and need initializing.
+description: Locate and sync the vendored reference specs and runtimes under vendor/ (Wasm, WASI P3, and Component Model specs; wasm-tools, wasmtime sources). Use when you need to read a Wasm/WASI/CM spec or wasmtime/wasm-tools source, when vendor/ submodules are missing and need initializing, or when building and profiling against a locally patched wasmtime.
 ---
 
 ## The Wasm and WASI (p3) specifications
@@ -27,3 +27,40 @@ mise run sync-vendor
 ```
 
 This syncs `vendor/wasmtime` to the exact version in `Cargo.lock` (required for WASI P3 compatibility), and updates other vendor submodules (`vendor/wasm`, `vendor/wasi`, `vendor/wasm-tools`, `vendor/component-model`) to their latest remote HEAD.
+
+## Building against a patched wasmtime
+
+To test a change to wasmtime itself, edit `vendor/wasmtime` in place and add to
+the workspace `Cargo.toml`:
+
+```toml
+[patch.crates-io]
+wasmtime = { path = "vendor/wasmtime/crates/wasmtime" }
+wasmtime-wasi = { path = "vendor/wasmtime/crates/wasi" }
+wasmtime-wasi-http = { path = "vendor/wasmtime/crates/wasi-http" }
+wasmtime-wasi-tls = { path = "vendor/wasmtime/crates/wasi-tls" }
+```
+
+Those four names redirect 31 crates, reaching the whole `cranelift-*`,
+`pulley-*`, `wasmtime-internal-*` and `wiggle*` set through the dependency
+graph. `sync-vendor` already holds the submodule at the `Cargo.lock` version, so
+the sources match what the workspace expects and nothing needs porting.
+
+Keep the stanza on a throwaway branch. CI checks out without submodules
+(`submodules: false`, also `actions/checkout`'s default), so on `main` every job
+would fail parsing the manifest, before building anything. Landing it means
+turning submodule checkout on across every workflow.
+
+Profile with the `profiling` cargo profile, not `release`: `release` sets
+`strip = "symbols"`, which leaves a sampling profile unsymbolicatable. samply
+resolves symbols against the path it recorded, so profile each arm from a path
+that still holds that binary — overwrite `target/profiling/wado` and an earlier
+profile silently symbolicates against the new build.
+
+`reference/` holds patches written this way, each with its measurement:
+
+- `current_thread_split.patch` — splits the cold deferred-frame replay out of
+  `StoreOpaque::current_thread` so the fast path inlines. Removes ~1 point of
+  CPU; throughput flat.
+- `trace_fiber_roots.patch` — tracks fiber-owning reps instead of scanning the
+  whole component `ResourceTable` per GC. Not measurable.

--- a/.claude/skills/vendor-submodules/SKILL.md
+++ b/.claude/skills/vendor-submodules/SKILL.md
@@ -1,11 +1,9 @@
 ---
 name: vendor-submodules
-description: Locate and sync the vendored reference specs and runtimes under vendor/ (Wasm, WASI P3, and Component Model specs; wasm-tools, wasmtime sources). Use when you need to read a Wasm/WASI/CM spec or wasmtime/wasm-tools source, when vendor/ submodules are missing and need initializing, or when building and profiling against a locally patched wasmtime.
+description: Locate and sync the vendored reference specs and runtimes under vendor/ (Wasm, WASI P3, and Component Model specs; wasm-tools, wasmtime sources). Use when you need to read a Wasm/WASI/CM spec or wasmtime/wasm-tools source, when vendor/ submodules are missing and need initializing, or when building against a locally patched wasmtime.
 ---
 
-## The Wasm and WASI (p3) specifications
-
-There are external references in the module for convenience:
+## What is under `vendor/`
 
 - `vendor/wasm/` - WebAssembly/spec
 - `vendor/wasi/` - WebAssembly/WASI
@@ -14,19 +12,18 @@ There are external references in the module for convenience:
   - Concurrency (async, streams, futures): `vendor/component-model/design/mvp/Concurrency.md`
   - Explainer: `vendor/component-model/design/mvp/Explainer.md`
 - `vendor/wasmtime/` - a Wasm runtime with WASI P3 support
-- `vendor/wasm-tools/` - a Wasm toolchain, where the Wado compiler relies on
+- `vendor/wasm-tools/` - the Wasm toolchain the Wado compiler builds on
 
-Use `git submodule update --init` to have the vendor modules.
+`git submodule update --init --recommend-shallow` fetches them.
 
-### Syncing Vendor Submodules
-
-Run the following to sync all vendor submodules:
+## Syncing
 
 ```sh
 mise run sync-vendor
 ```
 
-This syncs `vendor/wasmtime` to the exact version in `Cargo.lock` (required for WASI P3 compatibility), and updates other vendor submodules (`vendor/wasm`, `vendor/wasi`, `vendor/wasm-tools`, `vendor/component-model`) to their latest remote HEAD.
+`vendor/wasmtime` goes to the exact version in `Cargo.lock`, which WASI P3
+compatibility requires. The other submodules go to their remote HEAD.
 
 ## Building against a patched wasmtime
 
@@ -41,21 +38,15 @@ wasmtime-wasi-http = { path = "vendor/wasmtime/crates/wasi-http" }
 wasmtime-wasi-tls = { path = "vendor/wasmtime/crates/wasi-tls" }
 ```
 
-Those four names redirect 31 crates, reaching the whole `cranelift-*`,
-`pulley-*`, `wasmtime-internal-*` and `wiggle*` set through the dependency
-graph. `sync-vendor` already holds the submodule at the `Cargo.lock` version, so
-the sources match what the workspace expects and nothing needs porting.
+Those four names redirect 31 crates. The `cranelift-*`, `pulley-*`,
+`wasmtime-internal-*` and `wiggle*` crates follow through the dependency graph.
+`sync-vendor` already holds the submodule at the `Cargo.lock` version, so the
+sources match what the workspace expects and nothing needs porting.
 
 Keep the stanza on a throwaway branch. CI checks out without submodules
 (`submodules: false`, also `actions/checkout`'s default), so on `main` every job
-would fail parsing the manifest, before building anything. Landing it means
-turning submodule checkout on across every workflow.
-
-Profile with the `profiling` cargo profile, not `release`: `release` sets
-`strip = "symbols"`, which leaves a sampling profile unsymbolicatable. samply
-resolves symbols against the path it recorded, so profile each arm from a path
-that still holds that binary — overwrite `target/profiling/wado` and an earlier
-profile silently symbolicates against the new build.
+dies while parsing the manifest. Landing it means turning submodule checkout on
+across every workflow.
 
 `reference/` holds patches written this way, each with its measurement:
 

--- a/.claude/skills/vendor-submodules/reference/current_thread_split.patch
+++ b/.claude/skills/vendor-submodules/reference/current_thread_split.patch
@@ -1,0 +1,40 @@
+diff --git a/crates/wasmtime/src/runtime/component/concurrent.rs b/crates/wasmtime/src/runtime/component/concurrent.rs
+index f6b921b671..9eabef53a3 100644
+--- a/crates/wasmtime/src/runtime/component/concurrent.rs
++++ b/crates/wasmtime/src/runtime/component/concurrent.rs
+@@ -1601,6 +1601,12 @@ impl<T> StoreContextMut<'_, T> {
+ impl StoreOpaque {
+     /// Returns the currently-running thread, promoting any deferred lazy thread
+     /// into a fully-materialized `CurrentThread`.
++    ///
++    /// Every resource handle crossing the canonical ABI asks for this (see
++    /// `ResourceTables::resource_lower_borrow` and friends), so the two checks
++    /// that answer it stay here and the promotion lives in a cold callee that
++    /// does not stop this from inlining.
++    #[inline]
+     pub(crate) fn current_thread(&mut self) -> Result<CurrentThread> {
+         // Without concurrency support there is nothing to force.
+         if !self.concurrency_support() {
+@@ -1619,6 +1625,14 @@ impl StoreOpaque {
+                 .unforced_current_thread);
+         }
+ 
++        self.force_deferred_current_thread()
++    }
++
++    /// Materialize the deferred frames a fused adapter pushed inline, and
++    /// return the thread they resolve to. The slow half of `current_thread`.
++    #[cold]
++    #[inline(never)]
++    fn force_deferred_current_thread(&mut self) -> Result<CurrentThread> {
+         // The component instance whose adapters pushed the deferred frames; all
+         // frames in a guest-to-guest, sync-to-sync call chain of fused adapters
+         // live within a single `wasmtime::component::Instance` (because
+@@ -2343,6 +2357,7 @@ impl StoreOpaque {
+ 
+     /// Used by `ResourceTables` to record the scope of a borrow to get undone
+     /// in the future.
++    #[inline]
+     pub(crate) fn current_scope_id(&mut self) -> Result<Option<u32>> {
+         if !self.concurrency_support() {
+             return self.current_scope_id_not_concurrent();

--- a/.claude/skills/vendor-submodules/reference/trace_fiber_roots.patch
+++ b/.claude/skills/vendor-submodules/reference/trace_fiber_roots.patch
@@ -1,0 +1,90 @@
+diff --git a/crates/wasmtime/src/runtime/component/concurrent.rs b/crates/wasmtime/src/runtime/component/concurrent.rs
+index f6b921b671..9e25b64aef 100644
+--- a/crates/wasmtime/src/runtime/component/concurrent.rs
++++ b/crates/wasmtime/src/runtime/component/concurrent.rs
+@@ -5310,6 +5310,15 @@ pub struct ConcurrentState {
+     ///
+     /// Used in the implementation of `Accessor::poll_ready_for_concurrent_call`.
+     ready_for_concurrent_call_waker: Option<Waker>,
++
++    /// Table entries that may own a fiber, i.e. the `WaitableSet` and
++    /// `GuestThread` entries `Self::trace_fiber_roots` has to visit.
++    ///
++    /// A superset: an entry is added when pushed and removed when deleted, and
++    /// a stale rep costs the tracer one failed lookup or downcast, which is
++    /// what visiting a non-fiber entry cost it anyway. Only a *missing* rep
++    /// could drop a root, and reps enter here at the one place they are made.
++    fiber_bearing: BTreeSet<u32>,
+ }
+ 
+ impl Default for ConcurrentState {
+@@ -5327,10 +5336,19 @@ impl Default for ConcurrentState {
+             interesting_tasks: 0,
+             interesting_tasks_empty_waker: None,
+             ready_for_concurrent_call_waker: None,
++            fiber_bearing: BTreeSet::new(),
+         }
+     }
+ }
+ 
++/// Whether a table entry of type `V` can own a fiber, and so has to be visited
++/// by `ConcurrentState::trace_fiber_roots`. Constant per monomorphization.
++#[cfg(feature = "gc")]
++fn may_own_fiber<V: 'static>() -> bool {
++    let id = core::any::TypeId::of::<V>();
++    id == core::any::TypeId::of::<WaitableSet>() || id == core::any::TypeId::of::<GuestThread>()
++}
++
+ impl ConcurrentState {
+     /// Take ownership of any fibers and futures owned by this object.
+     ///
+@@ -5412,6 +5430,7 @@ impl ConcurrentState {
+             worker,
+             high_priority,
+             low_priority,
++            fiber_bearing,
+ 
+             // TODO(cm-gc): This field contains `ValRaw`s, but they are never GC
+             // references because the component model doesn't support GC yet. We
+@@ -5428,7 +5447,15 @@ impl ConcurrentState {
+             ready_for_concurrent_call_waker: _,
+         } = self;
+ 
+-        for entry in table.get_mut().iter_mut() {
++        // Only the entries that can own a fiber, rather than the whole table:
++        // a long-lived instance holds one entry per in-flight request's
++        // resources, and every collection walked all of them to reach the few
++        // that hold a fiber.
++        let table = table.get_mut();
++        for &rep in fiber_bearing.iter() {
++            let Ok(entry) = table.get_any_mut(rep) else {
++                continue;
++            };
+             if let Some(set) = entry.downcast_mut::<WaitableSet>() {
+                 for mode in set.waiting.values_mut() {
+                     if let WaitMode::Fiber(fiber) = mode {
+@@ -5472,7 +5499,12 @@ impl ConcurrentState {
+         &mut self,
+         value: V,
+     ) -> Result<TableId<V>, ResourceTableError> {
+-        self.table.get_mut().push(value).map(TableId::from)
++        let id = self.table.get_mut().push(value).map(TableId::from)?;
++        #[cfg(feature = "gc")]
++        if may_own_fiber::<V>() {
++            self.fiber_bearing.insert(id.rep());
++        }
++        Ok(id)
+     }
+ 
+     fn get_mut<V: 'static>(&mut self, id: TableId<V>) -> Result<&mut V, ResourceTableError> {
+@@ -5500,6 +5532,10 @@ impl ConcurrentState {
+     }
+ 
+     fn delete<V: 'static>(&mut self, id: TableId<V>) -> Result<V, ResourceTableError> {
++        #[cfg(feature = "gc")]
++        if may_own_fiber::<V>() {
++            self.fiber_bearing.remove(&id.rep());
++        }
+         self.table.get_mut().delete(Resource::from(id))
+     }
+ 


### PR DESCRIPTION
`vendor-submodules` covers testing a change to wasmtime itself: the
`[patch.crates-io]` stanza that points the workspace at `vendor/wasmtime`, why
it stays off `main`, and the patches written that way.

## The stanza

Four crate names redirect 31 crates. The `cranelift-*`, `pulley-*`,
`wasmtime-internal-*` and `wiggle*` crates follow through the dependency graph.
`mise run sync-vendor` holds the submodule at the `Cargo.lock` version, so the
vendored sources match what the workspace expects and nothing needs porting.

It belongs on a throwaway branch. CI checks out with `submodules: false`, so on
`main` every job dies while parsing the manifest. Landing it means turning
submodule checkout on across every workflow.

## `reference/`

Two patches against wasmtime `v47.0.3`, each with its measurement:

- `current_thread_split.patch` — splits the cold deferred-frame replay out of
  `StoreOpaque::current_thread`, so the fast path inlines into the canonical-ABI
  resource operations that call it once per handle crossing. Removes ~1 point of
  the server's CPU; throughput flat.
- `trace_fiber_roots.patch` — tracks fiber-owning reps instead of scanning the
  whole component `ResourceTable` per GC. Not measurable.

## Two corrections on the way past

`profiling-wado-compiler` states that symbols resolve against the path the
profile recorded, not the binary that produced it, so an A/B needs each arm on
its own path.

The init line passes `--recommend-shallow`, matching `shallow = true` in
`.gitmodules` and every other place in the tree that names the command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)